### PR TITLE
don't warn when `context_precision` is correctly called

### DIFF
--- a/src/ragas/metrics/context_precision.py
+++ b/src/ragas/metrics/context_precision.py
@@ -186,4 +186,4 @@ class ContextRelevancy(ContextPrecision):
 
 
 context_precision = ContextPrecision()
-context_precision = ContextRelevancy()
+context_relevancy = ContextRelevancy()


### PR DESCRIPTION
I'm not sure when `0.1.0` is scheduled for release, but in the meantime, when `context_precision` is (correctly) called, you still get a deprecation warning because of what I _think_ is a typo.

Before change:
<img width="640" alt="image" src="https://github.com/explodinggradients/ragas/assets/7339255/0dec6b73-605e-4ce6-83b4-f8bccf24017d">

After change:
<img width="635" alt="image" src="https://github.com/explodinggradients/ragas/assets/7339255/875a0d29-801d-473b-8178-118028b7accf">
