### PR TITLE
fix(evaluation): Update evaluation dataset parameters docs

### DIFF
--- a/src/ragas/evaluation.py
+++ b/src/ragas/evaluation.py
@@ -53,7 +53,7 @@ def evaluate(
 
     Parameters
     ----------
-    dataset : Dataset[question: list[str], contexts: list[list[str]], answer: list[str], ground_truth: list[list[str]]]
+    dataset : Dataset[question: list[str], contexts: list[list[str]], answer: list[str], ground_truth: list[str]]
         The dataset in the format of ragas which the metrics will use to score the RAG
         pipeline with
     metrics : list[Metric] , optional


### PR DESCRIPTION
Hi, I used the evaluation and found the docs of ground_truth parameter should be `list[str]`. 
See the `validate_column_dtypes` method in [validation.py](https://github.com/explodinggradients/ragas/blob/main/src/ragas/validation.py#L43).
Thanks.