### PR TITLE
Fix code example in docs/concepts/prompt_adaptation.md

### DIFF
--- a/docs/concepts/prompt_adaptation.md
+++ b/docs/concepts/prompt_adaptation.md
@@ -50,7 +50,7 @@ examples=[{
 }],
     input_keys=["sentence"],
     output_key="nouns",
-    output_type="json"
+    output_type="array"
 )
 
 openai_model = ChatOpenAI(model_name="gpt-4")


### PR DESCRIPTION
Documentation for **Prompt Adaptation** have invalid **output_type** of "json", correct one is "array".

Current example fails with following error:

```
  File "/home/jumski/Code/jumski/ai-sandbox/ragas-tests/.venv/lib/python3.11/site-packages/ragas/llms/prompt.py", line 157, in get_all_keys
    for key, value in nested_json.items():
                      ^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'items'
``` 

See relevant thread on discord: https://discord.com/channels/1119637219561451644/1207988145681858641