### PR TITLE
feat: Add new "entity-based context recall" metric

### DIFF
--- a/src/ragas/metrics/__init__.py
+++ b/src/ragas/metrics/__init__.py
@@ -12,6 +12,8 @@ from ragas.metrics._context_relevancy import ContextRelevancy, context_relevancy
 from ragas.metrics._faithfulness import Faithfulness, faithfulness
 from ragas.metrics.critique import AspectCritique
 
+from ragas.metrics._context_entities_recall import ContextEntityRecall, context_entity_recall
+
 __all__ = [
     "AnswerCorrectness",
     "answer_correctness",
@@ -30,4 +32,6 @@ __all__ = [
     "ContextRelevancy",
     "AnswerRelevancy",
     "answer_relevancy",
+    "ContextEntityRecall",
+    "context_entity_recall"
 ]

--- a/src/ragas/metrics/__init__.py
+++ b/src/ragas/metrics/__init__.py
@@ -1,6 +1,10 @@
 from ragas.metrics._answer_correctness import AnswerCorrectness, answer_correctness
 from ragas.metrics._answer_relevance import AnswerRelevancy, answer_relevancy
 from ragas.metrics._answer_similarity import AnswerSimilarity, answer_similarity
+from ragas.metrics._context_entities_recall import (
+    ContextEntityRecall,
+    context_entity_recall,
+)
 from ragas.metrics._context_precision import (
     ContextPrecision,
     ContextUtilization,
@@ -11,8 +15,6 @@ from ragas.metrics._context_recall import ContextRecall, context_recall
 from ragas.metrics._context_relevancy import ContextRelevancy, context_relevancy
 from ragas.metrics._faithfulness import Faithfulness, faithfulness
 from ragas.metrics.critique import AspectCritique
-
-from ragas.metrics._context_entities_recall import ContextEntityRecall, context_entity_recall
 
 __all__ = [
     "AnswerCorrectness",
@@ -33,5 +35,5 @@ __all__ = [
     "AnswerRelevancy",
     "answer_relevancy",
     "ContextEntityRecall",
-    "context_entity_recall"
+    "context_entity_recall",
 ]

--- a/src/ragas/metrics/_context_entities_recall.py
+++ b/src/ragas/metrics/_context_entities_recall.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import json
 import logging
 import typing as t
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict
 
-
+from ragas.llms.json_load import json_loader
 from ragas.llms.prompt import Prompt
 from ragas.metrics.base import EvaluationMode, MetricWithLLM
 
@@ -15,103 +14,71 @@ if t.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-CONTEXT_ENTITY_RECALL = Prompt(
-    name="context_entity_recall",
-    instruction="""Based on the provided contexts and the ground truth, extract entities
-    present in the ground truth and the context. Make sure you do not repeat entities if they
-    are present more than once, in some different form, in ground_truth or context. 
-    Output should be in plain JSON format without any additional text. 
-    Follow the structure provided in the examples.""",
-    input_keys=["ground_truth", "context"],
+TEXT_ENTITY_EXTRACTION = Prompt(
+    name="text_entity_extraction",
+    instruction="""Given a text, extract unique entities without repetition. Ensure you consider different forms or mentions of the same entity as a single entity.""",
+    input_keys=["text"],
     output_key="output",
     output_type="json",
     examples=[
         {
-            "ground_truth": """The Eiffel Tower is located in Paris, France. 
-            It is one of the most famous landmarks in the world. 
-            The tower was completed in 1889.""",
-            "context": """The Eiffel Tower attracts millions of visitors each year. 
-            It offers breathtaking views of Paris from its top. 
-            The construction of the tower was completed in time for the 1889 World's Fair.""",
-            "output":{
-                    "entities_in_ground_truth": ['Eiffel Tower', 'Paris', 'France', '1889'],
-                    "entities_in_context": ['Eiffel Tower', 'Paris', '1889']
-                    }
+            "text": """The Eiffel Tower, located in Paris, France, is one of the most iconic landmarks globally. 
+            Millions of visitors are attracted to it each year for its breathtaking views of the city. 
+            Completed in 1889, it was constructed in time for the 1889 World's Fair.""",
+            "output": {
+                "entities": ["Eiffel Tower", "Paris", "France", "1889", "World's Fair"],
+            },
         },
         {
-            "ground_truth": """The Colosseum, also known as the Flavian Amphitheatre, is an oval amphitheatre in the centre of Rome, Italy. 
-                        It is the largest ancient amphitheatre ever built and is considered one of the greatest works of Roman architecture and engineering. 
-                        The Colosseum could hold an estimated 50,000 to 80,000 spectators and was used for gladiatorial contests and public spectacles.""",
-            "context": """The Colosseum is an iconic symbol of ancient Rome's power and grandeur. 
-                        It is a popular tourist attraction and a testament to the architectural and engineering prowess of the Romans. 
-                        The construction of the Colosseum began in AD 70 under the emperor Vespasian and was completed in AD 80 under his successor and heir Titus.""",
-            "output":{
-                    "entities_in_ground_truth": ['Colosseum', 'Rome', 'Italy'],
-                    "entities_in_context": ['Colosseum', 'Rome', 'Titus', 'AD 70', 'Vespasian', 'Titus']
-                    }
+            "text": """The Colosseum in Rome, also known as the Flavian Amphitheatre, stands as a monument to Roman architectural and engineering achievement. 
+            Construction began under Emperor Vespasian in AD 70 and was completed by his son Titus in AD 80. 
+            It could hold between 50,000 and 80,000 spectators who watched gladiatorial contests and public spectacles.""",
+            "output": {
+                "entities": [
+                    "Colosseum",
+                    "Rome",
+                    "Flavian Amphitheatre",
+                    "Vespasian",
+                    "AD 70",
+                    "Titus",
+                    "AD 80",
+                ],
+            },
         },
         {
-            "ground_truth": """The Great Wall of China is a series of fortifications made of stone, brick, tamped earth, wood, and other materials. 
-                        It was built along the northern borders of China to protect the Chinese states and empires against the raids and invasions of the various nomadic groups of the Eurasian Steppe. 
-                        The wall stretches over approximately 21,196 kilometers (13,171 miles) from east to west of China.""",
-            "context": """The Great Wall of China is one of the most impressive architectural feats in history. 
-                        It is a UNESCO World Heritage Site and attracts millions of tourists each year. 
-                        The construction of the wall began as early as the 7th century BC and continued for centuries.""",
-            "output":{
-                    "entities_in_ground_truth": ['Great Wall of China', 'China', 'Eurasian Steppe'],
-                    "entities_in_context": ['Great Wall of China', 'UNESCO World Heritage Site', '7th century BC']
-                    }
+            "text": """The Great Wall of China, stretching over 21,196 kilometers from east to west, is a marvel of ancient defensive architecture. 
+            Built to protect against invasions from the north, its construction started as early as the 7th century BC. 
+            Today, it is a UNESCO World Heritage Site and a major tourist attraction.""",
+            "output": {
+                "entities": [
+                    "Great Wall of China",
+                    "21,196 kilometers",
+                    "7th century BC",
+                    "UNESCO World Heritage Site",
+                ],
+            },
         },
         {
-            "ground_truth": """The Apollo 11 mission was the first crewed mission to land humans on the Moon. 
-                        It was launched by NASA on July 16, 1969, and the astronauts Neil Armstrong, Buzz Aldrin, and Michael Collins were onboard. 
-                        Neil Armstrong became the first person to step onto the lunar surface on July 20, 1969.""",
-            "context": """The Apollo 11 mission was a monumental achievement in human history. 
-                        It marked the culmination of years of scientific and technological advancements. 
-                        The successful landing of the lunar module 'Eagle' on the Moon paved the way for future space exploration.""",
-            "output":{
-                    "entities_in_ground_truth": ['Apollo 11 mission', 'Moon', 'NASA', 'July 16, 1969', 'Neil Armstrong', 'Buzz Aldrin', 'Michael Collins'],
-                    "entities_in_context": ['Apollo 11 mission', 'Moon', 'lunar module']
-                    }
-        }
-    ]
+            "text": """The Apollo 11 mission, which launched on July 16, 1969, marked the first time humans landed on the Moon. 
+            Astronauts Neil Armstrong, Buzz Aldrin, and Michael Collins made history, with Armstrong being the first man to step on the lunar surface. 
+            This event was a significant milestone in space exploration.""",
+            "output": {
+                "entities": [
+                    "Apollo 11 mission",
+                    "July 16, 1969",
+                    "Moon",
+                    "Neil Armstrong",
+                    "Buzz Aldrin",
+                    "Michael Collins",
+                ],
+            },
+        },
+    ],
 )
 
-# This function is needed for post-processing LLM reponse
-# Sometimes the LLM, despite of instructing not to, adds 
-# this - ```json - to the response. So this function extracts only the 
-# valid part from the response
-def _extract_valid_json(text):
-    # Find the first occurrence of a valid JSON object
-    start_index = -1
-    end_index = -1
-    for i in range(len(text)):
-        if text[i] == '{':
-            start_index = i
-            break
-
-    if start_index != -1:
-        # Find the last occurrence of a valid JSON object
-        for i in range(len(text) - 1, -1, -1):
-            if text[i] == '}':
-                end_index = i + 1
-                break
-
-    if start_index != -1 and end_index != -1:
-        json_text = text[start_index:end_index]
-        try:
-            # Attempt to load the extracted JSON
-            json_data = json.loads(json_text)
-            return json_data
-        except json.JSONDecodeError as e:
-            print("JSON decoding error:", e)
-            return None
-    else:
-        print("No valid JSON found in the text.")
-        return None
 
 @dataclass
-class ContextEntityRecall(MetricWithLLM): 
+class ContextEntityRecall(MetricWithLLM):
     """
     Calculates recall based on entities present in ground truth and context.
     Let CN be the set of entities present in context,
@@ -122,8 +89,8 @@ class ContextEntityRecall(MetricWithLLM):
 
     If this quantity is 1, we can say that the retrieval mechanism has
     retrieved context which covers all entities present in the ground truth,
-    thus being a useful retrieval. Thus this can be used to evaluate retrieval 
-    mechanisms in specific use cases where entities matter, for example, a 
+    thus being a useful retrieval. Thus this can be used to evaluate retrieval
+    mechanisms in specific use cases where entities matter, for example, a
     tourism help chatbot.
 
     Attributes
@@ -133,45 +100,61 @@ class ContextEntityRecall(MetricWithLLM):
         Batch size for openai completion.
     """
 
-    name: str = "context_entity_recall" # type: ignore
-    evaluation_mode: EvaluationMode = EvaluationMode.qc  # type: ignore
-    context_entity_recall_prompt: Prompt = field(default_factory=lambda: CONTEXT_ENTITY_RECALL)
+    name: str = "context_entity_recall"  # type: ignore
+    evaluation_mode: EvaluationMode = EvaluationMode.gc  # type: ignore
+    context_entity_recall_prompt: Prompt = field(
+        default_factory=lambda: TEXT_ENTITY_EXTRACTION
+    )
     batch_size: int = 15
 
-    def _compute_score(self, response: str) -> float:
-        response_dict = _extract_valid_json(response)
-        entities_in_ground_truth = set(response_dict['entities_in_ground_truth'])
-        entities_in_context = set(response_dict['entities_in_context'])
-        
-        num_entities_in_both = len(set(entities_in_context).intersection(set(entities_in_ground_truth)))
-        num_entities_in_ground_truth = len(entities_in_ground_truth)
-        return num_entities_in_both/num_entities_in_ground_truth
-    
-    def _score(self, row: Dict, callbacks: Callbacks) -> float:
+    def _compute_score(
+        self, ground_truth_entities: set, context_entities: set
+    ) -> float:
+        num_entities_in_both = len(
+            set(context_entities).intersection(set(ground_truth_entities))
+        )
+        return num_entities_in_both / (len(ground_truth_entities) + 1e-8)
+
+    async def get_entities(
+        self,
+        text: str,
+        callbacks: Callbacks,
+        is_async: bool,
+    ) -> Dict:
         assert self.llm is not None, "LLM is not initialized"
 
-        ground_truth, contexts = row["ground_truths"], row["contexts"]
-        result = self.llm.generate_text(
+        result = await self.llm.generate(
             prompt=self.context_entity_recall_prompt.format(
-                ground_truth="\n".join(ground_truth), context="\n".join(contexts)
+                text=text,
             ),
-            callbacks=callbacks
+            callbacks=callbacks,
+            is_async=is_async,
         )
-        return self._compute_score(result.generations[0][0].text)
-    
-    async def _ascore(self, row: Dict, callbacks: Callbacks) -> float:
-        assert self.llm is not None, "LLM is not initialized"
+        response_dict = await json_loader.safe_load(
+            result.generations[0][0].text, self.llm, is_async=is_async
+        )
+        response_dict = response_dict if isinstance(response_dict, dict) else {}
+        return response_dict
 
-        ground_truth, contexts = row["ground_truths"], row["contexts"]
-        result = self.llm.agenerate_text(
-            prompt=self.context_entity_recall_prompt.format(
-                ground_truth="\n".join(ground_truth), context="\n".join(contexts)
-            ),
-            callbacks=callbacks
+    async def _ascore(
+        self,
+        row: Dict,
+        callbacks: Callbacks,
+        is_async: bool,
+    ) -> float:
+        ground_truth, contexts = row["ground_truth"], row["contexts"]
+        ground_truth = await self.get_entities(
+            ground_truth, callbacks=callbacks, is_async=is_async
         )
-        return self._compute_score(result.generations[0][0].text)
-    
+        contexts = await self.get_entities(
+            "\n".join(contexts), callbacks=callbacks, is_async=is_async
+        )
+        return self._compute_score(
+            ground_truth.get("entities", []), contexts.get("entities", [])
+        )
+
     def save(self, cache_dir: str | None = None) -> None:
         return self.context_entity_recall_prompt.save(cache_dir)
+
 
 context_entity_recall = ContextEntityRecall(batch_size=15)

--- a/src/ragas/metrics/_context_entities_recall.py
+++ b/src/ragas/metrics/_context_entities_recall.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import logging
+import typing as t
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+from ragas.llms.prompt import Prompt
+from ragas.metrics.base import EvaluationMode, MetricWithLLM
+
+if t.TYPE_CHECKING:
+    from langchain.callbacks.base import Callbacks
+
+logger = logging.getLogger(__name__)
+
+CONTEXT_ENTITY_RECALL = Prompt(
+    name="context_entity_recall",
+    instruction="""Based on the provided contexts and the ground truth, extract entities
+    present in the ground truth and the context. Make sure you do not repeat entities if they
+    are present more than once, in some different form, in ground_truth or context. 
+    Output should be in plain JSON format without any additional text. 
+    Follow the structure provided in the examples.""",
+    input_keys=["ground_truth", "context"],
+    output_key="output",
+    output_type="json",
+    examples=[
+        {
+            "ground_truth": """The Eiffel Tower is located in Paris, France. 
+            It is one of the most famous landmarks in the world. 
+            The tower was completed in 1889.""",
+            "context": """The Eiffel Tower attracts millions of visitors each year. 
+            It offers breathtaking views of Paris from its top. 
+            The construction of the tower was completed in time for the 1889 World's Fair.""",
+            "output":{
+                    "entities_in_ground_truth": ['Eiffel Tower', 'Paris', 'France', '1889'],
+                    "entities_in_context": ['Eiffel Tower', 'Paris', '1889']
+                    }
+        },
+        {
+            "ground_truth": """The Colosseum, also known as the Flavian Amphitheatre, is an oval amphitheatre in the centre of Rome, Italy. 
+                        It is the largest ancient amphitheatre ever built and is considered one of the greatest works of Roman architecture and engineering. 
+                        The Colosseum could hold an estimated 50,000 to 80,000 spectators and was used for gladiatorial contests and public spectacles.""",
+            "context": """The Colosseum is an iconic symbol of ancient Rome's power and grandeur. 
+                        It is a popular tourist attraction and a testament to the architectural and engineering prowess of the Romans. 
+                        The construction of the Colosseum began in AD 70 under the emperor Vespasian and was completed in AD 80 under his successor and heir Titus.""",
+            "output":{
+                    "entities_in_ground_truth": ['Colosseum', 'Rome', 'Italy'],
+                    "entities_in_context": ['Colosseum', 'Rome', 'Titus', 'AD 70', 'Vespasian', 'Titus']
+                    }
+        },
+        {
+            "ground_truth": """The Great Wall of China is a series of fortifications made of stone, brick, tamped earth, wood, and other materials. 
+                        It was built along the northern borders of China to protect the Chinese states and empires against the raids and invasions of the various nomadic groups of the Eurasian Steppe. 
+                        The wall stretches over approximately 21,196 kilometers (13,171 miles) from east to west of China.""",
+            "context": """The Great Wall of China is one of the most impressive architectural feats in history. 
+                        It is a UNESCO World Heritage Site and attracts millions of tourists each year. 
+                        The construction of the wall began as early as the 7th century BC and continued for centuries.""",
+            "output":{
+                    "entities_in_ground_truth": ['Great Wall of China', 'China', 'Eurasian Steppe'],
+                    "entities_in_context": ['Great Wall of China', 'UNESCO World Heritage Site', '7th century BC']
+                    }
+        },
+        {
+            "ground_truth": """The Apollo 11 mission was the first crewed mission to land humans on the Moon. 
+                        It was launched by NASA on July 16, 1969, and the astronauts Neil Armstrong, Buzz Aldrin, and Michael Collins were onboard. 
+                        Neil Armstrong became the first person to step onto the lunar surface on July 20, 1969.""",
+            "context": """The Apollo 11 mission was a monumental achievement in human history. 
+                        It marked the culmination of years of scientific and technological advancements. 
+                        The successful landing of the lunar module 'Eagle' on the Moon paved the way for future space exploration.""",
+            "output":{
+                    "entities_in_ground_truth": ['Apollo 11 mission', 'Moon', 'NASA', 'July 16, 1969', 'Neil Armstrong', 'Buzz Aldrin', 'Michael Collins'],
+                    "entities_in_context": ['Apollo 11 mission', 'Moon', 'lunar module']
+                    }
+        }
+    ]
+)
+
+# This function is needed for post-processing LLM reponse
+# Sometimes the LLM, despite of instructing not to, adds 
+# this - ```json - to the response. So this function extracts only the 
+# valid part from the response
+def _extract_valid_json(text):
+    # Find the first occurrence of a valid JSON object
+    start_index = -1
+    end_index = -1
+    for i in range(len(text)):
+        if text[i] == '{':
+            start_index = i
+            break
+
+    if start_index != -1:
+        # Find the last occurrence of a valid JSON object
+        for i in range(len(text) - 1, -1, -1):
+            if text[i] == '}':
+                end_index = i + 1
+                break
+
+    if start_index != -1 and end_index != -1:
+        json_text = text[start_index:end_index]
+        try:
+            # Attempt to load the extracted JSON
+            json_data = json.loads(json_text)
+            return json_data
+        except json.JSONDecodeError as e:
+            print("JSON decoding error:", e)
+            return None
+    else:
+        print("No valid JSON found in the text.")
+        return None
+
+@dataclass
+class ContextEntityRecall(MetricWithLLM): 
+    """
+    Calculates recall based on entities present in ground truth and context.
+    Let CN be the set of entities present in context,
+    GN be the set of entities present in the ground truth.
+
+    Then we define can the context entity recall as follows:
+    Context Entity recall = | CN ∩ GN | / | GN |
+
+    If this quantity is 1, we can say that the retrieval mechanism has
+    retrieved context which covers all entities present in the ground truth,
+    thus being a useful retrieval. Thus this can be used to evaluate retrieval 
+    mechanisms in specific use cases where entities matter, for example, a 
+    tourism help chatbot.
+
+    Attributes
+    ----------
+    name : str
+    batch_size : int
+        Batch size for openai completion.
+    """
+
+    name: str = "context_entity_recall" # type: ignore
+    evaluation_mode: EvaluationMode = EvaluationMode.qc  # type: ignore
+    context_entity_recall_prompt: Prompt = field(default_factory=lambda: CONTEXT_ENTITY_RECALL)
+    batch_size: int = 15
+
+    def _compute_score(self, response: str) -> float:
+        response_dict = _extract_valid_json(response)
+        entities_in_ground_truth = set(response_dict['entities_in_ground_truth'])
+        entities_in_context = set(response_dict['entities_in_context'])
+        
+        num_entities_in_both = len(set(entities_in_context).intersection(set(entities_in_ground_truth)))
+        num_entities_in_ground_truth = len(entities_in_ground_truth)
+        return num_entities_in_both/num_entities_in_ground_truth
+    
+    def _score(self, row: Dict, callbacks: Callbacks) -> float:
+        assert self.llm is not None, "LLM is not initialized"
+
+        ground_truth, contexts = row["ground_truths"], row["contexts"]
+        result = self.llm.generate_text(
+            prompt=self.context_entity_recall_prompt.format(
+                ground_truth="\n".join(ground_truth), context="\n".join(contexts)
+            ),
+            callbacks=callbacks
+        )
+        return self._compute_score(result.generations[0][0].text)
+    
+    async def _ascore(self, row: Dict, callbacks: Callbacks) -> float:
+        assert self.llm is not None, "LLM is not initialized"
+
+        ground_truth, contexts = row["ground_truths"], row["contexts"]
+        result = self.llm.agenerate_text(
+            prompt=self.context_entity_recall_prompt.format(
+                ground_truth="\n".join(ground_truth), context="\n".join(contexts)
+            ),
+            callbacks=callbacks
+        )
+        return self._compute_score(result.generations[0][0].text)
+    
+    def save(self, cache_dir: str | None = None) -> None:
+        return self.context_entity_recall_prompt.save(cache_dir)
+
+context_entity_recall = ContextEntityRecall(batch_size=15)


### PR DESCRIPTION
This PR adds a new metric, "context_entity_recall", based on "entities" present in ground-truth and context, to evaluate retrieval mechanisms. I had discussed this metric in #482.

**Description**: 
In use cases where entities like names, places, dates etc matter, it is important that our retrieval mechanism fetches the right context, which has to be fed to the model. An example is tourism industry, names of cities, tourist places, special-dishes, etc matter quite a lot. Other examples could be health or finance domains. 

**Formulation of  `context_entity_recall`**:
I propose this new metric to be the ratio of number of entities present in `ground_truths` and `contexts` both to the number of entities present in `ground_truths` alone. This is like a measure of coverage of `ground_truth entities` by the `context`. I have used a simple formula -  $|CE \cap GE| / |GE|$ - where $CE$ and $GE$ are set of entities in `contexts` and `ground_truths` respectively.

**Example usage in RAGAS**:
```python
from datasets import load_dataset
from ragas import evaluate
from ragas.metrics import context_entity_recall

amnesty_qa = load_dataset("explodinggradients/amnesty_qa")

amnesty_result = evaluate(
    amnesty_qa["eval"].select(range(2)), 
    metrics=[
        context_entity_recall
    ],
    llm = LangchainLLMWrapper(llm) # I used llm separately because I am using OpenRouter
)
amnesty_result.to_pandas()
```
Below is the output:
![image](https://github.com/explodinggradients/ragas/assets/84656834/1a4f8f4e-496d-4a8f-9856-889ea08f92aa)

**LLM setting used to generate above example**:
```python
import os
from langchain.chat_models import ChatOpenAI

llm = ChatOpenAI(
    model = "google/gemma-7b-it:free",
    openai_api_key=os.getenv("OPENROUTER_API_KEY"),
    openai_api_base="https://openrouter.ai/api/v1"
)
```

**Discussions and further thoughts**:
As far as I am aware, no other such metric has been used, so this needs to be tested for usefulness and impact. Also, there can be versions of this. Initially I have considered evluating retrieval, so I used `ground_truths` and `contexts`. 
If we need to evaluate our LLM on how it handles entities in context, we can use this similar metric on `answer` and `contexts`.
Or in general, on any pair of the inputs.

I am open to and would encourage discussions, in the community and with mentors, regarding usefulness and additions to this metric. Looking forward for feebback/review.
@shahules786 @jjmachan 