### PR TITLE
Fixed the issue of changing to Unicode characters in the json.dumps

### DIFF
--- a/src/ragas/dataset_schema.py
+++ b/src/ragas/dataset_schema.py
@@ -87,7 +87,7 @@ class EvaluationDataset(BaseModel):
             for sample in rows:
                 for item in sample["user_input"]:
                     if not isinstance(item["content"], str):
-                        item["content"] = json.dumps(item["content"])
+                        item["content"] = json.dumps(item["content"], ensure_ascii=False)
 
         return Dataset.from_list(rows)
 

--- a/src/ragas/llms/output_parser.py
+++ b/src/ragas/llms/output_parser.py
@@ -47,7 +47,7 @@ def get_json_format_instructions(pydantic_object: t.Type[TBaseModel]) -> str:
     if "title" in reduced_schema:
         del reduced_schema["title"]
     # Ensure json in context is well-formed with double quotes.
-    schema_str = json.dumps(reduced_schema)
+    schema_str = json.dumps(reduced_schema, ensure_ascii=False)
 
     resp = JSON_FORMAT_INSTRUCTIONS.format(schema=schema_str)
     return resp

--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -160,7 +160,7 @@ class Prompt(BaseModel):
             )
         for key, value in kwargs.items():
             if isinstance(value, str):
-                kwargs[key] = json.dumps(value)
+                kwargs[key] = json.dumps(value, ensure_ascii=False)
 
         prompt = self.to_string()
         return PromptValue(prompt_str=prompt.format(**kwargs))
@@ -277,7 +277,7 @@ class Prompt(BaseModel):
 
         cache_path = os.path.join(cache_dir, f"{self.name}.json")
         with open(cache_path, "w") as file:
-            json.dump(self.dict(), file, indent=4)
+            json.dump(self.dict(), file, indent=4, ensure_ascii=False)
 
     @classmethod
     def _load(cls, language: str, name: str, cache_dir: str) -> Prompt:

--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -215,7 +215,7 @@ class Faithfulness(MetricWithLLM, SingleTurnMetric):
         contexts = row["retrieved_contexts"]
         # check if the statements are support in the contexts
         contexts_str: str = "\n".join(contexts)
-        statements_str: str = json.dumps(statements)
+        statements_str: str = json.dumps(statements, ensure_ascii=False)
         prompt_value = self.nli_statements_message.format(
             context=contexts_str, statements=statements_str
         )

--- a/src/ragas/metrics/_noise_sensitivity.py
+++ b/src/ragas/metrics/_noise_sensitivity.py
@@ -86,7 +86,7 @@ class NoiseSensitivity(MetricWithLLM, SingleTurnMetric):
     def _create_nli_prompt(self, contexts: str, statements: t.List[str]) -> PromptValue:
         assert self.llm is not None, "llm must be set to compute score"
 
-        statements_str: str = json.dumps(statements)
+        statements_str: str = json.dumps(statements, ensure_ascii=False)
         prompt_value = self.nli_statements_message.format(
             context=contexts, statements=statements_str
         )


### PR DESCRIPTION
When using json.dumps, if the character is not an ASCII character, it is converted to a Unicode character and output or passed to LLM. Due to this issue, LLM is unable to respond properly.

Added ensure_ascii=False option to output Unicode characters literally.