### PR TITLE
add support for liteLLM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "protobuf<=3.20.0",
     "langchain>=0.0.218",
     "openai",
+    "litellm",
     "pydantic<2.0"
 ]
 dynamic = ["version", "readme"]

--- a/src/ragas/metrics/base.py
+++ b/src/ragas/metrics/base.py
@@ -14,7 +14,7 @@ from math import floor
 
 from datasets import Dataset
 from langchain.callbacks.manager import CallbackManager, trace_as_chain_group
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatOpenAI, ChatLiteLLM
 from langchain.chat_models.base import BaseChatModel
 from langchain.llms.base import BaseLLM
 from tqdm import tqdm
@@ -107,7 +107,7 @@ class Metric(ABC):
 
 
 def _llm_factory():
-    return ChatOpenAI(model_name="gpt-3.5-turbo-16k")  # type: ignore
+    return ChatLiteLLM(model_name="gpt-3.5-turbo-16k")  # type: ignore
 
 
 @dataclass

--- a/src/ragas/metrics/llms.py
+++ b/src/ragas/metrics/llms.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatOpenAI, ChatLiteLLM
 from langchain.chat_models.base import BaseChatModel
 from langchain.llms import OpenAI
 from langchain.llms.base import BaseLLM
@@ -14,7 +14,7 @@ if t.TYPE_CHECKING:
 
 
 def isOpenAI(llm: BaseLLM | BaseChatModel) -> bool:
-    return isinstance(llm, OpenAI) or isinstance(llm, ChatOpenAI)
+    return isinstance(llm, OpenAI) or isinstance(llm, ChatLiteLLM)
 
 
 def generate(
@@ -28,7 +28,7 @@ def generate(
     n_swapped = False
     llm.temperature = temperature
     if n is not None:
-        if isinstance(llm, OpenAI) or isinstance(llm, ChatOpenAI):
+        if isinstance(llm, OpenAI) or isinstance(llm, ChatLiteLLM):
             old_n = llm.n
             llm.n = n
             n_swapped = True
@@ -44,7 +44,7 @@ def generate(
         ps = [p.format_messages() for p in prompts]
         result = llm.generate(ps, callbacks=callbacks)
 
-    if (isinstance(llm, OpenAI) or isinstance(llm, ChatOpenAI)) and n_swapped:
+    if (isinstance(llm, OpenAI) or isinstance(llm, ChatLiteLLM)) and n_swapped:
         llm.n = old_n  # type: ignore
 
     return result


### PR DESCRIPTION
This PR adds support for 100+ models using: https://github.com/BerriAI/litellm/ 

LiteLLM allows you to use an LLM as drop in replacement for gpt-3.5

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the `ChatOpenAI` I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```