### PR TITLE
Fix: json format inconsistency in context recall (prompt for statemen…

### DIFF
--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -52,21 +52,25 @@ CONTEXT_RECALL_RA = Prompt(
             "question": """who won 2020 icc world cup?""",
             "context": """The 2022 ICC Men's T20 World Cup, held from October 16 to November 13, 2022, in Australia, was the eighth edition of the tournament. Originally scheduled for 2020, it was postponed due to the COVID-19 pandemic. England emerged victorious, defeating Pakistan by five wickets in the final to clinch their second ICC Men's T20 World Cup title.""",
             "answer": """England""",
-            "classification": {
-                "statement_1": "England won the 2022 ICC Men's T20 World Cup.",
-                "reason": "From context it is clear that England defeated Pakistan to win the World Cup.",
-                "Attributed": "1",
-            },
+            "classification": [
+                {
+                    "statement_1": "England won the 2022 ICC Men's T20 World Cup.",
+                    "reason": "From context it is clear that England defeated Pakistan to win the World Cup.",
+                    "Attributed": "1",
+                }
+            ],
         },
         {
             "question": """What is the primary fuel for the Sun?""",
             "context": """NULL""",
             "answer": """Hydrogen""",
-            "classification": {
-                "statement_1": "The Sun's primary fuel is hydrogen.",
-                "reason": "The context contains no information",
-                "Attributed": "0",
-            },
+            "classification": [
+                {
+                    "statement_1": "The Sun's primary fuel is hydrogen.",
+                    "reason": "The context contains no information",
+                    "Attributed": "0",
+                }
+            ],
         },
     ],
     input_keys=["question", "context", "answer"],


### PR DESCRIPTION
There is a small inconsistency in the prompt for statement creation / attribution for the context recall metric. The output key `classification` is expected to be an array of attributed statements (one or more statements). This is defined correctly in the first example, but in the two following examples the array brackets are missing. 

This inconsistency may not lead to any problems when working with powerful llms (e.g. with OpenAI) most of the time, but I noticed some confusion about the expected output when running the original code with some other smaller models. This way it is more clear and consistent, that one **or more** statements are expected to be returned.