### PR TITLE
Updated imports, added dotenv

### DIFF
--- a/docs/howtos/integrations/langchain.ipynb
+++ b/docs/howtos/integrations/langchain.ipynb
@@ -14,13 +14,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "id": "cc3fe0c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install ragas langchain_openai python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "fb5deb25",
    "metadata": {},
    "outputs": [],
    "source": [
     "# attach to the existing event loop when using jupyter notebooks\n",
     "import nest_asyncio\n",
+    "import os\n",
+    "import openai\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Load environment variables from .env file\n",
+    "load_dotenv()\n",
+    "# IMPORTANT: Remember to create a .env variable containing: OPENAI_API_KEY=sk-xyz where xyz is your key\n",
+    "\n",
+    "# Access the API key from the environment variable\n",
+    "api_key = os.environ.get('OPENAI_API_KEY')\n",
+    "\n",
+    "# Initialize the OpenAI API client\n",
+    "openai.api_key = api_key\n",
     "\n",
     "nest_asyncio.apply()"
    ]
@@ -35,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "4aa9a986",
    "metadata": {},
    "outputs": [],
@@ -43,7 +66,7 @@
     "from langchain.document_loaders import TextLoader\n",
     "from langchain.indexes import VectorstoreIndexCreator\n",
     "from langchain.chains import RetrievalQA\n",
-    "from langchain.chat_models import ChatOpenAI\n",
+    "from langchain_openai import ChatOpenAI\n",
     "\n",
     "loader = TextLoader(\"./nyc_wikipedia/nyc_text.txt\")\n",
     "index = VectorstoreIndexCreator().from_loaders([loader])\n",
@@ -59,21 +82,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "b0ebdf8d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'New York City was originally named New Amsterdam by Dutch colonists in 1626. However, in 1664, the city came under British control and was renamed New York after King Charles II of England granted the lands to his brother, the Duke of York. The city has been continuously named New York since November 1674.'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# testing it out\n",
     "\n",
@@ -92,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "e67ce0e0",
    "metadata": {},
    "outputs": [],
@@ -139,21 +151,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "8f89d719",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'The borough of Brooklyn (Kings County) has the highest population in New York City.'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "result = qa_chain({\"query\": eval_questions[1]})\n",
     "result[\"result\"]"
@@ -161,21 +162,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "81fa9c47",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'The Statue of Liberty in New York City holds great significance as a symbol of the United States and its ideals of liberty and peace. It greeted millions of immigrants as they arrived in the U.S. in the late 19th and early 20th centuries, representing hope and opportunity. It has become an iconic landmark and a representation of freedom and cultural diversity.'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "result = qa_chain(examples[4])\n",
     "result[\"result\"]"
@@ -183,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "1d9266d4",
    "metadata": {},
    "outputs": [],
@@ -215,27 +205,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "1b574584",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'query': 'What is the significance of the Statue of Liberty in New York City?',\n",
-       " 'ground_truths': ['The Statue of Liberty in New York City holds great significance as a symbol of the United States and its ideals of liberty and peace. It greeted millions of immigrants who arrived in the U.S. by ship in the late 19th and early 20th centuries, representing hope and freedom for those seeking a better life. It has since become an iconic landmark and a global symbol of cultural diversity and freedom.'],\n",
-       " 'result': 'The Statue of Liberty in New York City holds great significance as a symbol of the United States and its ideals of liberty and peace. It greeted millions of immigrants as they arrived in the U.S. in the late 19th and early 20th centuries, representing hope and opportunity. It has become an iconic landmark and a representation of freedom and cultural diversity.',\n",
-       " 'source_documents': [Document(page_content='from 1785 until 1790, and has been the largest U.S. city since 1790. The Statue of Liberty greeted millions of immigrants as they came to the U.S. by ship in the late 19th and early 20th centuries, and is a symbol of the U.S. and its ideals of liberty and peace. In the 21st century, New York City has emerged as a global node of creativity, entrepreneurship, and as a symbol of freedom and cultural diversity. The New York Times has won the most Pulitzer Prizes for journalism and remains the U.S. media\\'s \"newspaper of record\". In 2019, New York City was voted the greatest city in the world in a survey of over 30,000 people from 48 cities worldwide, citing its cultural diversity.Many districts and monuments in New York City are major landmarks, including three of the world\\'s ten most visited tourist attractions in 2013. A record 66.6 million tourists visited New York City in 2019. Times Square is the brightly illuminated hub of the Broadway Theater District, one of the world\\'s busiest', metadata={'source': './nyc_wikipedia/nyc_text.txt'}),\n",
-       "  Document(page_content=\"The Statue of Liberty National Monument and Ellis Island Immigration Museum are managed by the National Park Service and are in both New York and New Jersey. They are joined in the harbor by Governors Island National Monument. Historic sites under federal management on Manhattan Island include Stonewall National Monument; Castle Clinton National Monument; Federal Hall National Memorial; Theodore Roosevelt Birthplace National Historic Site; General Grant National Memorial (Grant's Tomb); African Burial Ground National Monument; and Hamilton Grange National Memorial. Hundreds of properties are listed on the National Register of Historic Places or as a National Historic Landmark.\", metadata={'source': './nyc_wikipedia/nyc_text.txt'}),\n",
-       "  Document(page_content=\"The majority of the most high-profile tourist destinations to the city are situated in Manhattan. These include Times Square; Broadway theater productions; the Empire State Building; the Statue of Liberty; Ellis Island; the United Nations headquarters; the World Trade Center (including the National September 11 Memorial & Museum and One World Trade Center); the art museums along Museum Mile; green spaces such as Central Park, Washington Square Park, the High Line, and the medieval gardens of The Cloisters; the Stonewall Inn; Rockefeller Center; ethnic enclaves including the Manhattan Chinatown, Koreatown, Curry Hill, Harlem, Spanish Harlem, Little Italy, and Little Australia; luxury shopping along Fifth and Madison Avenues; and events such as the Halloween Parade in Greenwich Village; the Brooklyn Bridge (shared with Brooklyn); the Macy's Thanksgiving Day Parade; the lighting of the Rockefeller Center Christmas Tree; the St. Patrick's Day Parade; seasonal activities such as ice\", metadata={'source': './nyc_wikipedia/nyc_text.txt'}),\n",
-       "  Document(page_content=\"Tourism is a vital industry for New York City, and NYC & Company represents the city's official bureau of tourism. New York has witnessed a growing combined volume of international and domestic tourists, reflecting over 60 million visitors to the city per year, the world's busiest tourist destination. Approximately 12 million visitors to New York City have been from outside the United States, with the highest numbers from the United Kingdom, Canada, Brazil, and China. Multiple sources have called New York the most photographed city in the world.I Love New York (stylized I ❤ NY) is both a logo and a song that are the basis of an advertising campaign and have been used since 1977 to promote tourism in New York City, and later to promote New York State as well. The trademarked logo, owned by New York State Empire State Development, appears in souvenir shops and brochures throughout the city and state, some licensed, many not. The song is the state song of New York.\", metadata={'source': './nyc_wikipedia/nyc_text.txt'})]}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Recheck the result that we are going to validate.\n",
     "result"
@@ -251,21 +224,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "5ede32cd",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.8"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "eval_result = faithfulness_chain(result)\n",
     "eval_result[\"faithfulness_score\"]"
@@ -283,21 +245,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "d46535f6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fake_result = result.copy()\n",
     "fake_result[\"result\"] = \"we are the champions\"\n",
@@ -315,21 +266,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "94b5544e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.0"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "eval_result = context_recall_chain(result)\n",
     "eval_result[\"context_recall_score\"]"
@@ -347,21 +287,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "8fc25156",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain.schema import Document\n",
     "\n",
@@ -383,39 +312,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "1ce7bff1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "evaluating...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|█████████████████████████████████████████████████████████████| 1/1 [00:49<00:00, 49.13s/it]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[{'faithfulness_score': 1.0},\n",
-       " {'faithfulness_score': 0.5},\n",
-       " {'faithfulness_score': 1.0},\n",
-       " {'faithfulness_score': 1.0},\n",
-       " {'faithfulness_score': 0.8}]"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# run the queries as a batch for efficiency\n",
     "predictions = qa_chain.batch(examples)\n",
@@ -428,39 +328,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "55299f14",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "evaluating...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|█████████████████████████████████████████████████████████████| 1/1 [00:36<00:00, 36.18s/it]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[{'context_recall_score': 1.0},\n",
-       " {'context_recall_score': 0.1},\n",
-       " {'context_recall_score': 1.0},\n",
-       " {'context_recall_score': 1.0},\n",
-       " {'context_recall_score': 1.0}]"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# evaluate context recall\n",
     "print(\"evaluating...\")\n",
@@ -485,18 +356,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "e75144c5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created a new dataset:  NYC test\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# dataset creation\n",
     "\n",
@@ -539,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "3a6decc6",
    "metadata": {},
    "outputs": [],
@@ -564,19 +427,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "25f7992f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "View the evaluation results for project '2023-09-26-16-02-59-RetrievalQA' at:\n",
-      "https://smith.langchain.com/projects/p/624cd93e-7310-46c5-9156-6dcb46e92c5b?eval=true\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain.smith import RunEvalConfig, run_on_dataset\n",
     "\n",
@@ -640,7 +494,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some imports were outdated since langchain's first stable version (namely v0.1.0) came out.
I also added dotenv to simplify managing the OpenAI API Key.