### PR TITLE
Support google gemini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "langchain-core",
     "langchain-community",
     "langchain_openai",
+    "langchain-google-genai",
     "openai>1",
     "pysbd>=0.3.4",
     "nest-asyncio",

--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -136,19 +136,17 @@ class LangchainLLMWrapper(BaseRagasLLM):
         stop: t.Optional[t.List[str]] = None,
         callbacks: t.Optional[Callbacks] = None,
     ) -> LLMResult:
-        temperature = self.get_temperature(n=n)
+        self.langchain_llm.temperature = self.get_temperature(n=n)
         if is_multiple_completion_supported(self.langchain_llm):
             return self.langchain_llm.generate_prompt(
                 prompts=[prompt],
                 n=n,
-                temperature=temperature,
                 stop=stop,
                 callbacks=callbacks,
             )
         else:
             result = self.langchain_llm.generate_prompt(
                 prompts=[prompt] * n,
-                temperature=temperature,
                 stop=stop,
                 callbacks=callbacks,
             )
@@ -166,19 +164,17 @@ class LangchainLLMWrapper(BaseRagasLLM):
         stop: t.Optional[t.List[str]] = None,
         callbacks: t.Optional[Callbacks] = None,
     ) -> LLMResult:
-        temperature = self.get_temperature(n=n)
+        self.langchain_llm.temperature = self.get_temperature(n=n)
         if is_multiple_completion_supported(self.langchain_llm):
             return await self.langchain_llm.agenerate_prompt(
                 prompts=[prompt],
                 n=n,
-                temperature=temperature,
                 stop=stop,
                 callbacks=callbacks,
             )
         else:
             result = await self.langchain_llm.agenerate_prompt(
                 prompts=[prompt] * n,
-                temperature=temperature,
                 stop=stop,
                 callbacks=callbacks,
             )

--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -119,19 +119,19 @@ class TestsetGenerator:
             HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE,
         }
         generator_llm_model = LangchainLLMWrapper(
-            ChatGoogleGenerativeAI(
+            ChatGoogleGenerativeAI(  # type: ignore
                 model=generator_llm,
                 safety_settings=safety_blocknone,
             )
         )
         critic_llm_model = LangchainLLMWrapper(
-            ChatGoogleGenerativeAI(
+            ChatGoogleGenerativeAI(  # type: ignore
                 model=critic_llm,
                 safety_settings=safety_blocknone,
             )
         )
         embeddings_model = LangchainEmbeddingsWrapper(
-            GoogleGenerativeAIEmbeddings(model=embeddings)
+            GoogleGenerativeAIEmbeddings(model=embeddings)  # type: ignore
         )
         return cls._common_constructor(
             chunk_size=chunk_size,

--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -97,6 +97,7 @@ class TestsetGenerator:
             generator_llm_model=generator_llm_model,
             embeddings_model=embeddings_model,
             critic_llm_model=critic_llm_model,
+            docstore=docstore,
             run_config=run_config,
         )
 
@@ -146,7 +147,7 @@ class TestsetGenerator:
         cls,
         chunk_size: int,
         generator_llm_model: LangchainLLMWrapper,
-        embeddings_model: LangchainLLMWrapper,
+        embeddings_model: BaseRagasEmbeddings,
         critic_llm_model: LangchainLLMWrapper,
         docstore: t.Optional[DocumentStore],
         run_config: t.Optional[RunConfig],


### PR DESCRIPTION
This change allows one to use `langchain-google-genai` and simply

```Python
generator = TestsetGenerator.with_google(...)
```

just like one would with `with_openai()` and get on with life.
Initial tests show no errors in embedding and testset generation. Prompt adaptations work on condition of #676 being merged first.

---

CI/CD check fail: `langchain-google-genai` requires `Python >=3.9, <4.0`