### PR TITLE
fix - typo & prompt

### DIFF
--- a/src/ragas/testset/docstore.py
+++ b/src/ragas/testset/docstore.py
@@ -269,9 +269,9 @@ class InMemoryDocumentStore(DocumentStore):
                 self.node_embeddings_list.append(n.embedding)
 
         self.calculate_nodes_docs_similarity()
-        self.set_node_relataionships()
+        self.set_node_relationships()
 
-    def set_node_relataionships(self):
+    def set_node_relationships(self):
         for i, node in enumerate(self.nodes):
             if i > 0:
                 prev_node = self.nodes[i - 1]

--- a/src/ragas/testset/prompts.py
+++ b/src/ragas/testset/prompts.py
@@ -204,7 +204,7 @@ keyphrase_extraction_prompt = Prompt(
 
 seed_question_prompt = Prompt(
     name="seed_question",
-    instruction="Generate a question that can be fully answered from given context. The question should be formed using topic",
+    instruction="Generate a question that can be fully answered from given context. The question should be formed using the given keyphrase.",
     examples=[
         {
             "context": "Photosynthesis in plants involves converting light energy into chemical energy, using chlorophyll and other pigments to absorb light. This process is crucial for plant growth and the production of oxygen.",

--- a/tests/unit/testset_generator/test_docstore.py
+++ b/tests/unit/testset_generator/test_docstore.py
@@ -41,7 +41,7 @@ def test_adjacent_nodes():
     splitter = TokenTextSplitter(chunk_size=100, chunk_overlap=0)
     store = InMemoryDocumentStore(splitter=splitter, embeddings=fake_embeddings)
     store.nodes = [a1, a2, b]
-    store.set_node_relataionships()
+    store.set_node_relationships()
 
     assert store.nodes[0].next == a2
     assert store.nodes[1].prev == a1


### PR DESCRIPTION
1. Function typo 
Original name - set_node_relataionships()
Fixed name - set_node_relationships()

2. In the seed_question_prompt, a keyphrase is given.   
But in the instruction, it is mentioned that `The question should be formed using topic`.   
![image](https://github.com/explodinggradients/ragas/assets/40126336/a69c4b29-8c57-4e6d-a959-2bf163178cb2)  
`The question should be formed using the given keyphrase.` would be better