### PR TITLE
fix: Adapted output keys do not match with the original output keys

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import partial
 
-from langchain_community.chat_models import ChatVertexAI
+from langchain_community.chat_models.vertexai import ChatVertexAI
 from langchain_community.llms import VertexAI
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.outputs import LLMResult

--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -236,7 +236,7 @@ class Prompt(BaseModel):
 
             if self.output_type.lower() == "json":
                 output = example_dict[self.output_key]
-                if isinstance(output, dict):
+                if isinstance(output, dict) and output_keys[i]:
                     assert (
                         set(output.keys()) == output_keys[i]
                     ), f"Adapted output keys {set(output.keys())=} do not match with the original output keys: {output_keys[i]=}"


### PR DESCRIPTION
this should fix the error mentioned [here](https://github.com/explodinggradients/ragas/issues/774) and [here](https://github.com/explodinggradients/ragas/issues/804) 

the error is thrown due to an example with an empty list of statements.