### PR TITLE
wrap as_complete with async

### DIFF
--- a/src/ragas/executor.py
+++ b/src/ragas/executor.py
@@ -23,7 +23,7 @@ def is_event_loop_running() -> bool:
         return loop.is_running()
 
 
-def as_completed(coros, max_workers):
+async def as_completed(coros, max_workers):
     if max_workers == -1:
         return asyncio.as_completed(coros)
 
@@ -103,7 +103,7 @@ class Executor:
         async def _aresults() -> t.List[t.Any]:
             results = []
             for future in tqdm(
-                futures_as_they_finish,
+                await futures_as_they_finish,
                 desc=self.desc,
                 total=len(self.jobs),
                 # whether you want to keep the progress bar after completion

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -82,7 +82,7 @@ def test_as_completed_in_script():
 
     async def _run():
         results = []
-        for t in as_completed([echo_order(1), echo_order(2), echo_order(3)], 3):
+        for t in await as_completed([echo_order(1), echo_order(2), echo_order(3)], 3):
             r = await t
             results.append(r)
         return results

--- a/tests/unit/test_executor_in_jupyter.ipynb
+++ b/tests/unit/test_executor_in_jupyter.ipynb
@@ -66,7 +66,7 @@
     "\n",
     "async def _run():\n",
     "    results = []\n",
-    "    for t in as_completed([echo_order(1), echo_order(2), echo_order(3)], 3):\n",
+    "    for t in await as_completed([echo_order(1), echo_order(2), echo_order(3)], 3):\n",
     "        r = await t\n",
     "        results.append(r)\n",
     "    return results\n",


### PR DESCRIPTION
Originally as_complete is not defined with async, the asyncio.Semaphore is created in main thread not in asynci.run. This will cause 'There is no event loop' error when: 
1. len(coros) is more than max_workers; 
2. run 'evalute' function at the second time and nest_asyncio is not applied.