### PR TITLE
Fix adapt issue for keyphrase extractor

### DIFF
--- a/src/ragas/testset/evolutions.py
+++ b/src/ragas/testset/evolutions.py
@@ -296,7 +296,7 @@ class SimpleEvolution(Evolution):
         results = await self.generator_llm.generate(
             prompt=self.seed_question_prompt.format(
                 context=merged_node.page_content,
-                topic=rng.choice(np.array(merged_node.keyphrases), size=1)[0],
+                keyphrase=rng.choice(np.array(merged_node.keyphrases), size=1)[0],
             )
         )
         seed_question = results.generations[0][0].text

--- a/src/ragas/testset/extractor.py
+++ b/src/ragas/testset/extractor.py
@@ -6,10 +6,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
 from ragas.llms.json_load import json_loader
-from ragas.testset.prompts import (
-    keyphrase_extraction_prompt,
-    main_topic_extraction_prompt,
-)
+from ragas.testset.prompts import keyphrase_extraction_prompt
 
 if t.TYPE_CHECKING:
     from ragas.llms.base import BaseRagasLLM
@@ -43,30 +40,25 @@ class Extractor(ABC):
 
 @dataclass
 class KeyphraseExtractor(Extractor):
-    keyphrase_extraction_prompt: Prompt = field(
-        default_factory=lambda: main_topic_extraction_prompt
+    extractor_prompt: Prompt = field(
+        default_factory=lambda: keyphrase_extraction_prompt
     )
 
     async def extract(self, node: Node, is_async: bool = True) -> t.List[str]:
-        prompt = self.keyphrase_extraction_prompt.format(text=node.page_content)
+        prompt = self.extractor_prompt.format(text=node.page_content)
         results = await self.llm.generate(prompt=prompt, is_async=is_async)
         keyphrases = await json_loader.safe_load(
             results.generations[0][0].text.strip(), llm=self.llm, is_async=is_async
         )
         keyphrases = keyphrases if isinstance(keyphrases, dict) else {}
         logger.debug("topics: %s", keyphrases)
-        if "topics" in keyphrases:
-            return keyphrases["topics"]
-        elif "keyphrases" in keyphrases:
-            return keyphrases["keyphrases"]
-        else:
-            return []
+        return keyphrases.get("keyphrases", [])
 
     def adapt(self, language: str, cache_dir: t.Optional[str] = None) -> None:
         """
         Adapt the extractor to a different language.
         """
-        self.keyphrase_extraction_prompt = keyphrase_extraction_prompt.adapt(
+        self.extractor_prompt = self.extractor_prompt.adapt(
             language, self.llm, cache_dir
         )
 
@@ -74,4 +66,4 @@ class KeyphraseExtractor(Extractor):
         """
         Save the extractor prompts to a path.
         """
-        self.keyphrase_extraction_prompt.save(cache_dir)
+        self.extractor_prompt.save(cache_dir)

--- a/src/ragas/testset/extractor.py
+++ b/src/ragas/testset/extractor.py
@@ -55,7 +55,12 @@ class KeyphraseExtractor(Extractor):
         )
         keyphrases = keyphrases if isinstance(keyphrases, dict) else {}
         logger.debug("topics: %s", keyphrases)
-        return keyphrases.get("topics", [])
+        if "topics" in keyphrases:
+            return keyphrases["topics"]
+        elif "keyphrases" in keyphrases:
+            return keyphrases["keyphrases"]
+        else:
+            return []
 
     def adapt(self, language: str, cache_dir: t.Optional[str] = None) -> None:
         """

--- a/src/ragas/testset/prompts.py
+++ b/src/ragas/testset/prompts.py
@@ -335,22 +335,22 @@ seed_question_prompt = Prompt(
     instruction="Generate a question that can be fully answered from given context. The question should be formed using topic",
     examples=[
         {
-            "context": "The ecosystem of the Amazon rainforest is incredibly diverse, hosting thousands of species that are not found anywhere else on Earth. This biodiversity is crucial for the stability of the global climate and helps regulate the Earth's air and water cycles.",
-            "topic": "biodiversity in the Amazon rainforest",
-            "question": "Why is the biodiversity in the Amazon rainforest considered crucial for global climate stability?",
+            "context": "Photosynthesis in plants involves converting light energy into chemical energy, using chlorophyll and other pigments to absorb light. This process is crucial for plant growth and the production of oxygen.",
+            "keyphrase": "Photosynthesis",
+            "question": "What is the role of photosynthesis in plant growth?",
         },
         {
-            "context": "Quantum computing represents a significant leap forward in computational capability, utilizing the principles of quantum mechanics to process information in ways that traditional computers cannot. This technology has the potential to revolutionize various fields by performing complex calculations at unprecedented speeds.",
-            "topic": "potential applications of quantum computing",
-            "question": "What fields could potentially be revolutionized by the applications of quantum computing?",
+            "context": "The Industrial Revolution, starting in the 18th century, marked a major turning point in history as it led to the development of factories and urbanization.",
+            "keyphrase": "Industrial Revolution",
+            "question": "How did the Industrial Revolution mark a major turning point in history?",
         },
         {
-            "context": "Renewable energy sources, such as solar and wind power, are essential for transitioning to a more sustainable energy system. They offer the potential to reduce greenhouse gas emissions and dependency on fossil fuels, addressing key environmental and economic challenges.",
-            "topic": "benefits of renewable energy sources",
-            "question": "What are the primary benefits of transitioning to renewable energy sources?",
+            "context": "The process of evaporation plays a crucial role in the water cycle, converting water from liquid to vapor and allowing it to rise into the atmosphere.",
+            "keyphrase": "Evaporation",
+            "question": "Why is evaporation important in the water cycle?",
         },
     ],
-    input_keys=["context", "topic"],
+    input_keys=["context", "keyphrase"],
     output_key="question",
     output_type="string",
 )


### PR DESCRIPTION
Hi,
This fixes [issue #625](https://github.com/explodinggradients/ragas/issues/625). This issue is happening when after adaption testset generation is called. This issue is caused by the fact, that after adaption the keyword extractor returns nothing. This leads to failure later.  However the keywords are indeed extracted correctly (as can be seen when debugging) but not returned properly from the function. The key "topics" doesn't exist (after adaption) in the dict, instead it's "keyphrases". This PR works for both with/without adaption.