### PR TITLE
Fix ensure_ascii for json.dumps

### DIFF
--- a/src/experimental/ragas_experimental/testset/extractors/base.py
+++ b/src/experimental/ragas_experimental/testset/extractors/base.py
@@ -25,7 +25,7 @@ class Extractor(ABC):
                 return await self.aextract_text(node.properties[self.attribute])
             elif self.attribute in node.properties["metadata"]:
                 return await self.aextract_text(
-                    json.dumps(node.properties["metadata"][self.attribute])
+                    json.dumps(node.properties["metadata"][self.attribute], ensure_ascii=False)
                 )
             else:
                 raise ValueError(f"Attribute {self.attribute} not found in node")
@@ -34,7 +34,7 @@ class Extractor(ABC):
                 return await self.aextract_text(node.page_content)
             elif self.attribute in node.metadata:
                 return await self.aextract_text(
-                    json.dumps(node.metadata[self.attribute])
+                    json.dumps(node.metadata[self.attribute], ensure_ascii=False)
                 )
             else:
                 raise ValueError(f"Attribute {self.attribute} not found in node")
@@ -45,7 +45,7 @@ class Extractor(ABC):
                 return self.extract_text(node.properties[self.attribute])
             elif self.attribute in node.properties["metadata"]:
                 return self.extract_text(
-                    json.dumps(node.properties["metadata"][self.attribute])
+                    json.dumps(node.properties["metadata"][self.attribute], ensure_ascii=False)
                 )
             else:
                 raise ValueError(f"Attribute {self.attribute} not found in node")
@@ -53,7 +53,7 @@ class Extractor(ABC):
             if self.attribute == "page_content":
                 return self.extract_text(node.page_content)
             elif self.attribute in node.metadata:
-                return self.extract_text(json.dumps(node.metadata[self.attribute]))
+                return self.extract_text(json.dumps(node.metadata[self.attribute], ensure_ascii=False))
             else:
                 raise ValueError(f"Attribute {self.attribute} not found in node")
 

--- a/src/experimental/ragas_experimental/testset/questions/abstract.py
+++ b/src/experimental/ragas_experimental/testset/questions/abstract.py
@@ -237,7 +237,7 @@ class AbstractQA(AbstractQuestions):
 
         query = LEAF_NODE_QUERY
         leaf_nodes = [
-            self.query_nodes(query, {"id": json.dumps(id)}) for id in node_ids
+            self.query_nodes(query, {"id": json.dumps(id, ensure_ascii=False)}) for id in node_ids
         ]
         leaf_nodes = [node for nodes in leaf_nodes for node in nodes]
         if leaf_nodes is None:
@@ -485,7 +485,7 @@ class ComparativeAbstractQA(AbstractQuestions):
 
         query = LEAF_NODE_QUERY
         leaf_nodes = [
-            self.query_nodes(query, {"id": json.dumps(id)}) for id in node_ids
+            self.query_nodes(query, {"id": json.dumps(id, ensure_ascii=False)}) for id in node_ids
         ]
         leaf_nodes = [node for nodes in leaf_nodes for node in nodes]
         leaf_nodes = [

--- a/src/ragas/_analytics.py
+++ b/src/ragas/_analytics.py
@@ -74,7 +74,7 @@ def get_userid() -> str:
         user_id = "a-" + uuid.uuid4().hex
         os.makedirs(user_id_path)
         with open(uuid_filepath, "w") as f:
-            json.dump({"userid": user_id}, f)
+            json.dump({"userid": user_id}, f, ensure_ascii=False)
     return user_id
 
 

--- a/src/ragas/llms/output_parser.py
+++ b/src/ragas/llms/output_parser.py
@@ -47,7 +47,7 @@ def get_json_format_instructions(pydantic_object: t.Type[TBaseModel]) -> str:
     if "title" in reduced_schema:
         del reduced_schema["title"]
     # Ensure json in context is well-formed with double quotes.
-    schema_str = json.dumps(reduced_schema)
+    schema_str = json.dumps(reduced_schema, ensure_ascii=False)
 
     resp = JSON_FORMAT_INSTRUCTIONS.format(schema=schema_str)
     return resp

--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -160,7 +160,7 @@ class Prompt(BaseModel):
             )
         for key, value in kwargs.items():
             if isinstance(value, str):
-                kwargs[key] = json.dumps(value)
+                kwargs[key] = json.dumps(value, ensure_ascii=False)
 
         prompt = self.to_string()
         return PromptValue(prompt_str=prompt.format(**kwargs))
@@ -277,7 +277,7 @@ class Prompt(BaseModel):
 
         cache_path = os.path.join(cache_dir, f"{self.name}.json")
         with open(cache_path, "w") as file:
-            json.dump(self.dict(), file, indent=4)
+            json.dump(self.dict(), file, indent=4, ensure_ascii=False)
 
     @classmethod
     def _load(cls, language: str, name: str, cache_dir: str) -> Prompt:

--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -202,7 +202,7 @@ class Faithfulness(MetricWithLLM):
         contexts = row["contexts"]
         # check if the statements are support in the contexts
         contexts_str: str = "\n".join(contexts)
-        statements_str: str = json.dumps(statements)
+        statements_str: str = json.dumps(statements, ensure_ascii=False)
         prompt_value = self.nli_statements_message.format(
             context=contexts_str, statements=statements_str
         )

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -90,7 +90,7 @@ def test_load_userid_from_json_file(tmp_path, monkeypatch):
     with open(userid_filepath, "w") as f:
         import json
 
-        json.dump({"userid": "test-userid"}, f)
+        json.dump({"userid": "test-userid"}, f, ensure_ascii=False)
 
     from ragas._analytics import get_userid
 


### PR DESCRIPTION
Hi! This PR simply fixes all `json.dumps`. With `ensure_ascii=False`, unicodes can be properly serialized into JSON files in the modern days when UTF-8 is basically universal. This may also prevent silent behavioral bugs from LLMs, since they can hardly understand literal strings like "\u00x" except common ones.

Some cases do not necessarily need `ensure_ascii=False`, but they are added for consistency.