### PR TITLE
fix: Recursive Key Retrieval to Handle Unspecified JSON Schema Types and Fix for Int Value Returns about context_precision and context_recall

### DIFF
--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -100,7 +100,7 @@ class ContextRecall(MetricWithLLM):
         """get 'Attributed' recursively"""
         if isinstance(item, dict):
             if "attributed" in item:
-                attributed_value = item["attributed"]
+                attributed_value = item["Attributed"]
                 if isinstance(attributed_value, int):
                     return 1 if attributed_value == 1 else 0
                 elif isinstance(attributed_value, str):

--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -99,7 +99,7 @@ class ContextRecall(MetricWithLLM):
     def _extract_attributed_value(self, item):
         """get 'Attributed' recursively"""
         if isinstance(item, dict):
-            if "attributed" in item:
+            if "Attributed" in item:
                 attributed_value = item["Attributed"]
                 if isinstance(attributed_value, int):
                     return 1 if attributed_value == 1 else 0


### PR DESCRIPTION
### Summary
While utilizing the OpenAI API's GPT-4 turbo, I encountered an issue where JSON responses were returning with schema types that were not predefined. Additionally, despite specifying values as strings, some keys were returning integers. This pull request introduces a solution for both of these issues.

### Changes
- Implemented a recursive key retrieval function that can handle JSON objects of any structure, ensuring robust parsing regardless of the schema.
- Added a type-checking mechanism that converts integers back to strings if the original schema specified string types for key values.

### Rationale
The flexibility of the JSON response format from the GPT-4 turbo endpoint requires a more dynamic approach to parsing. The recursive method ensures that our application can seamlessly handle any JSON structure without the need for predefined schemas. Furthermore, the integrity of the data types is crucial for downstream processes, hence the necessity for a type-correction mechanism.

### Impact
This update will enhance the reliability of our system when interfacing with the OpenAI API and provide a more consistent data handling experience, especially in cases where the API's response structure is unpredictable.

Please review the changes and provide your feedback.

Thank you!

i-w-a