### PR TITLE
fix : solves #1215 - Inconsistency in the Value of EVALMODE_TO_COLUMNS[EvaluationMode.ca]

### DIFF
--- a/src/ragas/validation.py
+++ b/src/ragas/validation.py
@@ -67,7 +67,7 @@ EVALMODE_TO_COLUMNS = {
     EvaluationMode.ga: ["ground_truth", "answer"],
     EvaluationMode.qga: ["question", "ground_truth", "answer"],
     EvaluationMode.qcg: ["question", "contexts", "ground_truth"],
-    EvaluationMode.ca: ["contexts", "summary"],
+    EvaluationMode.ca: ["contexts", "answer"],
 }
 
 


### PR DESCRIPTION
Sets `EVALMODE_TO_COLUMNS[EvaluationMode.ca] =  ["contexts", "answer"]` in `src/ragas/validation.py` to fix #1215.