### PR TITLE
Random seed fixed

### DIFF
--- a/src/ragas/run_config.py
+++ b/src/ragas/run_config.py
@@ -2,6 +2,7 @@ import logging
 import typing as t
 from dataclasses import dataclass
 
+import numpy as np
 from tenacity import (
     AsyncRetrying,
     Retrying,
@@ -30,6 +31,10 @@ class RunConfig:
         t.Tuple[t.Type[BaseException], ...],
     ] = (Exception,)
     log_tenacity: bool = False
+    seed: t.Optional[int] = None
+
+    def __post__init(self):
+        self.rng : np.random.Generator = np.random.default_rng(seed=self.seed)
 
 
 def add_retry(fn: WrappedFn, run_config: RunConfig) -> WrappedFn:

--- a/src/ragas/testset/docstore.py
+++ b/src/ragas/testset/docstore.py
@@ -325,7 +325,7 @@ class InMemoryDocumentStore(DocumentStore):
         prob = np.array(scores) * np.array(similarity_scores)
         prob = prob / np.sum(prob)
 
-        nodes = rng.choice(np.array(self.nodes), size=k, p=prob).tolist()
+        nodes = self.run_config.rng.choice(np.array(self.nodes), size=k, p=prob).tolist()
 
         for node in nodes:
             idx = self.nodes.index(node)

--- a/src/ragas/testset/evolutions.py
+++ b/src/ragas/testset/evolutions.py
@@ -104,6 +104,8 @@ class Evolution:
             self.node_filter.set_run_config(run_config)
         if self.question_filter:
             self.question_filter.set_run_config(run_config)
+        
+        self.run_config = run_config
 
     async def aretry_evolve(
         self,
@@ -305,7 +307,7 @@ class SimpleEvolution(Evolution):
         results = await self.generator_llm.generate(
             prompt=self.seed_question_prompt.format(
                 context=merged_node.page_content,
-                keyphrase=rng.choice(np.array(merged_node.keyphrases), size=1)[0],
+                keyphrase=self.run_config.rng.choice(np.array(merged_node.keyphrases), size=1)[0],
             )
         )
         seed_question = results.generations[0][0].text

--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -301,7 +301,7 @@ class TestsetGenerator:
 
         try:
             test_data_rows = exec.results()
-            if not test_data_rows:
+            if all(is_nan(row) for row in test_data_rows):
                 raise ExceptionInRunner()
 
         except ValueError as e:

--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -301,7 +301,7 @@ class TestsetGenerator:
 
         try:
             test_data_rows = exec.results()
-            if all(is_nan(row) for row in test_data_rows):
+            if all([is_nan(row) for row in test_data_rows]):
                 raise ExceptionInRunner()
 
         except ValueError as e:


### PR DESCRIPTION
# Description
Should fix #1140 

# Fonctionnality
Allow a user to fix the seed him/herself and use a random seed otherwise.

# Solution proposed

Define the `seed` as an initial attribute and the `rng` as a post_initialization attribute that a user can override and adapt its use in  `ragas.testset.docstore.InMemoryDocumentStore` and `ragas.testset.evolutions.Evolution`