### PR TITLE
Update models in Ragas documentation: change gpt-3.5-turbo-16k to gpt-4o-mini and gpt-4 to gpt-4o

### DIFF
--- a/docs/concepts/testset_generation.md
+++ b/docs/concepts/testset_generation.md
@@ -61,8 +61,8 @@ from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 # documents = load your documents
 
 # generator with openai models
-generator_llm = ChatOpenAI(model="gpt-3.5-turbo-16k")
-critic_llm = ChatOpenAI(model="gpt-4")
+generator_llm = ChatOpenAI(model="gpt-4o-mini")
+critic_llm = ChatOpenAI(model="gpt-4o")
 embeddings = OpenAIEmbeddings()
 
 generator = TestsetGenerator.from_langchain(

--- a/docs/howtos/applications/compare_embeddings.md
+++ b/docs/howtos/applications/compare_embeddings.md
@@ -34,8 +34,8 @@ query_space = "large language models"
 documents = loader.load_data(query=query_space, limit=100)
 
 # generator with openai models
-generator_llm = ChatOpenAI(model="gpt-3.5-turbo-16k")
-critic_llm = ChatOpenAI(model="gpt-4")
+generator_llm = ChatOpenAI(model="gpt-4o-mini")
+critic_llm = ChatOpenAI(model="gpt-4o")
 embeddings = OpenAIEmbeddings()
 
 generator = TestsetGenerator.from_langchain(

--- a/docs/howtos/applications/compare_llms.md
+++ b/docs/howtos/applications/compare_llms.md
@@ -42,8 +42,8 @@ reader = SimpleDirectoryReader("./arxiv-papers/",num_files_limit=30)
 documents = reader.load_data()
 
 # generator with openai models
-generator_llm = ChatOpenAI(model="gpt-3.5-turbo-16k")
-critic_llm = ChatOpenAI(model="gpt-4")
+generator_llm = ChatOpenAI(model="gpt-4o-mini")
+critic_llm = ChatOpenAI(model="gpt-4o")
 embeddings = OpenAIEmbeddings()
 
 generator = TestsetGenerator.from_langchain(

--- a/docs/howtos/applications/use_prompt_adaptation.md
+++ b/docs/howtos/applications/use_prompt_adaptation.md
@@ -127,8 +127,8 @@ from ragas.testset.evolutions import simple, reasoning, multi_context,conditiona
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
 # generator with openai models
-generator_llm = ChatOpenAI(model="gpt-3.5-turbo-16k")
-critic_llm = ChatOpenAI(model="gpt-4")
+generator_llm = ChatOpenAI(model="gpt-4o-mini")
+critic_llm = ChatOpenAI(model="gpt-4o")
 embeddings = OpenAIEmbeddings()
 
 generator = TestsetGenerator.from_langchain(


### PR DESCRIPTION
According to the OpenAI API reference, As of July 2024, gpt-4o-mini should be used in place of gpt-3.5-turbo, as it is cheaper, more capable, multimodal, and just as fast. gpt-3.5-turbo is still available for use in the API, but the advantages of gpt-4o-mini make it a better choice.

Additionally, the cost of using gpt-4 in the API is too high. Switching to gpt-4o is a more economical option without compromising performance. Personally, I had a significant chunk of my credits consumed due to the high cost of gpt-4 😢.