### PR TITLE
Fixing Demo Code - Compare Embeddings for retriever Docs

### DIFF
--- a/docs/howtos/applications/compare_embeddings.md
+++ b/docs/howtos/applications/compare_embeddings.md
@@ -29,6 +29,7 @@ For this tutorial notebook, I am using papers from Semantic Scholar that is rela
 :caption: load documents using llama-hub and create test data
 from llama_index import download_loader
 from ragas.testset.evolutions import simple, reasoning, multi_context
+from ragas.testset.generator import TestsetGenerator
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
 SemanticScholarReader = download_loader("SemanticScholarReader")

--- a/docs/howtos/applications/compare_embeddings.md
+++ b/docs/howtos/applications/compare_embeddings.md
@@ -27,7 +27,7 @@ For this tutorial notebook, I am using papers from Semantic Scholar that is rela
 
 ```{code-block} python
 :caption: load documents using llama-hub and create test data
-from llama_index import download_loader
+from llama_index.core import download_loader
 from ragas.testset.evolutions import simple, reasoning, multi_context
 from ragas.testset.generator import TestsetGenerator
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings

--- a/docs/howtos/applications/compare_embeddings.md
+++ b/docs/howtos/applications/compare_embeddings.md
@@ -56,7 +56,7 @@ distributions = {
 
 # generate testset
 testset = generator.generate_with_llamaindex_docs(documents, 100,distributions)
-testset.to_pandas()
+test_df = testset.to_pandas()
 ```
 
 <p align="left">


### PR DESCRIPTION
The code examples from `docs/howtos/applications/compare_embeddings.md` were missing important lines e.g. missing the `TestsetGenerator` import and assigning `test_df` before using it.

This pull request adressess these minor improvements.