### PR TITLE
fix: bedrock llm error when evaluating rag qa `validate_api_key`

### DIFF
--- a/src/ragas/metrics/base.py
+++ b/src/ragas/metrics/base.py
@@ -118,7 +118,8 @@ class MetricWithLLM(Metric):
         to load all the models
         Also check if the api key is valid for OpenAI and AzureOpenAI
         """
-        self.llm.validate_api_key()
+        if hasattr(self.llm, "validate_api_key"):
+            self.llm.validate_api_key()
         if hasattr(self, "embeddings"):
             # since we are using Langchain Embeddings directly, we need to check this
             if hasattr(self.embeddings, "validate_api_key"):


### PR DESCRIPTION
Add a conditional statement to check whether `validate_api_key` exists for the ChatModel Object from Langchain #348