### PR TITLE
modify first prompt of faithfullness

### DIFF
--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -16,13 +16,16 @@ if t.TYPE_CHECKING:
 #################
 LONG_FORM_ANSWER_PROMPT = HumanMessagePromptTemplate.from_template(
     """\
-Given a question and answer, create one or more statements from each sentence in the given answer.
+Given a question and answer, create one or more statements from each sentence in the given answer. If you can't create a statement, you can return None. 
 question: Who was  Albert Einstein and what is he best known for?
 answer: He was a German-born theoretical physicist, widely acknowledged to be one of the greatest and most influential physicists of all time. He was best known for developing the theory of relativity, he also made important contributions to the development of the theory of quantum mechanics.
 statements:\nAlbert Einstein was born in Germany.\nAlbert Einstein was best known for his theory of relativity.
 question: Cadmium Chloride is slightly soluble in this chemical, it is also called what?
 answer: alcohol
 statements:\nCadmium Chloride is slightly soluble in alcohol.
+question: Where is the Tokyo Tower located?
+answer: Nintendo 
+statements:\nNone
 question: Were Shahul and Jithin of the same nationality?
 answer: They were from different countries.
 statements:\nShahul and Jithin were from different countries.


### PR DESCRIPTION
This PR is kind of suggestion and related my previous PR #317.
Like previous my PR, if you change fake result into "Final Fantagy is good game" ,which is completely nun sense answer on cell 10 on [this notebook](https://github.com/explodinggradients/ragas/blob/main/docs/howtos/integrations/langchain.ipynb), the result of faithfullness will be 1. This is not good. You can try it out. This is because if the answer is too stupid, first output from LLM generate statement from question.
So I would like to change first PROMPT TEMPLATE that if LLM feel difficult to guess return None.