### PR TITLE
solved issue that adaptation crashes when havig multiple nested promp…

### DIFF
--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -158,6 +158,10 @@ class Prompt(BaseModel):
             raise ValueError(
                 f"Input variables {self.input_keys} do not match with the given parameters {list(kwargs.keys())}"
             )
+        for key, value in kwargs.items():
+            if isinstance(value, str):
+                kwargs[key] = json.dumps(value)
+
         prompt = self.to_string()
         return PromptValue(prompt_str=prompt.format(**kwargs))
 


### PR DESCRIPTION
I have faced the issue that when I adapt some prompts, some of the key-value pairs are objects itself and then do not get stored properly. The adaptation does not fail, however, when loading those prompt, they break since they are not in proper json format. This fix solves this particular issue I am using json.dumps on those object to store json-conform strings.