### PR TITLE
Empty generation, change None checking to is_nan call over list elements

### DIFF
--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -301,7 +301,7 @@ class TestsetGenerator:
 
         try:
             test_data_rows = exec.results()
-            if not test_data_rows:
+            if all(is_nan(row) for row in test_data_rows):
                 raise ExceptionInRunner()
 
         except ValueError as e:

--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -301,7 +301,7 @@ class TestsetGenerator:
 
         try:
             test_data_rows = exec.results()
-            if all(is_nan(row) for row in test_data_rows):
+            if all([is_nan(row) for row in test_data_rows]):
                 raise ExceptionInRunner()
 
         except ValueError as e:


### PR DESCRIPTION
# Description
Should fix #1137.

# Fonctionnality
An empty generation from `TestsetGenerator.generate` should raise a `ragas.exceptions.ExceptionInRunner`.

# Issue
Currently the behaviour is expected as written in the code but it is not actived by the comparison `if not test_data_rows`.

# Solution proposed
Check if all generated rows are empty and raise if it is the case (another approach could be to raise an error only if at least one element is nan).