### PR TITLE
Adding deployment_id when api_type is azure now works correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ This is a small example program you can run to see ragas in action!
 from ragas import evaluate
 from datasets import Dataset
 import os
-
+#if os.environ["OPENAI_API_TYPE"] is azure
+#os.environ["DEPLOYMENT_ID"]= "your-deployment_id"
 os.environ["OPENAI_API_KEY"] = "your-openai-key"
 
 # prepare your huggingface dataset in the format

--- a/src/ragas/metrics/base.py
+++ b/src/ragas/metrics/base.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from math import floor
+import os
 
 from datasets import Dataset
 from langchain.callbacks.manager import CallbackManager, trace_as_chain_group
@@ -107,8 +108,9 @@ class Metric(ABC):
 
 
 def _llm_factory():
+    if os.environ["OPENAI_API_TYPE"] == "azure":
+        return ChatOpenAI(model_name="gpt-3.5-turbo-16k", model_kwargs={"deployment_id": os.environ.get("DEPLOYMENT_ID")})
     return ChatOpenAI(model_name="gpt-3.5-turbo-16k")  # type: ignore
-
 
 @dataclass
 class MetricWithLLM(Metric):


### PR DESCRIPTION
If the api type is azure, deployment_id is required, so we added it to ChatOpenAI. If the api type is openAI, it returns ChatOpenAI without deployment_id.