### PR TITLE
docs: langchain.document_loaders is deprecated

### DIFF
--- a/docs/concepts/testset_generation.md
+++ b/docs/concepts/testset_generation.md
@@ -37,7 +37,7 @@ Moving forward, we are will be expanding the range of evolution techniques to of
 
 ```{code-block} python
 :caption: loading documents using langchain
-from langchain.document_loaders import PubMedLoader
+from langchain_community.document_loaders import PubMedLoader
 
 loader = PubMedLoader("liver", load_max_docs=10)
 documents = loader.load()

--- a/docs/getstarted/testset_generation.md
+++ b/docs/getstarted/testset_generation.md
@@ -15,7 +15,7 @@ Initially, a collection of documents is needed to generate synthetic `Question/C
 
 ```{code-block} python
 :caption: Load documents from directory
-from langchain.document_loaders import DirectoryLoader
+from langchain_community.document_loaders import DirectoryLoader
 loader = DirectoryLoader("your-directory")
 documents = loader.load()
 ```

--- a/docs/howtos/applications/use_prompt_adaptation.md
+++ b/docs/howtos/applications/use_prompt_adaptation.md
@@ -106,7 +106,7 @@ git clone https://huggingface.co/datasets/explodinggradients/hindi-wikipedia
 Now you can load the documents using a document loader, here I am using `DirectoryLoader`
 
 ```{code-block} python
-from langchain.document_loaders import DirectoryLoader
+from langchain_community.document_loaders import DirectoryLoader
 
 loader = DirectoryLoader("./hindi-wikipedia/")
 documents = loader.load()

--- a/docs/howtos/customisations/azure-openai.ipynb
+++ b/docs/howtos/customisations/azure-openai.ipynb
@@ -448,7 +448,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.document_loaders import DirectoryLoader\n",
+    "from langchain_community.document_loaders import DirectoryLoader\n",
     "from ragas.testset.generator import TestsetGenerator\n",
     "from ragas.testset.evolutions import simple, reasoning, multi_context\n",
     "\n",

--- a/docs/howtos/customisations/ragas_custom_model.ipynb
+++ b/docs/howtos/customisations/ragas_custom_model.ipynb
@@ -46,7 +46,7 @@
     "    evolution_elimination_prompt,\n",
     "    filter_question_prompt,\n",
     ")\n",
-    "from langchain.document_loaders import DirectoryLoader\n",
+    "from langchain_community.document_loaders import DirectoryLoader\n",
     "from ragas.testset.generator import TestsetGenerator\n",
     "from ragas.testset.evolutions import simple, reasoning, multi_context"
    ]

--- a/docs/howtos/integrations/langchain.ipynb
+++ b/docs/howtos/integrations/langchain.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.document_loaders import TextLoader\n",
+    "from langchain_community.document_loaders import TextLoader\n",
     "from langchain.indexes import VectorstoreIndexCreator\n",
     "from langchain.chains import RetrievalQA\n",
     "from langchain_openai import ChatOpenAI\n",


### PR DESCRIPTION
In the example code provided in the documentation, document loaders are currently imported from `langchain` instead of `langchain_community`.

This triggers the following deprecation warnings:
```
LangChainDeprecationWarning: Importing document loaders from langchain is deprecated. Importing from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:

`from langchain_community.document_loaders import DirectoryLoader`.

To install langchain-community run `pip install -U langchain-community`.
```

This PR updates the imports in the documentation from `langchain.document_loaders` to `langchain_community.document_loaders` to eliminate these warnings.