### PR TITLE
Custom embeddings from HuggingFace (sentence transformer) do not pass the assertion in src/ragas/metrics/_answer_similarity.py  

### DIFF
--- a/src/ragas/embeddings/base.py
+++ b/src/ragas/embeddings/base.py
@@ -66,7 +66,7 @@ class HuggingfaceEmbeddings(RagasEmbeddings):
             texts, normalize_embeddings=True, **self.encode_kwargs
         )
 
-        #assert isinstance(embeddings, Tensor)
+        assert isinstance(embeddings, Tensor)
         return embeddings.tolist()
 
     def predict(self, texts: List[List[str]]) -> List[List[float]]:

--- a/src/ragas/embeddings/base.py
+++ b/src/ragas/embeddings/base.py
@@ -66,7 +66,7 @@ class HuggingfaceEmbeddings(RagasEmbeddings):
             texts, normalize_embeddings=True, **self.encode_kwargs
         )
 
-        assert isinstance(embeddings, Tensor)
+        #assert isinstance(embeddings, Tensor)
         return embeddings.tolist()
 
     def predict(self, texts: List[List[str]]) -> List[List[float]]:

--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -53,7 +53,7 @@ class AnswerSimilarity(MetricWithLLM):
         # only for cross encoder
         if isinstance(self.embeddings, HuggingfaceEmbeddings):
             self.is_cross_encoder = True if self.embeddings.is_cross_encoder else False
-            self.embeddings.encode_kwargs = {"batch_size": self.batch_size}
+            self.embeddings.encode_kwargs = {"batch_size": self.batch_size, "convert_to_tensor": True}
 
     def init_model(self):
         super().init_model()


### PR DESCRIPTION
When passing the embeddings for example in the answer relevancy, sentence transformers do not pass assert isinstance(embeddings, Tensor) in src/ragas/embeddings/base.py, so the solution is to add "convert_to_tensor": True as follows:
 
AnswerRelevancy(embeddings=HuggingfaceEmbeddings(
    model_name='intfloat/multilingual-e5-large', encode_kwargs={"convert_to_tensor": True}))

However, this does not work for the src/ragas/metrics/_answer_similarity.py because encode_kwargs are initialized with self.embeddings.encode_kwargs = {"batch_size": self.batch_size}
my proposed solution is to change line 56 to:
self.embeddings.encode_kwargs = {"batch_size": self.batch_size, "convert_to_tensor": True}