### PR TITLE
Fix: context_recall AttributeError

### DIFF
--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -114,6 +114,7 @@ class ContextRecall(MetricWithLLM):
             self._create_context_recall_prompt(row), callbacks=callbacks
         )
         response = json_loader.safe_load(result.generations[0][0].text, self.llm)
+        response = [response] if isinstance(response, dict) else response
 
         return self._compute_score(response)
 


### PR DESCRIPTION
Simple workaround to fix `AttributeError: 'str' object has no attribute 'get'` caused by non consistent LLM evaluation output. Resulting in the use of .get() on a str instead of a dict.  
More on this [issue ](https://github.com/explodinggradients/ragas/issues/429)