### PR TITLE
Fix remap_column_names 

### DIFF
--- a/src/ragas/validation.py
+++ b/src/ragas/validation.py
@@ -9,6 +9,7 @@ def remap_column_names(dataset: Dataset, column_map: dict[str, str]) -> Dataset:
     """
     Remap the column names in case dataset uses different column names
     """
+    column_map = {k: v for k, v in column_map.items() if v in dataset.column_names}
     inverse_column_map = {v: k for k, v in column_map.items()}
     return dataset.from_dict(
         {inverse_column_map[name]: dataset[name] for name in column_map.values()}

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -105,3 +105,23 @@ def test_column_remap(column_map):
     remapped_dataset = remap_column_names(TEST_DATASET, column_map)
 
     assert remapped_dataset.column_names == list(column_map.keys())
+
+
+def test_column_remap_omit():
+    TEST_DATASET = Dataset.from_dict(
+        {
+            "query": [""],
+            "answer": [""],
+            "contexts": [[""]],
+        }
+    )
+
+    column_map = {
+        "question": "query",
+        "contexts": "contexts",
+        "answer": "answer",
+        "ground_truths": "ground_truths",
+    }
+
+    remapped_dataset = remap_column_names(TEST_DATASET, column_map)
+    assert remapped_dataset.column_names == ["question", "contexts", "answer"]


### PR DESCRIPTION
When I try to do the following, I got error:

```python
ds = Dataset.from_dict(
    {
        "question": ["question"],
        "answer": ["answer"],
        "contexts": [["context"]],
    }
)

from ragas import evaluate
from ragas.metrics import Faithfulness

evaluate(dataset =ds, metrics=[Faithfulness(batch_size=1)])
```

```
KeyError: "Column ground_truths not in the dataset. Current columns in the dataset: ['question', 'answer', 'contexts']"
```
But `ground_truths ` is not needed for `Faithfulness` .

This PR is to fix it.

