### PR TITLE
fix(testset): for generating testset with new docs

### DIFF
--- a/src/ragas/testset/evolutions.py
+++ b/src/ragas/testset/evolutions.py
@@ -352,14 +352,13 @@ class ComplexEvolution(Evolution):
             run_config = RunConfig()
         super().init(is_async=is_async, run_config=run_config)
 
-        if self.se is None:
-            # init simple evolution to get seed question
-            self.se = SimpleEvolution(
-                generator_llm=self.generator_llm,
-                docstore=self.docstore,
-                node_filter=self.node_filter,
-                question_filter=self.question_filter,
-            )
+        # init simple evolution to get seed question
+        self.se = SimpleEvolution(
+            generator_llm=self.generator_llm,
+            docstore=self.docstore,
+            node_filter=self.node_filter,
+            question_filter=self.question_filter,
+        )
         # init evolution filter with critic llm from another filter
         assert self.node_filter is not None, "node filter cannot be None"
         if self.evolution_filter is None:

--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -217,11 +217,11 @@ class TestsetGenerator:
         )
 
     def init_evolution(self, evolution: Evolution) -> None:
+        evolution.docstore = self.docstore
+        
         if evolution.generator_llm is None:
             evolution.generator_llm = self.generator_llm
-            if evolution.docstore is None:
-                evolution.docstore = self.docstore
-
+            
             if evolution.question_filter is None:
                 evolution.question_filter = QuestionFilter(llm=self.critic_llm)
             if evolution.node_filter is None:


### PR DESCRIPTION
fixes #848 

This pull request introduces updates to the TestsetGenerator and ComplexEvolution classes within the generator.py and evolutions.py files respectively. The primary focus of these changes is to improve the handling of new documents during test dataset generation, ensuring that data from previous documents does not interfere with the generation process.

### Before
![Screenshot 2024-05-31 183725 before](https://github.com/explodinggradients/ragas/assets/77217074/dcc24e81-2e35-4e20-8638-2904d6779225)
Here row 2 and 4 are generated from the document used for the previous generation
### After
![Screenshot 2024-05-31 184647 after](https://github.com/explodinggradients/ragas/assets/77217074/582afeeb-9ade-4d35-891c-af54af21c859)
Here all rows generated are based on the new document provided
