### PR TITLE
Fix bug in calculating score when output from LLM is broken

### DIFF
--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -120,9 +120,12 @@ class Faithfulness(MetricWithLLM):
                     )
                     score = score / len(list_statements[i])
                 else:
-                    score = max(0, output.count("verdict: no")) / len(
-                        list_statements[i]
-                    )
+                    if 'verdict: no' in output or 'verdict: yes' in output:
+                        score = max(0, output.count("verdict: no")) / len(
+                            list_statements[i]
+                        )
+                    else: # output from LLM is broken and we can't evaluate score.
+                        score = 1
 
                 scores.append(1 - score)
 


### PR DESCRIPTION
If generated answer is too stupid, evaluation of faithfull will be broken.

For example, if you change fake result into "I love christmass" ,which is completely nun sense answer on cell 10 on [this notebook](https://github.com/explodinggradients/ragas/blob/main/docs/howtos/integrations/langchain.ipynb), the result of faithfullness will be 1. This is not good. You can try it out.

I debug the reason and showed like if the result is too stupid,
1st and 2nd output from LLM will be 
`There is no relevant statement that can be created from the given answer.`
but [ragas implementation](https://github.com/explodinggradients/ragas/blob/13465f01224c3c2f0ba3dac183d708a545dcecd5/src/ragas/metrics/_faithfulness.py#L124) is based the assumption there are "verdict: yes" or "verdict: no".

The way to solve this issue is not only one. for example, slitly modify template prompt for stupid answer is one example, but it can be affect the result.

So I make pr for my suggestion.

Maybe this PR will conflict my PR #307, If so I will fix conflict!

Thanks