### PR TITLE
fix: polishing `raise_exception` and `max_workers`

### DIFF
--- a/src/ragas/evaluation.py
+++ b/src/ragas/evaluation.py
@@ -48,6 +48,30 @@ def evaluate(
     metrics : list[Metric] , optional
         List of metrics to use for evaluation. If not provided then ragas will run the
         evaluation on the best set of metrics to give a complete view.
+    llm: BaseRagasLLM, optional
+        The language model to use for the metrics. If not provided then ragas will use
+        the default language model. This can we overridden by the llm specified in
+        the metric level with `metric.llm`.
+    embeddings: BaseRagasEmbeddings, optional
+        The embeddings to use for the metrics. If not provided then ragas will use
+        the default embeddings. This can we overridden by the embeddings specified in
+        the metric level with `metric.embeddings`.
+    callbacks: Callbacks, optional
+        Lifecycle Langchain Callbacks to run during evaluation. Check the
+        [langchain documentation](https://python.langchain.com/docs/modules/callbacks/)
+        for more information.
+    is_async: bool, optional
+        Whether to run the evaluation in async mode or not. If set to True then the
+        evaluation is run by calling the `metric.ascore` method. In case the llm or
+        embeddings does not support async then the evaluation can be run in sync mode
+        with `is_async=False`. Default is False.
+    max_workers: int, optional
+        The number of workers to use for the evaluation. This is used by the
+        `ThreadpoolExecutor` to run the evaluation in sync mode.
+    raise_exceptions: bool, optional
+        Whether to raise exceptions or not. If set to True then the evaluation will
+        raise an exception if any of the metrics fail. If set to False then the
+        evaluation will return `np.nan` for the row that failed. Default is True.
     column_map : dict[str, str], optional
         The column names of the dataset to use for evaluation. If the column names of
         the dataset are different from the default ones then you can provide the

--- a/src/ragas/evaluation.py
+++ b/src/ragas/evaluation.py
@@ -178,7 +178,7 @@ def evaluate(
             evaluation_rm.on_chain_error(e)
 
         raise e
-    finally:
+    else:
         result = Result(
             scores=Dataset.from_list(scores),
             dataset=dataset,

--- a/src/ragas/executor.py
+++ b/src/ragas/executor.py
@@ -3,8 +3,8 @@ import typing as t
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 
-from tqdm.auto import tqdm
 import numpy as np
+from tqdm.auto import tqdm
 
 
 @dataclass

--- a/src/ragas/executor.py
+++ b/src/ragas/executor.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 
 from tqdm.auto import tqdm
+import numpy as np
 
 
 @dataclass
@@ -74,7 +75,7 @@ class Executor:
             desc=self.desc,
             total=len(self.futures),
         ):
-            r = (-1, None)
+            r = (-1, np.nan)
             try:
                 r = await future
             except Exception as e:
@@ -109,11 +110,11 @@ class Executor:
                     desc=self.desc,
                     total=len(self.futures),
                 ):
-                    r = (-1, None)
+                    r = (-1, np.nan)
                     try:
                         r = future.result()
                     except Exception as e:
-                        r = (-1, None)
+                        r = (-1, np.nan)
                         if self.raise_exceptions:
                             raise e
                     finally:
@@ -121,6 +122,5 @@ class Executor:
             finally:
                 self.executor.shutdown(wait=False)
 
-        print(results)
         sorted_results = sorted(results, key=lambda x: x[0])
         return [r[1] for r in sorted_results]


### PR DESCRIPTION
- polsihed `raise_exception` which can control if you want to raise an exception or return np.nan if an error occurs
- `max_workers` can used control how many requests you do - incase you run into rate limits with ur endpoints