### PR TITLE
Cleaned installation step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,16 @@ Ragas provides you with the tools based on the latest research for evaluating LL
 
 ## :shield: Installation
 
+From release:
+
 ```bash
 pip install ragas
 ```
 
-if you want to install from source
+Alternatively, from source:
 
 ```bash
-git clone https://github.com/explodinggradients/ragas && cd ragas
-pip install -e .
+pip install git+https://github.com/explodinggradients/ragas
 ```
 
 ## :fire: Quickstart


### PR DESCRIPTION
I saw that the installation step from source was unnecessarily complicated in the README.

I simplified it, following patterns using in most other large python package frameworks.

I also changed the text around to make it clearer to the user what each step does.