### PR TITLE
change default model to gpt4o-mini

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -289,7 +289,7 @@ class LlamaIndexLLMWrapper(BaseRagasLLM):
 
 
 def llm_factory(
-    model: str = "gpt-3.5-turbo", run_config: t.Optional[RunConfig] = None
+    model: str = "gpt-4o-mini", run_config: t.Optional[RunConfig] = None
 ) -> BaseRagasLLM:
     timeout = None
     if run_config is not None:

--- a/src/ragas/testset/generator.py
+++ b/src/ragas/testset/generator.py
@@ -146,8 +146,8 @@ class TestsetGenerator:
     @deprecated("0.1.4", removal="0.2.0", alternative="from_langchain")
     def with_openai(
         cls,
-        generator_llm: str = "gpt-3.5-turbo-16k",
-        critic_llm: str = "gpt-4",
+        generator_llm: str = "gpt-4o-mini",
+        critic_llm: str = "gpt-4o",
         embeddings: str = "text-embedding-ada-002",
         docstore: t.Optional[DocumentStore] = None,
         chunk_size: int = 1024,


### PR DESCRIPTION
Reasons
1. gpt4o-mini is 2x cheaper than the current default model of gpt3.5-turbo
2. Extended context length of 128k tokens
3. All the public benchmarks indicate better performance on all tasks by gpt4o-mini compared to gpt3.5-turbo. [Source](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/) 