### PR TITLE
add normalization factor to answer similarity score calculation

### DIFF
--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -71,7 +71,12 @@ class AnswerSimilarity(MetricWithLLM, MetricWithEmbeddings):
         else:
             embeddings_1 = np.array(await self.embeddings.embed_texts(ground_truth))
             embeddings_2 = np.array(await self.embeddings.embed_texts(answers))
-            similarity = embeddings_1 @ embeddings_2.T
+            # Normalization factors of the above embeddings
+            norms_1 = np.linalg.norm(embeddings_1, axis=1, keepdims=True)
+            norms_2 = np.linalg.norm(embeddings_2, axis=1, keepdims=True)
+            embeddings_1_normalized = embeddings_1 / norms_1
+            embeddings_2_normalized = embeddings_2 / norms_2
+            similarity = embeddings_1_normalized @ embeddings_2_normalized.T
             if similarity.size == 1:
                 scores = similarity.flatten()
             else:


### PR DESCRIPTION
Hi Ragas maintainers,

I was calculating answer similarity and noticed that my score was way above 1. I found out it was because the ground truth and generated answer embeddings were not normalized before fed into cosine similarity.

Note that this does not happen to all embeddings, only those that doesn't have L2-norm equal 1 innately.


It'd be nice if I can get some feedback and have this PR merged.

Thanks a bunch!