### PR TITLE
Make testgenerator output compatible with evaluate

### DIFF
--- a/src/ragas/testset/testset_generator.py
+++ b/src/ragas/testset/testset_generator.py
@@ -50,7 +50,7 @@ question_deep_map = {
     "conditional": "_condition_question",
 }
 
-DataRow = namedtuple("DataRow", ["question", "context", "answer", "question_type"])
+DataRow = namedtuple("DataRow", ["question", "ground_truth_context", "ground_truth", "question_type"])
 
 
 @dataclass
@@ -64,17 +64,15 @@ class TestDataset:
     def to_pandas(self) -> pd.DataFrame:
         data_samples = []
         for data in self.test_data:
-            is_conv = len(data.context) > 1
-            question_type = data.question_type
+            is_conv = len(data.ground_truth_context) > 1
             data = [
                 {
-                    "question": qstn,
-                    "context": ctx,
-                    "answer": ans,
-                    "question_type": question_type,
+                    "question": data.question,
+                    "ground_truth_context": data.ground_truth_context,
+                    "ground_truth": data.ground_truth,
+                    "question_type": data.question_type,
                     "episode_done": True,
                 }
-                for qstn, ctx, ans in zip(data.question, data.context, data.answer)
             ]
             if is_conv:
                 data[0].update({"episode_done": False})
@@ -253,10 +251,10 @@ class TestsetGenerator:
         return available_indices
 
     def _generate_doc_nodes_map(
-        self, documenet_nodes: t.List[BaseNode]
+        self, document_nodes: t.List[BaseNode]
     ) -> t.Dict[str, t.List[BaseNode]]:
         doc_nodes_map: t.Dict[str, t.List[BaseNode]] = defaultdict(list)
-        for node in documenet_nodes:
+        for node in document_nodes:
             if node.ref_doc_id:
                 doc_nodes_map[node.ref_doc_id].append(node)
 
@@ -392,8 +390,9 @@ class TestsetGenerator:
             if is_valid_question:
                 context = self._generate_context(question, text_chunk)
                 answer = self._generate_answer(question, context)
-                samples.append(
-                    DataRow(question.split("\n"), context, answer, evolve_type)
+                samples.extend(
+                    DataRow(qstn, [ctx], ans, evolve_type)
+                    for qstn, ctx, ans in zip(question.split("\n"), context, answer)
                 )
                 count += 1
                 pbar.update(count)


### PR DESCRIPTION
* Changed context from str to List[str] so that it is consistent with eval. Now output of TestDataset can be used for evaluation.
*  Changed typo in _generate_doc_nodes_map
*  Changed TestDataset class to reflect the changes in test set generation. Drawback is episode_done will be True in all cases as data is changed at the level above.