### PR TITLE
fix: change documentation to reflect accurate method name

### DIFF
--- a/docs/howtos/applications/compare_embeddings.md
+++ b/docs/howtos/applications/compare_embeddings.md
@@ -55,7 +55,7 @@ distributions = {
 }
 
 # generate testset
-testset = generator.generate_with_llama_index_docs(documents, 100,distributions)
+testset = generator.generate_with_llamaindex_docs(documents, 100,distributions)
 testset.to_pandas()
 ```
 


### PR DESCRIPTION
Updates the docs to reflect the correct method name.