### PR TITLE
feat(executor): remove the need to have both sync and async versions of the function

### DIFF
--- a/src/ragas/embeddings/base.py
+++ b/src/ragas/embeddings/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import typing as t
 import asyncio
+import typing as t
 from abc import ABC
 from dataclasses import field
 from typing import List
@@ -10,8 +10,6 @@ import numpy as np
 from langchain_core.embeddings import Embeddings
 from langchain_openai.embeddings import OpenAIEmbeddings
 from pydantic.dataclasses import dataclass
-
-from ragas.llms.base import LangchainLLMWrapper
 
 DEFAULT_MODEL_NAME = "BAAI/bge-small-en-v1.5"
 

--- a/src/ragas/evaluation.py
+++ b/src/ragas/evaluation.py
@@ -157,7 +157,7 @@ def evaluate(
     executor = Executor(
         desc="Evaluating",
         keep_progress_bar=True,
-        is_async=is_async,
+        is_async=True,
         max_workers=max_workers,
         raise_exceptions=raise_exceptions,
     )
@@ -175,26 +175,18 @@ def evaluate(
             is_async=is_async,
         )
         row_run_managers.append((row_rm, row_group_cm))
-
-        if is_async:
-            with ThreadPoolExecutor() as executor_internal:
-                [
-                    executor.submit(
-                        metric.ascore,
-                        row,
-                        row_group_cm,
-                        executor_internal,
-                        name=f"{metric.name}-{i}",
-                    )
-                    for metric in metrics
-                ]
-        else:
-            [executor.submit(metric.score, row, row_group_cm) for metric in metrics]
+        [
+            executor.submit(
+                metric.ascore, row, row_group_cm, is_async, name=f"{metric.name}-{i}"
+            )
+            for metric in metrics
+        ]
 
     scores = []
     try:
         # get the results
         results = executor.results()
+        return
         # convert results to dataset_like
         for i, _ in enumerate(dataset):
             s = {}

--- a/src/ragas/evaluation.py
+++ b/src/ragas/evaluation.py
@@ -185,7 +185,7 @@ def evaluate(
     try:
         # get the results
         results = executor.results()
-        return
+
         # convert results to dataset_like
         for i, _ in enumerate(dataset):
             s = {}

--- a/src/ragas/evaluation.py
+++ b/src/ragas/evaluation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import typing as t
 from dataclasses import dataclass, field
-from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 from datasets import Dataset, concatenate_datasets

--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import typing as t
 import asyncio
+import typing as t
 from abc import ABC, abstractmethod
-from functools import partial
 from dataclasses import dataclass
+from functools import partial
 
 from langchain_community.chat_models import AzureChatOpenAI, ChatOpenAI, ChatVertexAI
 from langchain_community.llms import AzureOpenAI, OpenAI, VertexAI

--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -86,6 +86,7 @@ class BaseRagasLLM(ABC):
                 callbacks=callbacks,
             )
         else:
+            loop = asyncio.get_event_loop()
             generate_text = partial(
                 self.generate_text,
                 prompt=prompt,

--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -109,7 +109,7 @@ class LangchainLLMWrapper(BaseRagasLLM):
 
     langchain_llm: BaseLanguageModel
 
-    @retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(6))
+    @retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(15))
     def generate_text(
         self,
         prompt: PromptValue,
@@ -140,7 +140,7 @@ class LangchainLLMWrapper(BaseRagasLLM):
             result.generations = generations
             return result
 
-    @retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(6))
+    @retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(15))
     async def agenerate_text(
         self,
         prompt: PromptValue,

--- a/src/ragas/llms/json_load.py
+++ b/src/ragas/llms/json_load.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import asyncio
+from functools import partial
 import logging
 import typing as t
 from dataclasses import dataclass
@@ -75,7 +77,7 @@ Output:
 class JsonLoader:
     max_retries: int = 2
 
-    def safe_load(self, text: str, llm: BaseRagasLLM, callbacks: Callbacks = None):
+    def _safe_load(self, text: str, llm: BaseRagasLLM, callbacks: Callbacks = None):
         retry = 0
         while retry <= self.max_retries:
             try:
@@ -94,7 +96,7 @@ class JsonLoader:
 
         return {}
 
-    async def asafe_load(
+    async def _asafe_load(
         self, text: str, llm: BaseRagasLLM, callbacks: Callbacks = None
     ):
         retry = 0
@@ -114,6 +116,25 @@ class JsonLoader:
             retry += 1
 
         return {}
+
+    async def safe_load(
+        self,
+        text: str,
+        llm: BaseRagasLLM,
+        callbacks: Callbacks = None,
+        is_async: bool = True,
+    ):
+        loop = asyncio.get_event_loop()
+        if is_async:
+            return await self._asafe_load(text=text, llm=llm, callbacks=callbacks)
+        else:
+            safe_load = partial(
+                self._safe_load, text=text, llm=llm, callbacks=callbacks
+            )
+            return await loop.run_in_executor(
+                None,
+                safe_load,
+            )
 
     def _find_outermost_json(self, text):
         stack = []

--- a/src/ragas/llms/json_load.py
+++ b/src/ragas/llms/json_load.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import json
 import asyncio
-from functools import partial
+import json
 import logging
 import typing as t
 from dataclasses import dataclass
+from functools import partial
 
 logger = logging.getLogger(__name__)
 
@@ -124,10 +124,10 @@ class JsonLoader:
         callbacks: Callbacks = None,
         is_async: bool = True,
     ):
-        loop = asyncio.get_event_loop()
         if is_async:
             return await self._asafe_load(text=text, llm=llm, callbacks=callbacks)
         else:
+            loop = asyncio.get_event_loop()
             safe_load = partial(
                 self._safe_load, text=text, llm=llm, callbacks=callbacks
             )

--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -190,7 +190,7 @@ class Prompt(BaseModel):
                 {k: v for k, v in zip(self.input_keys, example[: len(self.input_keys)])}
             )
             example_dict[self.output_key] = (
-                json_loader.safe_load(example[-1], llm)
+                json_loader._safe_load(example[-1], llm)
                 if self.output_type.lower() == "json"
                 else example[-1]
             )

--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -56,7 +56,9 @@ class AnswerSimilarity(MetricWithLLM, MetricWithEmbeddings):
     def init_model(self):
         super().init_model()
 
-    def _score(self, row: t.Dict, callbacks: Callbacks) -> float:
+    async def _ascore(
+        self: t.Self, row: t.Dict, callbacks: Callbacks, is_async: bool
+    ) -> float:
         assert self.embeddings is not None, "embeddings must be set"
 
         ground_truth, answers = row["ground_truth"], row["answer"]
@@ -67,37 +69,8 @@ class AnswerSimilarity(MetricWithLLM, MetricWithEmbeddings):
                 "async score [ascore()] not implemented for HuggingFace embeddings"
             )
         else:
-            embeddings_1 = np.array(self.embeddings.embed_documents(ground_truth))
-            embeddings_2 = np.array(self.embeddings.embed_documents(answers))
-            similarity = embeddings_1 @ embeddings_2.T
-            if similarity.size == 1:
-                # If similarity has only one value, directly use this value as scores
-                scores = similarity.flatten()
-            else:
-                # If similarity contains multiple values, extract the diagonal as scores
-                scores = np.diagonal(similarity)
-
-        assert isinstance(scores, np.ndarray), "Expects ndarray"
-        if self.threshold:
-            scores = scores >= self.threshold
-
-        return scores.tolist()[0]
-
-    async def _ascore(self: t.Self, row: t.Dict, callbacks: Callbacks = []) -> float:
-        assert self.embeddings is not None, "embeddings must be set"
-
-        ground_truth: t.List[str] = row["ground_truth"]
-        answer: t.List[str] = row["answer"]
-
-        if self.is_cross_encoder and isinstance(self.embeddings, HuggingfaceEmbeddings):
-            raise NotImplementedError(
-                "async score [ascore()] not implemented for HuggingFace embeddings"
-            )
-        else:
-            embeddings_1 = np.array(
-                await self.embeddings.aembed_documents(ground_truth)
-            )
-            embeddings_2 = np.array(await self.embeddings.aembed_documents(answer))
+            embeddings_1 = np.array(await self.embeddings.embed_texts(ground_truths))
+            embeddings_2 = np.array(await self.embeddings.embed_texts(answers))
             similarity = embeddings_1 @ embeddings_2.T
             if similarity.size == 1:
                 scores = similarity.flatten()

--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -69,7 +69,7 @@ class AnswerSimilarity(MetricWithLLM, MetricWithEmbeddings):
                 "async score [ascore()] not implemented for HuggingFace embeddings"
             )
         else:
-            embeddings_1 = np.array(await self.embeddings.embed_texts(ground_truths))
+            embeddings_1 = np.array(await self.embeddings.embed_texts(ground_truth))
             embeddings_2 = np.array(await self.embeddings.embed_texts(answers))
             similarity = embeddings_1 @ embeddings_2.T
             if similarity.size == 1:

--- a/src/ragas/metrics/_context_relevancy.py
+++ b/src/ragas/metrics/_context_relevancy.py
@@ -69,7 +69,7 @@ class ContextRelevancy(MetricWithLLM):
         else:
             return min(len(indices) / len(context_sents), 1)
 
-    def _score(self, row: t.Dict, callbacks: Callbacks) -> float:
+    async def _ascore(self, row: t.Dict, callbacks: Callbacks, is_async: bool) -> float:
         assert self.llm is not None, "LLM is not initialized"
 
         if self.show_deprecation_warning:
@@ -78,25 +78,7 @@ class ContextRelevancy(MetricWithLLM):
             )
 
         question, contexts = row["question"], row["contexts"]
-        result = self.llm.generate_text(
-            self.context_relevancy_prompt.format(
-                question=question, context="\n".join(contexts)
-            ),
-            callbacks=callbacks,
-        )
-
-        return self._compute_score(result.generations[0][0].text, row)
-
-    async def _ascore(self, row: t.Dict, callbacks: Callbacks) -> float:
-        assert self.llm is not None, "LLM is not initialized"
-
-        if self.show_deprecation_warning:
-            logger.warning(
-                "The 'context_relevancy' metric is going to be deprecated soon! Please use the 'context_precision' metric instead. It is a drop-in replacement just a simple search and replace should work."  # noqa
-            )
-
-        question, contexts = row["question"], row["contexts"]
-        result = await self.llm.agenerate_text(
+        result = await self.llm.generate(
             self.context_relevancy_prompt.format(
                 question=question, context="\n".join(contexts)
             ),

--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import typing as t
+from functools import partial
 import asyncio
 from dataclasses import dataclass, field
 
@@ -168,38 +169,32 @@ class Faithfulness(MetricWithLLM):
 
         return score
 
-    async def _ascore(self: t.Self, row: t.Dict, callbacks: Callbacks) -> float:
+    async def _ascore(
+        self: t.Self, row: t.Dict, callbacks: Callbacks, is_async: bool
+    ) -> float:
         """
         returns the NLI score for each (q, c, a) pair
         """
-        loop = asyncio.get_running_loop()
         assert self.llm is not None, "LLM is not set"
         p = self._create_answer_prompt(row)
-        answer_result = await self.llm.agenerate_text(p, callbacks=callbacks)
-
-        statements = await loop.run_in_executor(
-            None, json_loader.safe_load, answer_result.generations[0][0].text, self.llm
+        answer_result = await self.llm.generate(
+            p, callbacks=callbacks, is_async=is_async
         )
+        statements = await json_loader.safe_load(
+            text=answer_result.generations[0][0].text,
+            llm=self.llm,
+            callbacks=callbacks,
+            is_async=is_async,
+        )
+
         p = self._create_nli_prompt(row, statements.get("statements", []))
-        result = await loop.run_in_executor(None, self.llm.generate_text, p)
-
-        json_output = await loop.run_in_executor(
-            None, json_loader.safe_load, result.generations[0][0].text, self.llm
+        nli_result = await self.llm.generate(p, callbacks=callbacks, is_async=is_async)
+        json_output = await json_loader.safe_load(
+            text=nli_result.generations[0][0].text,
+            llm=self.llm,
+            callbacks=callbacks,
+            is_async=is_async,
         )
-        return self._compute_score(json_output)
-
-    def _score(self, row: t.Dict, callbacks: Callbacks) -> float:
-        assert self.llm is not None, "LLM is not set"
-        p = self._create_answer_prompt(row)
-        answer_result = self.llm.generate_text(p, callbacks=callbacks)
-
-        statements = json_loader.safe_load(
-            answer_result.generations[0][0].text, self.llm
-        )
-        p = self._create_nli_prompt(row, statements.get("statements", []))
-        result = self.llm.generate_text(p, callbacks=callbacks)
-
-        json_output = json_loader.safe_load(result.generations[0][0].text, self.llm)
         return self._compute_score(json_output)
 
     def adapt(self, language: str, cache_dir: t.Optional[str] = None) -> None:

--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import logging
 import typing as t
-from functools import partial
-import asyncio
 from dataclasses import dataclass, field
 
 import numpy as np

--- a/src/ragas/metrics/base.py
+++ b/src/ragas/metrics/base.py
@@ -7,6 +7,7 @@ G - ground_truths: ground truth answer
 from __future__ import annotations
 
 import typing as t
+import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -69,7 +70,9 @@ class Metric(ABC):
             self.name, inputs=row, callbacks=callbacks, is_async=False
         )
         try:
-            score = self._score(row=row, callbacks=group_cm)
+            score = asyncio.run(
+                self._ascore(row=row, callbacks=group_cm, is_async=False)
+            )
         except Exception as e:
             if not group_cm.ended:
                 rm.on_chain_error(e)
@@ -79,16 +82,14 @@ class Metric(ABC):
                 rm.on_chain_end({"output": score})
         return score
 
-    @abstractmethod
-    def _score(self, row: t.Dict, callbacks: Callbacks) -> float:
-        ...
-
-    async def ascore(self: t.Self, row: t.Dict, callbacks: Callbacks = []) -> float:
+    async def ascore(
+        self: t.Self, row: t.Dict, callbacks: Callbacks = [], is_async: bool = True
+    ) -> float:
         rm, group_cm = new_group(
             self.name, inputs=row, callbacks=callbacks, is_async=True
         )
         try:
-            score = await self._ascore(row=row, callbacks=group_cm)
+            score = await self._ascore(row=row, callbacks=group_cm, is_async=is_async)
         except Exception as e:
             if not group_cm.ended:
                 rm.on_chain_error(e)
@@ -99,7 +100,7 @@ class Metric(ABC):
         return score
 
     @abstractmethod
-    async def _ascore(self, row: t.Dict, callbacks: Callbacks) -> float:
+    async def _ascore(self, row: t.Dict, callbacks: Callbacks, is_async: bool) -> float:
         ...
 
 

--- a/src/ragas/metrics/base.py
+++ b/src/ragas/metrics/base.py
@@ -6,8 +6,8 @@ G - ground_truths: ground truth answer
 """
 from __future__ import annotations
 
-import typing as t
 import asyncio
+import typing as t
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum

--- a/src/ragas/metrics/critique.py
+++ b/src/ragas/metrics/critique.py
@@ -112,32 +112,21 @@ class AspectCritique(MetricWithLLM):
 
         return score
 
-    def _score(self: t.Self, row: t.Dict, callbacks: Callbacks) -> float:
+    async def _ascore(
+        self: t.Self, row: t.Dict, callbacks: Callbacks, is_async: bool
+    ) -> float:
         assert self.llm is not None, "set LLM before use"
 
         q, c, a = row["question"], row["contexts"], row["answer"]
 
-        result = self.llm.generate_text(
-            self.prompt_format(q, a, c), callbacks=callbacks
-        )
-
-        responses = [r.text for r in result.generations[0]]
-        safe_loaded_responses = [json_loader.safe_load(r, self.llm) for r in responses]
-
-        return self._compute_score(safe_loaded_responses)
-
-    async def _ascore(self: t.Self, row: t.Dict, callbacks: Callbacks) -> float:
-        assert self.llm is not None, "set LLM before use"
-
-        q, c, a = row["question"], row["contexts"], row["answer"]
-
-        result = await self.llm.agenerate_text(
-            self.prompt_format(q, a, c), callbacks=callbacks
+        result = await self.llm.generate(
+            self.prompt_format(q, a, c), callbacks=callbacks, is_async=is_async
         )
 
         responses = [r.text for r in result.generations[0]]
         safe_loaded_responses = [
-            await json_loader.asafe_load(r, self.llm) for r in responses
+            await json_loader.safe_load(r, self.llm, is_async=is_async)
+            for r in responses
         ]
 
         return self._compute_score(safe_loaded_responses)

--- a/src/ragas/testset/filters.py
+++ b/src/ragas/testset/filters.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import typing as t
 from abc import ABC
@@ -31,10 +30,7 @@ class NodeFilter(Filter):
     llm: BaseRagasLLM
     threshold: float = 7.5
 
-    def filter(self, node: Node) -> t.Dict:
-        return asyncio.get_event_loop().run_until_complete(self.afilter(node))
-
-    async def afilter(self, node: Node) -> t.Dict:
+    async def filter(self, node: Node) -> t.Dict:
         prompt = context_scoring_prompt.format(context=node.page_content)
         results = await self.llm.agenerate_text(prompt=prompt)
         output = results.generations[0][0].text.strip()
@@ -47,10 +43,7 @@ class NodeFilter(Filter):
 class QuestionFilter(Filter):
     llm: BaseRagasLLM
 
-    def filter(self, question: str) -> bool:
-        return asyncio.get_event_loop().run_until_complete(self.afilter(question))
-
-    async def afilter(self, question: str) -> bool:
+    async def filter(self, question: str) -> bool:
         prompt = filter_question_prompt.format(question=question)
         results = await self.llm.agenerate_text(prompt=prompt)
         results = results.generations[0][0].text.strip()
@@ -63,12 +56,7 @@ class QuestionFilter(Filter):
 class EvolutionFilter(Filter):
     llm: BaseRagasLLM
 
-    def filter(self, simple_question: str, compressed_question: str) -> bool:
-        return asyncio.get_event_loop().run_until_complete(
-            self.afilter(simple_question, compressed_question)
-        )
-
-    async def afilter(self, simple_question: str, compressed_question: str) -> bool:
+    async def filter(self, simple_question: str, compressed_question: str) -> bool:
         prompt = evolution_elimination_prompt.format(
             question1=simple_question, question2=compressed_question
         )

--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -10,7 +10,7 @@ from langchain_openai.chat_models import ChatOpenAI
 from langchain_openai.embeddings import OpenAIEmbeddings
 
 from ragas._analytics import TesetGenerationEvent, track
-from ragas.embeddings import BaseRagasEmbeddings
+from ragas.embeddings.base import BaseRagasEmbeddings, LangchainEmbeddingsWrapper
 from ragas.executor import Executor
 from ragas.llms import BaseRagasLLM, LangchainLLMWrapper
 from ragas.testset.docstore import Document, DocumentStore, InMemoryDocumentStore
@@ -75,7 +75,9 @@ class TestsetGenerator:
     ) -> "TestsetGenerator":
         generator_llm_model = LangchainLLMWrapper(ChatOpenAI(model=generator_llm))
         critic_llm_model = LangchainLLMWrapper(ChatOpenAI(model=critic_llm))
-        embeddings_model = OpenAIEmbeddings(model=embeddings)
+        embeddings_model = LangchainEmbeddingsWrapper(
+            OpenAIEmbeddings(model=embeddings)
+        )
         if docstore is None:
             from langchain.text_splitter import TokenTextSplitter
 
@@ -142,6 +144,7 @@ class TestsetGenerator:
         test_size: int,
         distributions: Distributions = DEFAULT_DISTRIBUTION,
         with_debugging_logs=False,
+        is_async: bool = True,
     ):
         # init filters and evolutions
         for evolution in distributions:
@@ -159,7 +162,7 @@ class TestsetGenerator:
                 if evolution.evolution_filter is None:
                     evolution.evolution_filter = EvolutionFilter(llm=self.critic_llm)
 
-            evolution.init_evolution()
+            evolution.init_evolution(is_async=is_async)
         if with_debugging_logs:
             from ragas.utils import patch_logger
 

--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -107,6 +107,7 @@ class TestsetGenerator:
         test_size: int,
         distributions: Distributions = {},
         with_debugging_logs=False,
+        is_async: bool = True,
     ):
         # chunk documents and add to docstore
         self.docstore.add_documents(
@@ -117,6 +118,7 @@ class TestsetGenerator:
             test_size=test_size,
             distributions=distributions,
             with_debugging_logs=with_debugging_logs,
+            is_async=is_async,
         )
 
     # if you add any arguments to this function, make sure to add them to
@@ -127,6 +129,7 @@ class TestsetGenerator:
         test_size: int,
         distributions: Distributions = {},
         with_debugging_logs=False,
+        is_async: bool = True,
     ):
         # chunk documents and add to docstore
         self.docstore.add_documents(
@@ -137,6 +140,7 @@ class TestsetGenerator:
             test_size=test_size,
             distributions=distributions,
             with_debugging_logs=with_debugging_logs,
+            is_async=is_async,
         )
 
     def generate(

--- a/tests/benchmarks/benchmark_eval.py
+++ b/tests/benchmarks/benchmark_eval.py
@@ -27,15 +27,15 @@ metrics = [
     faithfulness,
     # context_recall,
     # answer_relevancy,
-    # answer_correctness,
+    answer_correctness,
     # harmfulness,
     # context_relevancy,
     # context_precision,
     # context_utilization,
-    # answer_similarity,
+    answer_similarity,
 ]
 
-os.environ["PYTHONASYNCIODEBUG"] = "1"
+# os.environ["PYTHONASYNCIODEBUG"] = "1"
 IGNORE_THREADS = False
 IGNORE_ASYNCIO = False
 

--- a/tests/benchmarks/benchmark_eval.py
+++ b/tests/benchmarks/benchmark_eval.py
@@ -1,7 +1,7 @@
 import os
 import time
 
-from datasets import DatasetDict, load_dataset
+from datasets import DatasetDict, load_dataset, concatenate_datasets
 
 from ragas import evaluate
 from ragas.metrics import (
@@ -20,18 +20,19 @@ from ragas.metrics.critique import harmfulness
 ds = load_dataset("explodinggradients/amnesty_qa", "english_v2")
 assert isinstance(ds, DatasetDict)
 eval_dataset = ds["eval"]
+eval_dataset = concatenate_datasets([eval_dataset] * 3)
 
 # metrics
 metrics = [
     faithfulness,
-    context_recall,
-    answer_relevancy,
-    answer_correctness,
-    harmfulness,
-    context_relevancy,
-    context_precision,
-    context_utilization,
-    answer_similarity,
+    # context_recall,
+    # answer_relevancy,
+    # answer_correctness,
+    # harmfulness,
+    # context_relevancy,
+    # context_precision,
+    # context_utilization,
+    # answer_similarity,
 ]
 
 os.environ["PYTHONASYNCIODEBUG"] = "1"

--- a/tests/benchmarks/benchmark_eval.py
+++ b/tests/benchmarks/benchmark_eval.py
@@ -1,7 +1,6 @@
-import os
 import time
 
-from datasets import DatasetDict, load_dataset, concatenate_datasets
+from datasets import DatasetDict, load_dataset
 
 from ragas import evaluate
 from ragas.metrics import (
@@ -20,18 +19,17 @@ from ragas.metrics.critique import harmfulness
 ds = load_dataset("explodinggradients/amnesty_qa", "english_v2")
 assert isinstance(ds, DatasetDict)
 eval_dataset = ds["eval"]
-eval_dataset = concatenate_datasets([eval_dataset] * 3)
 
 # metrics
 metrics = [
     faithfulness,
-    # context_recall,
-    # answer_relevancy,
+    context_recall,
+    answer_relevancy,
     answer_correctness,
-    # harmfulness,
-    # context_relevancy,
-    # context_precision,
-    # context_utilization,
+    harmfulness,
+    context_relevancy,
+    context_precision,
+    context_utilization,
     answer_similarity,
 ]
 

--- a/tests/benchmarks/benchmark_testsetgen.py
+++ b/tests/benchmarks/benchmark_testsetgen.py
@@ -22,22 +22,33 @@ def get_documents():
     return documents
 
 
-IGNORE_THREADS = True
+IGNORE_THREADS = False
 IGNORE_ASYNCIO = False
+# os.environ["PYTHONASYNCIODEBUG"] = "1"
 
 if __name__ == "__main__":
     documents = get_documents()
 
     # asyncio
     if not IGNORE_ASYNCIO:
-        os.environ["PYTHONASYNCIODEBUG"] = "1"
         print("Starting [Asyncio]")
         start = time.time()
         generator.generate_with_llamaindex_docs(
-            documents=documents, test_size=100, distributions=distributions
+            documents=documents,
+            test_size=50,
+            distributions=distributions,
+            is_async=True,
         )
         print(f"Time taken: {time.time() - start:.2f}s")
 
     # Threads
     if not IGNORE_THREADS:
         print("Starting [Threads]")
+        start = time.time()
+        generator.generate_with_llamaindex_docs(
+            documents=documents,
+            test_size=50,
+            distributions=distributions,
+            is_async=False,
+        )
+        print(f"Time taken [Threads]: {time.time() - start:.2f}s")


### PR DESCRIPTION
Unifed the calls to LLM, embeddings and json_loader with the following logic
```py
if is_async: # just call the async version
	return await self._asafe_load(text=text, llm=llm, callbacks=callbacks)
else: # call the sync version inside the event_loop
	loop = asyncio.get_event_loop()
	safe_load = partial(
		self._safe_load, text=text, llm=llm, callbacks=callbacks
	)
	return await loop.run_in_executor(
		None,
		safe_load,
	)

```
### LLM
```py
async def generate(
	self,
	prompt: PromptValue,
	n: int = 1,
	temperature: float = 1e-8,
	stop: t.Optional[t.List[str]] = None,
	callbacks: Callbacks = [],
	is_async: bool = True,
) -> LLMResult:
```
### Embeddings
```py
async def embed_texts(
	self, texts: List[str], is_async: bool = True
) -> t.List[t.List[float]]:
```
### Json Load
```py
async def safe_load(
	self,
	text: str,
	llm: BaseRagasLLM,
	callbacks: Callbacks = None,
	is_async: bool = True,
):
```