### PR TITLE
bugfix: fixed prompt adapt from English to other languages

### DIFF
--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -295,7 +295,7 @@ class Prompt(BaseModel):
 
         cache_path = os.path.join(cache_dir, f"{self.name}.json")
         with open(cache_path, "w") as file:
-            json.dump(self.dict(), file, indent=4)
+            json.dump(self.dict(), file, indent=4, ensure_ascii=False)
 
     @classmethod
     def _load(cls, language: str, name: str, cache_dir: str) -> Prompt:

--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -244,8 +244,8 @@ class Prompt(BaseModel):
                     # Extracting the dictionary part using string slicing
                     dict_str = example[-1].split("(")[0].strip()
                     example_dict[self.output_key] = ast.literal_eval(dict_str)
-                else:
-                    example_dict[self.output_key] = example[-1]
+            else:
+                example_dict[self.output_key] = example[-1]
             if self.output_type.lower() == "json":
                 output = example_dict[self.output_key]
                 if isinstance(output, dict):


### PR DESCRIPTION
Issue:

the adaptation failed to parse the result of translation, resulting the adapted prompts not usable.  Specifically:

-  A indentation error causes json loaded output to be overwritten by raw string, causing output for json in adaptation to be not readable

```
   ```json
   {
     "blah": 1
   }
   
```

- translation output for str_translation needs to be extracted before putting back to prompt. we fix it by cleaning llm translation output.
- the code assumes use str_translation for every value except output, it does not take care of contexts, which is an array of string. deal with translation for non-output items such as ```contexts: [ str1, str2, str3]```, fix with json_loader.

Solution:

- fix indentation error
- parse translation results correctly by only taking the translation result
- check field value, and use json_loader with json_translation when the value in original prompt is a list instead of str
