### PR TITLE
Add tests to `ragas.run_config.RunConfig` `rng` attribute.

### DIFF
--- a/tests/unit/test_run_config.py
+++ b/tests/unit/test_run_config.py
@@ -1,12 +1,17 @@
-from typing import TypeAlias, Callable
 import sys, importlib
-
+from packaging.version import parse as parse_version
+from platform import python_version
 import pytest
 from numpy.random import default_rng, Generator
 
 from ragas.run_config import RunConfig
 
-RandomComparison: TypeAlias = Callable[[Generator, Generator], bool]
+if parse_version(python_version()) == parse_version("3.9"):
+    from typing import NewType, Callable
+    RandomComparison = NewType("RandomComparison", Callable[[Generator, Generator], bool])
+elif parse_version(python_version()) > parse_version("3.9"):
+    from typing import TypeAlias, Callable
+    RandomComparison: TypeAlias = Callable[[Generator, Generator], bool]
 
 @pytest.fixture(scope="function")
 def compare_rng() -> Callable[[Generator, Generator], bool]:

--- a/tests/unit/test_run_config.py
+++ b/tests/unit/test_run_config.py
@@ -1,10 +1,77 @@
-import numpy as np
+from typing import Protocol
+import sys, importlib
+
 import pytest
+from numpy.random import default_rng, Generator
 
 from ragas.run_config import RunConfig
 
+class RandomComparison(Protocol):
+    """Pytest fixture wrapper to check :py:cls:`numpy.random.Generator` object equivalence.
+    
+    Args:
+        rng_0 (numpy.random.Generator) : The first generator to compare with.
+        rng_1 (numpy.random.Generator) : The second generator to compare with.
+    
+    Returns:
+        bool: Whether the two generators are at the same state.
 
-def test_random_num_generator():
-    rc = RunConfig(seed=32)
-    assert isinstance(rc.rng, np.random.Generator)
-    assert rc.rng.random() == pytest.approx(0.160, rel=1e2)
+    """
+    def __call__(self, a:Generator, b:Generator) -> bool: ...
+
+@pytest.fixture(scope="function")
+def compare_rng() -> RandomComparison:
+    def _compare_rng(rng_0:Generator, rng_1:Generator) -> bool:
+        return rng_0.random() == rng_1.random()
+    
+    return _compare_rng
+
+
+@pytest.mark.parametrize(
+    "seed, expected_equivalence",
+    (
+        [42, True],
+        [None, False],
+    )
+)
+def test_random_num_generator(seed, compare_rng:RandomComparison, expected_equivalence):
+    """Check :py:mod:`numpy.random` functionality and seed behaviour control."""
+    rc = RunConfig(seed=seed)
+
+    # Check type
+    assert isinstance(rc.rng, Generator)
+
+    # Check generated value
+    rng = default_rng(seed=seed)
+    assert compare_rng(rc.rng, rng) == expected_equivalence
+
+    # Check generation consistency
+    importlib.reload(sys.modules['numpy.random'])
+    new_rc = RunConfig(seed=seed)
+    new_rng = default_rng(seed=seed)
+
+    # Put generator into the same state
+    new_rc.rng.random()
+    new_rng.random()
+
+    # Check equivalence
+    if expected_equivalence:
+        assert all(
+             list(
+                  map(
+                       compare_rng,
+                       [rc.rng, new_rc.rng],
+                       [new_rng, rng]
+                    )
+                )
+            )
+    else:
+        assert all(
+             list(
+                  map(
+                       lambda x, y:not compare_rng(x, y),
+                       [rc.rng, new_rc.rng],
+                       [new_rng, rng]
+                    )
+                )
+            )

--- a/tests/unit/test_run_config.py
+++ b/tests/unit/test_run_config.py
@@ -6,10 +6,10 @@ from numpy.random import default_rng, Generator
 
 from ragas.run_config import RunConfig
 
-if parse_version(python_version()) == parse_version("3.9"):
+if parse_version(python_version()) < parse_version("3.10"):
     from typing import NewType, Callable
     RandomComparison = NewType("RandomComparison", Callable[[Generator, Generator], bool])
-elif parse_version(python_version()) > parse_version("3.9"):
+elif parse_version(python_version()) >= parse_version("3.10"):
     from typing import TypeAlias, Callable
     RandomComparison: TypeAlias = Callable[[Generator, Generator], bool]
 

--- a/tests/unit/test_run_config.py
+++ b/tests/unit/test_run_config.py
@@ -1,4 +1,4 @@
-from typing import Protocol
+from typing import TypeAlias, Callable
 import sys, importlib
 
 import pytest
@@ -6,22 +6,24 @@ from numpy.random import default_rng, Generator
 
 from ragas.run_config import RunConfig
 
-class RandomComparison(Protocol):
-    """Pytest fixture wrapper to check :py:cls:`numpy.random.Generator` object equivalence.
-    
-    Args:
-        rng_0 (numpy.random.Generator) : The first generator to compare with.
-        rng_1 (numpy.random.Generator) : The second generator to compare with.
-    
-    Returns:
-        bool: Whether the two generators are at the same state.
-
-    """
-    def __call__(self, a:Generator, b:Generator) -> bool: ...
+RandomComparison: TypeAlias = Callable[[Generator, Generator], bool]
 
 @pytest.fixture(scope="function")
-def compare_rng() -> RandomComparison:
+def compare_rng() -> Callable[[Generator, Generator], bool]:
+    """Pytest fixture wrapper to check :py:cls:`numpy.random.Generator` object equivalence.
+
+    """
     def _compare_rng(rng_0:Generator, rng_1:Generator) -> bool:
+        """Compare two :py:cls:`numpy.random.Generator`object.
+        
+        Args:
+            rng_0 (numpy.random.Generator) : The first generator to compare with.
+            rng_1 (numpy.random.Generator) : The second generator to compare with.
+
+        Returns:
+            bool: Whether the two generators are at the same state.
+                
+        """
         return rng_0.random() == rng_1.random()
     
     return _compare_rng


### PR DESCRIPTION
# Description
Previous exchanges about the `numpy.random.Generator` (#1140, #1142 and #1152) led to the need to implement some tests. Previous ones had been setup but a more precise definition of the context box might strengthen the confidence in the overall generation.

# Fonctionnality
Check the ability to generate a specific `numpy.random.Generator`, its fixed behaviour between generations and its consistency accross module reloads but also the actual random generation when the `seed` is set to `None`.

# Solution proposed
Pytest with 2 parametrized test: 1 with the `seed` fixed, the other one with `seed` set to `None`. Each test will check whether the generation is fixed, reproductible and consistent according to the seed.