### PR TITLE
fix: langchain EvaluatorChain OpenAI validation error

### DIFF
--- a/src/ragas/integrations/langchain.py
+++ b/src/ragas/integrations/langchain.py
@@ -19,6 +19,7 @@ from ragas.metrics.base import (
     get_required_columns,
 )
 from ragas.run_config import RunConfig
+from ragas.utils import get_or_init
 from ragas.validation import EVALMODE_TO_COLUMNS
 
 if t.TYPE_CHECKING:
@@ -43,10 +44,10 @@ class EvaluatorChain(Chain, RunEvaluator):
         else:
             run_config = RunConfig()
         if isinstance(self.metric, MetricWithLLM):
-            llm = kwargs.get("llm", ChatOpenAI())
+            llm = get_or_init(kwargs, "llm", ChatOpenAI)
             t.cast(MetricWithLLM, self.metric).llm = LangchainLLMWrapper(llm)
         if isinstance(self.metric, MetricWithEmbeddings):
-            embeddings = kwargs.get("embeddings", OpenAIEmbeddings())
+            embeddings = get_or_init(kwargs, "embeddings", OpenAIEmbeddings)
             t.cast(
                 MetricWithEmbeddings, self.metric
             ).embeddings = LangchainEmbeddingsWrapper(embeddings)

--- a/src/ragas/utils.py
+++ b/src/ragas/utils.py
@@ -144,3 +144,12 @@ def deprecated(
         return emit_warning
 
     return deprecate
+
+
+def get_or_init(
+    dictionary: t.Dict[str, t.Any], key: str, default: t.Callable[[], t.Any]
+) -> t.Any:    
+    _value = dictionary.get("key")
+    value = _value if _value is not None else default()
+    
+    return value


### PR DESCRIPTION
# This mr solve the following problem:
- When you are using a custom llm or embeddings with langchain EvaluatorChain and you have not set OpenAI's ENVs, a validation error is raised for missing ENVs