### PR TITLE
Fix typo in metric error message

### DIFF
--- a/src/ragas/validation.py
+++ b/src/ragas/validation.py
@@ -60,7 +60,7 @@ def validate_required_columns(ds: EvaluationDataset, metrics: list[Metric]):
         available_columns = ds.features()
         if not required_columns.issubset(available_columns):
             raise ValueError(
-                f"The metric [{m.name}] that that is used requires the following "
+                f"The metric [{m.name}] that is used requires the following "
                 f"additional columns {list(required_columns - available_columns)} "
                 f"to be present in the dataset."
             )


### PR DESCRIPTION
This pull request addresses a minor typo in the error message related to metric validation. The message previously contained a duplicated "that," which has been corrected for clarity.