### PR TITLE
fix: Add RagasLLM for customized test set generation

### DIFF
--- a/docs/concepts/testset_generation.md
+++ b/docs/concepts/testset_generation.md
@@ -66,8 +66,8 @@ from langchain.chat_models import ChatOpenAI
 # documents = load your documents
 
 # Add custom llms and embeddings
-generator_llm = ChatOpenAI(model="gpt-3.5-turbo")
-critic_llm = ChatOpenAI(model="gpt-4")
+generator_llm = LangchainLLM(llm=ChatOpenAI(model="gpt-3.5-turbo"))
+critic_llm = LangchainLLM(llm=ChatOpenAI(model="gpt-4"))
 embeddings_model = OpenAIEmbeddings()
 
 # Change resulting question type distribution

--- a/docs/concepts/testset_generation.md
+++ b/docs/concepts/testset_generation.md
@@ -61,7 +61,7 @@ Checkout [llama-index](https://gpt-index.readthedocs.io/en/stable/core_modules/d
 from ragas.testset import TestsetGenerator
 from langchain.embeddings import OpenAIEmbeddings
 from langchain.chat_models import ChatOpenAI
-
+from ragas.llms import LangchainLLM
 
 # documents = load your documents
 

--- a/docs/howtos/integrations/langchain.ipynb
+++ b/docs/howtos/integrations/langchain.ipynb
@@ -310,7 +310,7 @@
    "id": "3f3a66f8",
    "metadata": {},
    "source": [
-    "**Context Precision**"
+    "**Context Recall**"
    ]
   },
   {


### PR DESCRIPTION
Custom LLMs did not work for customized test set generation without first casting LLMs to RagasLLM