### PR TITLE
Parse JSON string in adapt()

### DIFF
--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -186,6 +186,8 @@ class Prompt(BaseModel):
             )
             if self.output_type.lower() == "json":
                 output = example.get(self.output_key)
+                if isinstance(output, str):
+                    output = json.loads(output)
                 if isinstance(output, dict):
                     output_keys.append(get_all_keys(output))
                 elif isinstance(output, list):


### PR DESCRIPTION
Thank you for this great framework for evaluating RAG systems.

When using RAGAS, I encountered the following error while trying to adapt metrics to a specific language because the content of the output key in the elements of the `examples` attribute in the `Prompt` class was in un-parsed JSON (=str). It would be great if this PR could fix this error. I would appreciate it if you could check. Here is the error:
```
/usr/lib/python3.10/site-packages/ragas/llms/prompt.py", line 154, in get_all_keys                                 
    for key, value in nested_json.items():                                                    
AttributeError: 'str' object has no attribute 'items'  
```