### PR TITLE
fix: fixed verdict comparison in evolutions.py

### DIFF
--- a/src/ragas/testset/evolutions.py
+++ b/src/ragas/testset/evolutions.py
@@ -237,7 +237,7 @@ class Evolution:
         answer = answer if isinstance(answer, dict) else {}
         logger.debug("answer generated: %s", answer)
         answer = (
-            np.nan if answer.get("verdict") == "-1" else answer.get("answer", np.nan)
+            np.nan if answer.get("verdict") == -1 else answer.get("answer", np.nan)
         )
 
         return DataRow(


### PR DESCRIPTION
The bug is located in the ragas.testset.Evolution class. The problem is that you are checking the ‘verdict’ field against a string value of ‘-1’, and you need to compare it against an int value of -1:
![{629CB6B1-CCF2-4FD0-988E-60BE9635D6FA}](https://github.com/user-attachments/assets/b7fc05c9-826e-426d-886a-cf5837cd7dca)
![{0CD30A93-DBB5-49AA-833D-1169960D694E}](https://github.com/user-attachments/assets/2b8f52b7-e9a6-4f09-88d8-d6cdccb6b916)

So I changed the verdict comparison from a string to an integer in the conditional check.