### PR TITLE
Tiny typo fix: it's -> its

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -34,7 +34,7 @@ Retrieval augmented generation (RAG) is a paradigm for augmenting LLM with custo
 ```{rubric} Continual Learning
 ```
 
-Continual learning is concept used in machine learning that aims to learn, iterate and improve ML pipelines over it's lifetime using the insights derived from continuous stream of data points.  In LLM & RAGs, this can be applied by iterating and improving each components of LLM application from insights derived from production and feedback data.
+Continual learning is concept used in machine learning that aims to learn, iterate and improve ML pipelines over its lifetime using the insights derived from continuous stream of data points.  In LLM & RAGs, this can be applied by iterating and improving each components of LLM application from insights derived from production and feedback data.
 :::
 
 ::::{grid} 2


### PR DESCRIPTION
A non-urgent, non-critical fix from contraction to possessive.

Elsewhere there is also an "it's" in `Question: Where is France and what is it's capital?`, but since that's a prompt a human might reasonably type, and in the answer "its" is used correctly, I thought it didn't need to be fixed.