### PR TITLE
bugfix: evaluation thread timeout

### DIFF
--- a/src/ragas/evaluation.py
+++ b/src/ragas/evaluation.py
@@ -200,7 +200,12 @@ def evaluate(
         row_run_managers.append((row_rm, row_group_cm))
         [
             executor.submit(
-                metric.ascore, row, row_group_cm, is_async, name=f"{metric.name}-{i}"
+                metric.ascore,
+                row,
+                row_group_cm,
+                is_async,
+                name=f"{metric.name}-{i}",
+                thread_timeout=run_config.thread_timeout,
             )
             for metric in metrics
         ]

--- a/src/ragas/metrics/base.py
+++ b/src/ragas/metrics/base.py
@@ -52,13 +52,11 @@ def get_required_columns(
 class Metric(ABC):
     @property
     @abstractmethod
-    def name(self) -> str:
-        ...
+    def name(self) -> str: ...
 
     @property
     @abstractmethod
-    def evaluation_mode(self) -> EvaluationMode:
-        ...
+    def evaluation_mode(self) -> EvaluationMode: ...
 
     @abstractmethod
     def init(self, run_config: RunConfig):
@@ -102,14 +100,21 @@ class Metric(ABC):
         return score
 
     async def ascore(
-        self: t.Self, row: t.Dict, callbacks: Callbacks = None, is_async: bool = True
+        self: t.Self,
+        row: t.Dict,
+        callbacks: Callbacks = None,
+        is_async: bool = True,
+        thread_timeout: float = None,
     ) -> float:
         callbacks = callbacks or []
         rm, group_cm = new_group(
             self.name, inputs=row, callbacks=callbacks, is_async=True
         )
         try:
-            score = await self._ascore(row=row, callbacks=group_cm, is_async=is_async)
+            score = await asyncio.wait_for(
+                self._ascore(row=row, callbacks=group_cm, is_async=is_async),
+                timeout=thread_timeout,
+            )
         except Exception as e:
             if not group_cm.ended:
                 rm.on_chain_error(e)
@@ -120,8 +125,9 @@ class Metric(ABC):
         return score
 
     @abstractmethod
-    async def _ascore(self, row: t.Dict, callbacks: Callbacks, is_async: bool) -> float:
-        ...
+    async def _ascore(
+        self, row: t.Dict, callbacks: Callbacks, is_async: bool
+    ) -> float: ...
 
 
 @dataclass

--- a/src/ragas/run_config.py
+++ b/src/ragas/run_config.py
@@ -21,6 +21,7 @@ class RunConfig:
     max_retries: int = 10
     max_wait: int = 60
     max_workers: int = 16
+    thread_timeout: float = 80.0
     exception_types: t.Union[
         t.Type[BaseException],
         t.Tuple[t.Type[BaseException], ...],


### PR DESCRIPTION
The current version of `evaluation` contains a threading timeout issue refered in issue #854 #722 #734 #810, which makes the evaluation process hangs in the last few cases and won't finish running.

This PR adds a `threading_timeout` parameter in the run_config, which raises asyncio.TimeoutError when the metric ascore function runs over the `threading_timeout`, avoiding the forever hanging situation.