### PR TITLE
Fix: Preserve non ascii characters when json.dumps

### DIFF
--- a/src/experimental/ragas_experimental/testset/extractors/base.py
+++ b/src/experimental/ragas_experimental/testset/extractors/base.py
@@ -25,7 +25,7 @@ class Extractor(ABC):
                 return await self.aextract_text(node.properties[self.attribute])
             elif self.attribute in node.properties["metadata"]:
                 return await self.aextract_text(
-                    json.dumps(node.properties["metadata"][self.attribute])
+                    json.dumps(node.properties["metadata"][self.attribute], ensure_ascii=False)
                 )
             else:
                 raise ValueError(f"Attribute {self.attribute} not found in node")
@@ -34,7 +34,7 @@ class Extractor(ABC):
                 return await self.aextract_text(node.page_content)
             elif self.attribute in node.metadata:
                 return await self.aextract_text(
-                    json.dumps(node.metadata[self.attribute])
+                    json.dumps(node.metadata[self.attribute], ensure_ascii=False)
                 )
             else:
                 raise ValueError(f"Attribute {self.attribute} not found in node")
@@ -45,7 +45,7 @@ class Extractor(ABC):
                 return self.extract_text(node.properties[self.attribute])
             elif self.attribute in node.properties["metadata"]:
                 return self.extract_text(
-                    json.dumps(node.properties["metadata"][self.attribute])
+                    json.dumps(node.properties["metadata"][self.attribute], ensure_ascii=False)
                 )
             else:
                 raise ValueError(f"Attribute {self.attribute} not found in node")
@@ -53,7 +53,7 @@ class Extractor(ABC):
             if self.attribute == "page_content":
                 return self.extract_text(node.page_content)
             elif self.attribute in node.metadata:
-                return self.extract_text(json.dumps(node.metadata[self.attribute]))
+                return self.extract_text(json.dumps(node.metadata[self.attribute], ensure_ascii=False))
             else:
                 raise ValueError(f"Attribute {self.attribute} not found in node")
 

--- a/src/experimental/ragas_experimental/testset/questions/abstract.py
+++ b/src/experimental/ragas_experimental/testset/questions/abstract.py
@@ -237,7 +237,7 @@ class AbstractQA(AbstractQuestions):
 
         query = LEAF_NODE_QUERY
         leaf_nodes = [
-            self.query_nodes(query, {"id": json.dumps(id)}) for id in node_ids
+            self.query_nodes(query, {"id": json.dumps(id, ensure_ascii=False)}) for id in node_ids
         ]
         leaf_nodes = [node for nodes in leaf_nodes for node in nodes]
         if leaf_nodes is None:
@@ -485,7 +485,7 @@ class ComparativeAbstractQA(AbstractQuestions):
 
         query = LEAF_NODE_QUERY
         leaf_nodes = [
-            self.query_nodes(query, {"id": json.dumps(id)}) for id in node_ids
+            self.query_nodes(query, {"id": json.dumps(id, ensure_ascii=False)}) for id in node_ids
         ]
         leaf_nodes = [node for nodes in leaf_nodes for node in nodes]
         leaf_nodes = [

--- a/src/ragas/llms/output_parser.py
+++ b/src/ragas/llms/output_parser.py
@@ -47,7 +47,7 @@ def get_json_format_instructions(pydantic_object: t.Type[TBaseModel]) -> str:
     if "title" in reduced_schema:
         del reduced_schema["title"]
     # Ensure json in context is well-formed with double quotes.
-    schema_str = json.dumps(reduced_schema)
+    schema_str = json.dumps(reduced_schema, ensure_ascii=False)
 
     resp = JSON_FORMAT_INSTRUCTIONS.format(schema=schema_str)
     return resp

--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -160,7 +160,7 @@ class Prompt(BaseModel):
             )
         for key, value in kwargs.items():
             if isinstance(value, str):
-                kwargs[key] = json.dumps(value)
+                kwargs[key] = json.dumps(value, ensure_ascii=False)
 
         prompt = self.to_string()
         return PromptValue(prompt_str=prompt.format(**kwargs))

--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -200,7 +200,7 @@ class Faithfulness(MetricWithLLM):
         contexts = row["contexts"]
         # check if the statements are support in the contexts
         contexts_str: str = "\n".join(contexts)
-        statements_str: str = json.dumps(statements)
+        statements_str: str = json.dumps(statements, ensure_ascii=False)
         prompt_value = self.nli_statements_message.format(
             context=contexts_str, statements=statements_str
         )

--- a/src/ragas/metrics/_noise_sensitivity.py
+++ b/src/ragas/metrics/_noise_sensitivity.py
@@ -70,7 +70,7 @@ class NoiseSensitivity(MetricWithLLM):
     def _create_nli_prompt(self, contexts: str, statements: t.List[str]) -> PromptValue:
         assert self.llm is not None, "llm must be set to compute score"
 
-        statements_str: str = json.dumps(statements)
+        statements_str: str = json.dumps(statements, ensure_ascii=False)
         prompt_value = self.nli_statements_message.format(
             context=contexts, statements=statements_str
         )


### PR DESCRIPTION

#### Description
This pull request addresses an issue related to the use of the `json.dumps` method in the prompt construction process. Currently, the `ensure_ascii` parameter is not set, which results in non-ASCII characters being escaped in the `\uXXXX` format. This can hinder the LLM's ability to understand the intended language meaning.

#### Changes Made
- Updated the `json.dumps` method calls to include the parameter `ensure_ascii=False`. This change will retain non-ASCII characters in their original form, improving the LLM's comprehension of the input.

#### Impact
By allowing non-ASCII characters to remain unescaped, this modification will enhance the language processing capabilities of our model, leading to more accurate interpretations.

#### Sample Code
```python
from ragas.metrics import context_recall

print(context_recall.context_recall_prompt.format(
    question='超级碗第一次举办是在什么时候 xx सूरज को क्या चलाता',
    context="\n".join(['第一次AFL–NFL世界冠军赛是一场美式足球比赛，于1967年1月15日在洛杉矶纪念体育场举行，位于洛杉矶。']),
    answer='第一次超级碗于1967年1月15日举行'
).to_string())
```
**Before**
```
...
Your actual task:

question: "\u8d85\u7ea7\u7897\u7b2c\u4e00\u6b21\u4e3e\u529e\u662f\u5728\u4ec0\u4e48\u65f6\u5019 xx \u0938\u0942\u0930\u091c \u0915\u094b \u0915\u094d\u092f\u093e \u091a\u0932\u093e\u0924\u093e"
context: "\u7b2c\u4e00\u6b21AFL\u2013NFL\u4e16\u754c\u51a0\u519b\u8d5b\u662f\u4e00\u573a\u7f8e\u5f0f\u8db3\u7403\u6bd4\u8d5b\uff0c\u4e8e1967\u5e741\u670815\u65e5\u5728\u6d1b\u6749\u77f6\u7eaa\u5ff5\u4f53\u80b2\u573a\u4e3e\u884c\uff0c\u4f4d\u4e8e\u6d1b\u6749\u77f6\u3002"
answer: "\u7b2c\u4e00\u6b21\u8d85\u7ea7\u7897\u4e8e1967\u5e741\u670815\u65e5\u4e3e\u884c"
classification: 
```
**After**
```
...
Your actual task:

question: "超级碗第一次举办是在什么时候 xx सूरज को क्या चलाता"
context: "第一次AFL–NFL世界冠军赛是一场美式足球比赛，于1967年1月15日在洛杉矶纪念体育场举行，位于洛杉矶。"
answer: "第一次超级碗于1967年1月15日举行"
classification: 
```
Please let me know if there are any questions or further changes needed.