### PR TITLE
Fix typo: Teset -> Testset

### DIFF
--- a/src/ragas/_analytics.py
+++ b/src/ragas/_analytics.py
@@ -90,7 +90,7 @@ class EvaluationEvent(BaseEvent):
     language: str
 
 
-class TesetGenerationEvent(BaseEvent):
+class TestsetGenerationEvent(BaseEvent):
     evolution_names: t.List[str]
     evolution_percentages: t.List[float]
     num_rows: int

--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -10,7 +10,7 @@ from datasets import Dataset
 from langchain_openai.chat_models import ChatOpenAI
 from langchain_openai.embeddings import OpenAIEmbeddings
 
-from ragas._analytics import TesetGenerationEvent, track
+from ragas._analytics import TestsetGenerationEvent, track
 from ragas.embeddings.base import BaseRagasEmbeddings, LangchainEmbeddingsWrapper
 from ragas.exceptions import ExceptionInRunner
 from ragas.executor import Executor
@@ -254,7 +254,7 @@ class TestsetGenerator:
         evol_lang = [get_feature_language(e) for e in distributions]
         evol_lang = [e for e in evol_lang if e is not None]
         track(
-            TesetGenerationEvent(
+            TestsetGenerationEvent(
                 event_type="testset_generation",
                 evolution_names=[e.__class__.__name__.lower() for e in distributions],
                 evolution_percentages=[distributions[e] for e in distributions],

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -96,12 +96,12 @@ def test_load_userid_from_json_file(tmp_path, monkeypatch):
 
 def test_testset_generation_tracking(monkeypatch):
     import ragas._analytics as analyticsmodule
-    from ragas._analytics import TesetGenerationEvent, track
+    from ragas._analytics import TestsetGenerationEvent, track
     from ragas.testset.evolutions import multi_context, reasoning, simple
 
     distributions = {simple: 0.5, multi_context: 0.3, reasoning: 0.2}
 
-    testset_event_payload = TesetGenerationEvent(
+    testset_event_payload = TestsetGenerationEvent(
         event_type="testset_generation",
         evolution_names=[e.__class__.__name__.lower() for e in distributions],
         evolution_percentages=[distributions[e] for e in distributions],


### PR DESCRIPTION
## **Description**
Fix typo


___

## **Copilot Description**
- Corrected a typo in the class name `TesetGenerationEvent` to `TestsetGenerationEvent` across multiple files.
- Updated all references to the corrected class name in the generator module and unit tests.
