### PR TITLE
Add save function for statement_prompt

### DIFF
--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -308,6 +308,6 @@ class Faithfulness(MetricWithLLM):
 
     def save(self, cache_dir: t.Optional[str] = None) -> None:
         self.nli_statements_message.save(cache_dir)
-
+        self.statement_prompt.save(cache_dir)
 
 faithfulness = Faithfulness()


### PR DESCRIPTION
Fixed problem with statement_prompt not being saved in cache when applying language adapter to faithfulness