### PR TITLE
Update validation to allow for empty context lists

### DIFF
--- a/src/ragas/validation.py
+++ b/src/ragas/validation.py
@@ -51,7 +51,7 @@ def validate_column_dtypes(ds: Dataset):
         if column_names in ds.features:
             if not (
                 isinstance(ds.features[column_names], Sequence)
-                and ds.features[column_names].feature.dtype == "string"
+                and (ds.features[column_names].feature.dtype == "string" or ds.features[column_names].length < 1)
             ):
                 raise ValueError(
                     f'Dataset feature "{column_names}" should be of type'


### PR DESCRIPTION
When no strings are provided in the contexts during evaluation, the context feature's type in the dataset is the generic Sequence type rather than the expected Sequence[string], thus it fails validation with a ValueError, despite being a valid dataset.

For example, if retrieval uses an unrealistically high similarity score threshold, no contexts will be found, but the error message will be the unhelpful and irrelevant `ValueError: Dataset feature "contexts" should be of type Sequence[string], got <class 'datasets.features.features.Sequence'>`.

See also https://github.com/explodinggradients/ragas/issues/286