### PR TITLE
Fix wrong input key name

### DIFF
--- a/src/ragas/experimental/metrics/_faithfulness.py
+++ b/src/ragas/experimental/metrics/_faithfulness.py
@@ -163,7 +163,7 @@ class FaithfulnessExperimental(MetricWithLLM, SingleTurnMetric):
     name: str = "faithfulness_experimental"  # type: ignore
     _required_columns: t.Dict[MetricType, t.Set[str]] = field(
         default_factory=lambda: {
-            MetricType.SINGLE_TURN: {"user_input", "response", "retreived_contexts"}
+            MetricType.SINGLE_TURN: {"user_input", "response", "retrieved_contexts"}
         }
     )
     sentence_segmenter: t.Optional[HasSegmentMethod] = None

--- a/src/ragas/metrics/_context_precision.py
+++ b/src/ragas/metrics/_context_precision.py
@@ -209,7 +209,7 @@ class LLMContextPrecisionWithoutReference(LLMContextPrecisionWithReference):
     name: str = "llm_context_precision_without_reference"
     _required_columns: t.Dict[MetricType, t.Set[str]] = field(
         default_factory=lambda: {
-            MetricType.SINGLE_TURN: {"user_input", "response", "retreived_contexts"}
+            MetricType.SINGLE_TURN: {"user_input", "response", "retrieved_contexts"}
         }
     )
 


### PR DESCRIPTION
ValueError: The metric [context_utilization] that that is used requires the following additional columns ['retreived_contexts'] to be present in the dataset.