### PR TITLE
Fix ValueError: diag requires an array of at least two dimensions #474

### DIFF
--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -92,7 +92,12 @@ class AnswerSimilarity(MetricWithLLM):
             )
             embeddings_2 = np.array(await self.embeddings.aembed_documents(answers))
             similarity = embeddings_1 @ embeddings_2.T
-            scores = np.diagonal(similarity)
+            if similarity.size == 1:
+                # If similarity has only one value, directly use this value as scores
+                scores = similarity.flatten()
+            else:
+                # If similarity contains multiple values, extract the diagonal as scores
+                scores = np.diagonal(similarity)
 
         assert isinstance(scores, np.ndarray), "Expects ndarray"
         if self.threshold:

--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -70,7 +70,12 @@ class AnswerSimilarity(MetricWithLLM):
             embeddings_1 = np.array(self.embeddings.embed_documents(ground_truths))
             embeddings_2 = np.array(self.embeddings.embed_documents(answers))
             similarity = embeddings_1 @ embeddings_2.T
-            scores = np.diagonal(similarity)
+            if similarity.size == 1:
+                # If similarity has only one value, directly use this value as scores
+                scores = similarity.flatten()
+            else:
+                # If similarity contains multiple values, extract the diagonal as scores
+                scores = np.diagonal(similarity)
 
         assert isinstance(scores, np.ndarray), "Expects ndarray"
         if self.threshold:
@@ -93,10 +98,8 @@ class AnswerSimilarity(MetricWithLLM):
             embeddings_2 = np.array(await self.embeddings.aembed_documents(answers))
             similarity = embeddings_1 @ embeddings_2.T
             if similarity.size == 1:
-                # If similarity has only one value, directly use this value as scores
                 scores = similarity.flatten()
             else:
-                # If similarity contains multiple values, extract the diagonal as scores
                 scores = np.diagonal(similarity)
 
         assert isinstance(scores, np.ndarray), "Expects ndarray"


### PR DESCRIPTION
Detailed description:
- Directly use the single element as the score if the similarity array has only one item, instead of attempting to extract a diagonal.
- Added a condition to check similarity.size to determine whether diagonal extraction is necessary.
- Updated unit tests to reflect this change.

Fixes #474