### PR TITLE
fix: added support for google vertexAI

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -4,9 +4,9 @@ import os
 import typing as t
 from abc import ABC, abstractmethod
 
-from langchain.chat_models import AzureChatOpenAI, ChatOpenAI, BedrockChat
+from langchain.chat_models import AzureChatOpenAI, BedrockChat, ChatOpenAI, ChatVertexAI
 from langchain.chat_models.base import BaseChatModel
-from langchain.llms import AzureOpenAI, OpenAI, Bedrock
+from langchain.llms import AzureOpenAI, Bedrock, OpenAI, VertexAI
 from langchain.llms.base import BaseLLM
 from langchain.schema import LLMResult
 
@@ -20,13 +20,22 @@ if t.TYPE_CHECKING:
 def isOpenAI(llm: BaseLLM | BaseChatModel) -> bool:
     return isinstance(llm, OpenAI) or isinstance(llm, ChatOpenAI)
 
+
 def isBedrock(llm: BaseLLM | BaseChatModel) -> bool:
     return isinstance(llm, Bedrock) or isinstance(llm, BedrockChat)
 
+
 # have to specify it twice for runtime and static checks
-MULTIPLE_COMPLETION_SUPPORTED = [OpenAI, ChatOpenAI, AzureOpenAI, AzureChatOpenAI]
+MULTIPLE_COMPLETION_SUPPORTED = [
+    OpenAI,
+    ChatOpenAI,
+    AzureOpenAI,
+    AzureChatOpenAI,
+    ChatVertexAI,
+    VertexAI,
+]
 MultipleCompletionSupportedLLM = t.Union[
-    OpenAI, ChatOpenAI, AzureOpenAI, AzureChatOpenAI
+    OpenAI, ChatOpenAI, AzureOpenAI, AzureChatOpenAI, ChatVertexAI, VertexAI
 ]
 
 


### PR DESCRIPTION
added support for llm, chat and embeddings

```py
from langchain.llms import VertexAI
from langchain.chat_models import ChatVertexAI
from ragas.llms import LangchainLLM
from ragas.metrics import faithfulness

llm = VertexAI(credentials=creds)
chat = ChatVertexAI(credentials=creds)

ragas_llm = LangchainLLM(llm)
faithfulness.llm = ragas_llm
```

if your looking to change the embeddings as well
```py
from langchain.embeddings import VertexAIEmbeddings
from ragas.metrics import AnswerRelevancy

embeddings = VertexAIEmbeddings(credentials=creds)
ar = AnswerRelevancy(embeddings=embeddings)

# now you can use it as normal
r = evaluate(fiqa_eval.select(range(3)), metrics=[ar])
```