### PR TITLE
Fix test command in development.md to match Makefile configuration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,7 +62,7 @@ make run-ci
 To run the test suite:
 
 ```bash
-make tests
+make test
 ```
 
 ## Documentation


### PR DESCRIPTION
The development.md file previously suggested using make tests to run the tests. However, the [Makefile](https://github.com/explodinggradients/ragas/blob/main/Makefile#L28C1-L28C19) does not include a target named tests, which results in the error make: Nothing to be done for 'tests'. This commit updates the documentation to reflect the correct command for running tests, ensuring alignment with the existing Makefile configuration.