### PR TITLE
Added metadata field to datarows

### DIFF
--- a/src/ragas/testset/evolutions.py
+++ b/src/ragas/testset/evolutions.py
@@ -45,6 +45,7 @@ class DataRow(BaseModel):
     contexts: t.List[str]
     ground_truth: t.Union[str, float] = np.nan
     evolution_type: str
+    metadata: t.List[dict]
 
 
 @dataclass
@@ -237,6 +238,7 @@ class Evolution:
             contexts=[n.page_content for n in relevant_context.nodes],
             ground_truth=answer,
             evolution_type=evolution_type,
+            metadata=[n.metadata for n in relevant_context.nodes]
         )
 
     def adapt(self, language: str, cache_dir: t.Optional[str] = None) -> None:


### PR DESCRIPTION
This would help have a better picture of the documents that were fetched. Users can choose to drop this column if not required. But in most cases, this would be a good addition at least in the initial stages for verifying the quality of the dataset and understanding the otherwise black-box nature of the dataset generation here.