### PR TITLE
Update on Json Format Prompt

### DIFF
--- a/src/ragas/llms/output_parser.py
+++ b/src/ragas/llms/output_parser.py
@@ -30,6 +30,7 @@ JSON_FORMAT_INSTRUCTIONS = """The output should be a well-formatted JSON instanc
 As an example, for the schema {{"properties": {{"foo": {{"title": "Foo", "description": "a list of strings", "type": "array", "items": {{"type": "string"}}}}}}, "required": ["foo"]}}
 the object {{"foo": ["bar", "baz"]}} is a well-formatted instance of the schema. The object {{"properties": {{"foo": ["bar", "baz"]}}}} is not well-formatted.
 
+Never return the answer as a raw string, always return it as a JSON object with the following schema.
 Here is the output JSON schema:
 ```
 {schema}


### PR DESCRIPTION
Hi! 

I was calculating the summarization score and faithfullness metric with the `azure openai gpt35-turbo-1106 ` but sometimes it was not giving proper JSON output and it was breaking the code for me.

The following change in the JSON formatting prompt solved the problem for me. 
 

