### PR TITLE
fix(typo): missing 'to' in prompt instruction

### DIFF
--- a/src/ragas/metrics/_context_relevancy.py
+++ b/src/ragas/metrics/_context_relevancy.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 CONTEXT_RELEVANCE = Prompt(
     name="context_relevancy",
-    instruction="""Please extract relevant sentences from the provided context that is absolutely required answer the following question. If no relevant sentences are found, or if you believe the question cannot be answered from the given context, return the phrase "Insufficient Information".  While extracting candidate sentences you're not allowed to make any changes to sentences from given context.""",
+    instruction="""Please extract relevant sentences from the provided context that is absolutely required to answer the following question. If no relevant sentences are found, or if you believe the question cannot be answered from the given context, return the phrase "Insufficient Information".  While extracting candidate sentences you're not allowed to make any changes to sentences from given context.""",
     input_keys=["question", "context"],
     output_key="candidate sentences",
     output_type="json",


### PR DESCRIPTION
Looking into the underlying prompt to compute context relevancy, the missing "to" annoyed me.