### PR TITLE
Docs: Fix and supplement answer relevancy description

### DIFF
--- a/docs/concepts/metrics/answer_relevance.md
+++ b/docs/concepts/metrics/answer_relevance.md
@@ -1,6 +1,23 @@
 # Answer Relevance
 
-The evaluation metric, Answer Relevancy, focuses on assessing how pertinent the generated answer is to the given prompt. A lower score is assigned to answers that are incomplete or contain redundant information. This metric is computed using the `question` and the `answer`, with values ranging between 0 and 1, where higher scores indicate better relevancy.
+The evaluation metric, Answer Relevancy, focuses on assessing how pertinent the generated answer is to the given prompt. A lower score is assigned to answers that are incomplete or contain redundant information and higher scores indicate better relevancy. This metric is computed using the `question`, the `context` and the `answer`. 
+
+The Answer Relevancy is defined as the mean cosine similartiy of the orginal `question` to a number of artifical questions, which where generated (reverse engineered) based on the `answer`: 
+
+```{math}
+\text{answer relevancy} = \frac{1}{N} \sum_{i=1}^{N} cos(E_{g_i}, E_o)
+````
+```{math}
+\text{answer relevancy} = \frac{1}{N} \sum_{i=1}^{N} \frac{E_{g_i} \cdot E_o}{\|E_{g_i}\|\|E_o\|}
+````
+
+Where: 
+
+* $E_{g_i}$ is the embedding of the generated question $i$.
+* $E_o$ is the embedding of the original question.
+* $N$ is the number of generated questions, which is 3 default.
+
+Please note, that eventhough in practice the score will range between 0 and 1 most of the time, this is not mathematically guranteed, due to the nature of the cosine similarity ranging from -1 to 1.
 
 :::{note}
 This is reference free metric. If you're looking to compare ground truth answer with generated answer refer to [answer_correctness](./answer_correctness.md)
@@ -50,4 +67,3 @@ To calculate the relevance of the answer to the given question, we follow two st
 - **Step 2:** Calculate the mean cosine similarity between the generated questions and the actual question.
 
 The underlying concept is that if the answer correctly addresses the question, it is highly probable that the original question can be reconstructed solely from the answer.
-


### PR DESCRIPTION
The docs for the answer relevancy metric are wrong in that it is claimed that the score ranges between 0 and 1. As it is written in the calculation section an averaged cosine similarity is used to calculate the metric. The cosine similarity can range between -1 and 1. Of course, most of the time the original question and generated questions will be kind of similar in practice, leading to scores between 0 and 1, but this is not mathematically guaranteed and depends on the used embedder and how it stretches the embedding space.

The following example shows this:
```python
from ragas.metrics import AnswerRelevancy
from langchain_core import embeddings

# demo embedder
class MyEmbeddings(embeddings.Embeddings):

    embedding_lookup = { # some example embeddings
        "Where is France and what is it’s capital?": [0.33, 0.33, 0.333],
         "Pig?": [-0.33, -0.33, -0.33],
        "Orange!": [0.1, 0.2, 0.3],
        "Dark 897897?": [-1000, 0, -1000]
    }

    def embed_documents(self, texts):
        return [self.embedding_lookup[text] for text in texts]

    def embed_query(self, text):
        return self.embedding_lookup[text]
    

answer_relevancy = AnswerRelevancy()
answer_relevancy.embeddings =  MyEmbeddings()

question = "Where is France and what is it’s capital?"

generated_questions = [
    "Pig?", 
    "Orange!", 
    "Dark 897897?"
]

r = answer_relevancy.calculate_similarity(question, generated_questions)
# Score can be negative, depending on embedder:
print(r)
```
```
[-0.99999087  0.92721016 -0.8177225 ]
```

I updated the description and added a formula to make it clearer.