### PR TITLE
Fix: Enable Critique Prompt Customization in AspectCritique

### DIFF
--- a/src/ragas/metrics/critique.py
+++ b/src/ragas/metrics/critique.py
@@ -89,7 +89,7 @@ class AspectCritique(MetricWithLLM):
             if isinstance(context, list):
                 context = "\n".join(context)
             question = f"{question } answer using context: {context}"
-        return CRITIQUE_PROMPT.format(
+        return self.critic_prompt.format(
             input=question, submission=answer, criteria=self.definition
         )
 


### PR DESCRIPTION
This PR addresses an issue in the AspectCritique class where the prompt_format() method was incorrectly using a hardcoded default prompt (CRITIQUE_PROMPT.format()) for generating critique prompts. This behavior overlooked the critic_prompt field, which is intended to allow customization of the critique prompts.

Previously, attempts to customize the critique prompt for specific metrics (e.g., setting a new prompt for the harmfulness metric via harmfulness.critic_prompt = Prompt(...)) would not have the intended effect. The prompt_format() method would still return the default hardcoded prompt, thus ignoring the custom critic_prompt value.

So, I modified the prompt_format() method within the AspectCritique class to use self.critic_prompt.format() instead of CRITIQUE_PROMPT.format().