### PR TITLE
fix(metrics): avoid getting none in context_recall

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,7 @@ rich
 ruff
 isort
 black[jupyter]
-pyright
+pyright==1.1.338
 llama_index
 notebook
 sphinx-autobuild

--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -116,10 +116,14 @@ class ContextRecall(MetricWithLLM):
             for response in responses:
                 response = load_as_json(response[0])
                 if response:
+                    response = [
+                        int(item.get("Attributed", "").lower() == "yes")
+                        if item.get("Attributed")
+                        else np.nan
+                        for item in response
+                    ]
                     denom = len(response)
-                    numerator = sum(
-                        item.get("Attributed", "").lower() == "yes" for item in response
-                    )
+                    numerator = sum(response)
                     scores.append(numerator / denom)
                 else:
                     scores.append(np.nan)

--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -18,7 +18,7 @@ Given a context, and an answer, analyze each sentence in the answer and classify
 
 question: What can you tell me about albert Albert Einstein?
 context: Albert Einstein (14 March 1879 – 18 April 1955) was a German-born theoretical physicist,widely held to be one of the greatest and most influential scientists of all time. Best known for developing the theory of relativity, he also made important contributions to quantum mechanics, and was thus a central figure in the revolutionary reshaping of the scientific understanding of nature that modern physics accomplished in the first decades of the twentieth century. His mass–energy equivalence formula E = mc2, which arises from relativity theory, has been called "the world's most famous equation". He received the 1921 Nobel Prize in Physics "for his services to theoretical physics, and especially for his discovery of the law of the photoelectric effect", a pivotal step in the development of quantum theory. His work is also known for its influence on the philosophy of science. In a 1999 poll of 130 leading physicists worldwide by the British journal Physics World, Einstein was ranked the greatest physicist of all time. His intellectual achievements and originality have made Einstein synonymous with genius.
-answer: Albert Einstein born in 14 March 1879 was  German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time. He received the 1921 Nobel Prize in Physics "for his services to theoretical physics. He published 4 papers in 1905.  Einstein moved to Switzerland in 1895 
+answer: Albert Einstein born in 14 March 1879 was  German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time. He received the 1921 Nobel Prize in Physics "for his services to theoretical physics. He published 4 papers in 1905.  Einstein moved to Switzerland in 1895
 classification:
 [
     {{  "statement_1":"Albert Einstein, born on 14 March 1879, was a German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time.",
@@ -45,7 +45,7 @@ classification:
 question: who won 2020 icc world cup?
 context: Who won the 2022 ICC Men's T20 World Cup?
 The 2022 ICC Men's T20 World Cup, held from October 16 to November 13, 2022, in Australia, was the eighth edition of the tournament. Originally scheduled for 2020, it was postponed due to the COVID-19 pandemic. England emerged victorious, defeating Pakistan by five wickets in the final to clinch their second ICC Men's T20 World Cup title.
-answer: England 
+answer: England
 classification:
 [
     {{
@@ -118,7 +118,7 @@ class ContextRecall(MetricWithLLM):
                 if response:
                     denom = len(response)
                     numerator = sum(
-                        item.get("Attributed").lower() == "yes" for item in response
+                        item.get("Attributed", "").lower() == "yes" for item in response
                     )
                     scores.append(numerator / denom)
                 else:

--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -18,7 +18,7 @@ Given a context, and an answer, analyze each sentence in the answer and classify
 
 question: What can you tell me about albert Albert Einstein?
 context: Albert Einstein (14 March 1879 – 18 April 1955) was a German-born theoretical physicist,widely held to be one of the greatest and most influential scientists of all time. Best known for developing the theory of relativity, he also made important contributions to quantum mechanics, and was thus a central figure in the revolutionary reshaping of the scientific understanding of nature that modern physics accomplished in the first decades of the twentieth century. His mass–energy equivalence formula E = mc2, which arises from relativity theory, has been called "the world's most famous equation". He received the 1921 Nobel Prize in Physics "for his services to theoretical physics, and especially for his discovery of the law of the photoelectric effect", a pivotal step in the development of quantum theory. His work is also known for its influence on the philosophy of science. In a 1999 poll of 130 leading physicists worldwide by the British journal Physics World, Einstein was ranked the greatest physicist of all time. His intellectual achievements and originality have made Einstein synonymous with genius.
-answer: Albert Einstein born in 14 March 1879 was  German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time. He received the 1921 Nobel Prize in Physics "for his services to theoretical physics. He published 4 papers in 1905.  Einstein moved to Switzerland in 1895
+answer: Albert Einstein born in 14 March 1879 was  German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time. He received the 1921 Nobel Prize in Physics "for his services to theoretical physics. He published 4 papers in 1905.  Einstein moved to Switzerland in 1895 
 classification:
 [
     {{  "statement_1":"Albert Einstein, born on 14 March 1879, was a German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time.",
@@ -45,7 +45,7 @@ classification:
 question: who won 2020 icc world cup?
 context: Who won the 2022 ICC Men's T20 World Cup?
 The 2022 ICC Men's T20 World Cup, held from October 16 to November 13, 2022, in Australia, was the eighth edition of the tournament. Originally scheduled for 2020, it was postponed due to the COVID-19 pandemic. England emerged victorious, defeating Pakistan by five wickets in the final to clinch their second ICC Men's T20 World Cup title.
-answer: England
+answer: England 
 classification:
 [
     {{


### PR DESCRIPTION
Maybe this isssue https://github.com/explodinggradients/ragas/issues/352 is talking about the same thing.