### PR TITLE
Add note about when ground truth labels are required

### DIFF
--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -66,7 +66,7 @@
     "- question: `list[str]` - These are the questions you RAG pipeline will be evaluated on. \n",
     "- answer: `list[str]` - The answer generated from the RAG pipeline and give to the user.\n",
     "- contexts: `list[list[str]]` - The contexts which where passed into the LLM to answer the question.\n",
-    "- ground_truths: `list[list[str]]` - The ground truth answer to the questions.\n",
+    "- ground_truths: `list[list[str]]` - The ground truth answer to the questions. (only required if you are using context_recall)\n",
     "\n",
     "Ideally your list of questions should reflect the questions your users give, including those that you have been problamatic in the past.\n",
     "\n",


### PR DESCRIPTION
To reduce some confusion, add a note mentioning that ground truth labels are only required for context_recall, since the tool can generate other metrics in a "ground truth" free manner.