### PR TITLE
fix: pin langchain_core to <3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dependencies = [
     "datasets",
     "tiktoken",
     "langchain",
-    "langchain-core<3",
+    "langchain-core<0.3",
     "langchain-community",
     "langchain_openai",
     "openai>1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dependencies = [
     "datasets",
     "tiktoken",
     "langchain",
-    "langchain-core",
+    "langchain-core<3",
     "langchain-community",
     "langchain_openai",
     "openai>1",

--- a/src/ragas/integrations/opik.py
+++ b/src/ragas/integrations/opik.py
@@ -1,9 +1,9 @@
 import typing as t
 
 try:
-    from opik.integrations.langchain import (
+    from opik.integrations.langchain import (  # type: ignore
         OpikTracer as LangchainOpikTracer,
-    )  # type: ignore
+    )
 
     from ragas.evaluation import RAGAS_EVALUATION_CHAIN_NAME
 except ImportError:
@@ -32,7 +32,7 @@ class OpikTracer(LangchainOpikTracer):
     def _process_start_trace(self, run: "Run"):
         if (run.parent_run_id is None) and (run.name == RAGAS_EVALUATION_CHAIN_NAME):
             # Store the evaluation run id so we can flag the child traces and log them independently
-            self._evaluation_run_id = run.id
+            self._evaluation_run_id = str(run.id)
         else:
             if run.parent_run_id == self._evaluation_run_id:
                 run.parent_run_id = None


### PR DESCRIPTION
The new langchain v0.3 will break the current usage of metrics. 

the plan for actions is as follows
1. for ragas<0.2 we will pin langchain_core to <0.3
2. for ragas>0.2 we will directly depend on pydantic>=2

fixes: #1328 