### PR TITLE
Update data_preparation doc link in evaluation.md

### DIFF
--- a/docs/getstarted/evaluation.md
+++ b/docs/getstarted/evaluation.md
@@ -36,7 +36,7 @@ amnesty_qa
 
 :::{seealso}
 See [test set generation](./testset_generation.md) to learn how to generate your own `Question/Context/Ground_Truth` triplets for evaluation.
-See [preparing your own dataset](/docs/howtos/applications/data_preparation.md) to learn how to prepare your own dataset for evaluation.
+See [preparing your own dataset](../howtos/applications/data_preparation.md) to learn how to prepare your own dataset for evaluation.
 :::
 
 ## Metrics


### PR DESCRIPTION
The current link is not redirecting to the data_preparation doc. Changed the link to be relative similar to other working links.