### PR TITLE
Fix OpenAIEmbeddings reference error in answer_relevancy

### DIFF
--- a/docs/howtos/customisations/azure-openai.ipynb
+++ b/docs/howtos/customisations/azure-openai.ipynb
@@ -171,7 +171,7 @@
     "\n",
     "# init and change the embeddings\n",
     "# only for answer_relevancy\n",
-    "azure_embeddings = OpenAIEmbeddings(\n",
+    "azure_embeddings = AzureOpenAIEmbeddings(\n",
     "    deployment=\"your-embeddings-deployment-name\",\n",
     "    model=\"your-embeddings-model-name\",\n",
     "    openai_api_base=\"https://your-endpoint.openai.azure.com/\",\n",

--- a/docs/howtos/customisations/azure-openai.ipynb
+++ b/docs/howtos/customisations/azure-openai.ipynb
@@ -155,7 +155,7 @@
    "outputs": [],
    "source": [
     "from langchain.chat_models import AzureChatOpenAI\n",
-    "from langchain.embeddings import OpenAIEmbeddings\n",
+    "from langchain.embeddings import AzureOpenAIEmbeddings\n",
     "from ragas.llms import LangchainLLM\n",
     "\n",
     "azure_model = AzureChatOpenAI(\n",


### PR DESCRIPTION
The code previously raised a NotFoundError due to an incorrect reference to the OpenAIEmbeddings class. This commit corrects the reference to AzureOpenAIEmbeddings, resolving the error. #326