### PR TITLE
Handle embeddings for empty strings in AnswerSimilarity class

### DIFF
--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -57,6 +57,10 @@ class AnswerSimilarity(MetricWithLLM, MetricWithEmbeddings):
         ground_truth = t.cast(str, row["ground_truth"])
         answer = t.cast(str, row["answer"])
 
+        # Handle embeddings for empty strings
+        ground_truth = ground_truth or " "
+        answer = answer or " "
+
         if self.is_cross_encoder and isinstance(self.embeddings, HuggingfaceEmbeddings):
             raise NotImplementedError(
                 "async score [ascore()] not implemented for HuggingFace embeddings"


### PR DESCRIPTION
Fixes: #996 

Some embedding models do not work with empty strings (for example Gemini) and return an error.
The error does not appear with OpenAI which returns an embeddings even for an empty string.

Proposed resolution: replace empty strings with `" "`