### PR TITLE
Fix typos that cause fatal assertion errors in prompts

### DIFF
--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -229,7 +229,7 @@ class Prompt(BaseModel):
                 if isinstance(output, dict):
                     assert (
                         set(output.keys()) == output_keys[i]
-                    ), "Adapted output keys do not match with the original output keys"
+                    ), f"Adapted output keys {set(output.keys())=} do not match with the original output keys: {output_keys[i]=}"
                 elif isinstance(output, list) and all(
                     isinstance(item, dict) for item in output
                 ):

--- a/src/ragas/testset/evolutions.py
+++ b/src/ragas/testset/evolutions.py
@@ -18,7 +18,7 @@ from ragas.testset.filters import EvolutionFilter, NodeFilter, QuestionFilter
 from ragas.testset.prompts import (
     compress_question_prompt,
     conditional_question_prompt,
-    find_relevent_context_prompt,
+    find_relevant_context_prompt,
     multi_context_question_prompt,
     question_answer_prompt,
     question_rewrite_prompt,
@@ -56,8 +56,8 @@ class Evolution:
     question_answer_prompt: Prompt = field(
         default_factory=lambda: question_answer_prompt
     )
-    find_relevent_context_prompt: Prompt = field(
-        default_factory=lambda: find_relevent_context_prompt
+    find_relevant_context_prompt: Prompt = field(
+        default_factory=lambda: find_relevant_context_prompt
     )
     rewrite_invalid_question_prompt: Prompt = field(
         default_factory=lambda: question_rewrite_prompt
@@ -189,16 +189,16 @@ class Evolution:
             f"{i+1}\t{n.page_content}" for i, n in enumerate(current_nodes.nodes)
         ]
         results = await self.generator_llm.generate(
-            prompt=self.find_relevent_context_prompt.format(
+            prompt=self.find_relevant_context_prompt.format(
                 question=question, contexts=node_content
             )
         )
-        relevent_contexts_result = await json_loader.safe_load(
+        relevant_contexts_result = await json_loader.safe_load(
             results.generations[0][0].text.strip(), llm=self.generator_llm
         )
         relevant_context_indices = (
-            relevent_contexts_result.get("relevant_contexts", None)
-            if isinstance(relevent_contexts_result, dict)
+            relevant_contexts_result.get("relevant_contexts", None)
+            if isinstance(relevant_contexts_result, dict)
             else None
         )
         if relevant_context_indices is None:
@@ -249,7 +249,7 @@ class Evolution:
         self.question_answer_prompt = self.question_answer_prompt.adapt(
             language, self.generator_llm, cache_dir
         )
-        self.find_relevent_context_prompt = self.find_relevent_context_prompt.adapt(
+        self.find_relevant_context_prompt = self.find_relevant_context_prompt.adapt(
             language, self.generator_llm, cache_dir
         )
         self.rewrite_invalid_question_prompt = (
@@ -267,7 +267,7 @@ class Evolution:
         assert self.node_filter is not None, "node filter cannot be None"
         assert self.question_filter is not None, "question_filter cannot be None"
         self.question_answer_prompt.save(cache_dir)
-        self.find_relevent_context_prompt.save(cache_dir)
+        self.find_relevant_context_prompt.save(cache_dir)
         self.node_filter.save(cache_dir)
         self.question_filter.save(cache_dir)
 

--- a/src/ragas/testset/prompts.py
+++ b/src/ragas/testset/prompts.py
@@ -353,8 +353,8 @@ seed_question_prompt = Prompt(
     output_type="string",
 )
 
-find_relevent_context_prompt = Prompt(
-    name="find_relevent_context",
+find_relevant_context_prompt = Prompt(
+    name="find_relevant_context",
     instruction="Given a question and set of contexts, find the most relevant contexts to answer the question.",
     examples=[
         {
@@ -365,7 +365,7 @@ find_relevent_context_prompt = Prompt(
                 "3. Paris is the capital of France. It is also the most populous city in France, with a population of over 2 million people. Paris is known for its cultural landmarks like the Eiffel Tower and the Louvre Museum.",
             ],
             "output": {
-                "relevent_contexts": [1, 2],
+                "relevant_contexts": [1, 2],
             },
         },
         {

--- a/src/ragas/testset/prompts.py
+++ b/src/ragas/testset/prompts.py
@@ -178,7 +178,7 @@ filter_question_prompt = Prompt(
             "question": "What is the discovery about space?",
             "output": {
                 "reason": "The question is too vague and does not specify which discovery about space it is referring to.",
-                "verdit": "0",
+                "verdict": "0",
             },
         },
         {


### PR DESCRIPTION
This seems to be the cause of #653 when LLM attempts correct the typo and end up with keys not strictly identical to "expected" keys.