### PR TITLE
Add option to disable progress bar in `evaluate`

### DIFF
--- a/src/ragas/evaluation.py
+++ b/src/ragas/evaluation.py
@@ -66,6 +66,7 @@ def evaluate(
     token_usage_parser: t.Optional[TokenUsageParser] = None,
     raise_exceptions: bool = False,
     column_map: t.Optional[t.Dict[str, str]] = None,
+    show_progress: bool = True,
 ) -> Result:
     """
     Run the evaluation on the dataset with different metrics
@@ -109,6 +110,8 @@ def evaluate(
         the dataset are different from the default ones then you can provide the
         mapping as a dictionary here. Example: If the dataset column name is contexts_v1,
         column_map can be given as {"contexts":"contexts_v1"}
+    show_progress: bool, optional
+        Whether to show the progress bar during evaluation. If set to False, the progress bar will be disabled. Default is True.
 
     Returns
     -------
@@ -223,6 +226,7 @@ def evaluate(
         keep_progress_bar=True,
         raise_exceptions=raise_exceptions,
         run_config=run_config,
+        show_progress=show_progress,
     )
 
     # Ragas Callbacks

--- a/src/ragas/executor.py
+++ b/src/ragas/executor.py
@@ -42,6 +42,7 @@ def as_completed(coros, max_workers):
 class Executor:
     desc: str = "Evaluating"
     keep_progress_bar: bool = True
+    show_progress: bool = True
     jobs: t.List[t.Any] = field(default_factory=list, repr=False)
     raise_exceptions: bool = False
     run_config: t.Optional[RunConfig] = field(default=None, repr=False)
@@ -107,6 +108,7 @@ class Executor:
                 total=len(self.jobs),
                 # whether you want to keep the progress bar after completion
                 leave=self.keep_progress_bar,
+                disable=not self.show_progress,
             ):
                 r = await future
                 results.append(r)


### PR DESCRIPTION
Hello there :wave: I noticed that there was no way to disable the progress bar and thought it'd nice to have the option to silence the `tqdm` call in the executor, as it doesn’t play nicely with logs and adds noise.

I've added the following changes:

Add `show_progress` flag to `Executor` class and update `evaluate` function to use it.

* **Executor Class Changes:**
  - Add `show_progress` flag to the `Executor` class in `src/ragas/executor.py`.
  - Use the `show_progress` flag to control the display of the progress bar.
  - If `show_progress` is set to False, disable `tqdm` usage for displaying progress bars.

* **Evaluate Function Changes:**
  - Add `show_progress` parameter to the `evaluate` function in `src/ragas/evaluation.py`.
  - Pass the `show_progress` flag to the `Executor` class during initialization in the `evaluate` function.

