### PR TITLE
docs: Fix the precision calculation in context-precision metric doc

### DIFF
--- a/docs/concepts/metrics/context_precision.md
+++ b/docs/concepts/metrics/context_precision.md
@@ -30,7 +30,7 @@ Let's examine how context precision was calculated using the low context precisi
 **Step 2**: Calculate precision@k for each chunk in the context.
 
 ```{math}
-\text{Precision@1} = {\text{0} \over \text{1}} = 1
+\text{Precision@1} = {\text{0} \over \text{1}} = 0
 ````
 
 ```{math}
@@ -40,7 +40,7 @@ Let's examine how context precision was calculated using the low context precisi
 **Step 3**: Calculate the mean of precision@k to arrive at the final context precision score.
 
 ```{math}
- \text{Context Precision} = {\text{(1+0.5)} \over \text{2}} = 0.75
+ \text{Context Precision} = {\text{(0+0.5)} \over \text{2}} = 0.25
 ```
 
 :::


### PR DESCRIPTION
Precision@1 = 0/1 != 1. It should be 0.
This PR fixes the calculation of Precision@1 and subsequently `\text{Context Precision} = {\text{(0+0.5)} \over \text{2}} = 0.25`

![image](https://github.com/explodinggradients/ragas/assets/30175128/c92cc0ec-516b-4d62-b85a-2802dfafaa6a)
