### PR TITLE
Chore: Fix RuntimeError: ... got Future <..> attached to a different loop

### DIFF
--- a/src/ragas/executor.py
+++ b/src/ragas/executor.py
@@ -58,7 +58,10 @@ class Runner(threading.Thread):
         self.run_config = run_config or RunConfig()
 
         # create task
-        self.loop = asyncio.new_event_loop()
+        try:
+            self.loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self.loop = asyncio.new_event_loop()
         self.futures = as_completed(
             loop=self.loop,
             coros=[coro for coro, _ in self.jobs],
@@ -96,7 +99,6 @@ class Runner(threading.Thread):
             results = self.loop.run_until_complete(self._aresults())
         finally:
             self.results = results
-            self.loop.stop()
 
 
 @dataclass


### PR DESCRIPTION
In issue #963 I commented about the RuntimeError when trying to use TestsetGenerator. 

In issue  #681 you discussed that using get_event_loop() was the optimal way to solve the issue but it had a Deprecation warning. 

<img width="705" alt="image" src="https://github.com/explodinggradients/ragas/assets/76526314/94e5cd25-7e4f-4989-8b72-93cb74274a8f">

In newer python versions get_event_loop() raises a RuntimeError when no event loop is active. Thus we can avoid creating unnecessary new loops that seem to be the problem that was mentioned in both issues. 


I have modified the code the least possible to make it clear what I intended to, although in this setup runner could be avoided as was proposed in #689 

Setup: 
Ragas version: 0.1.7
Python version: Python 3.10.13