### PR TITLE
fix key error for FaithfulnesswithHHEM

### DIFF
--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -353,7 +353,7 @@ class FaithfulnesswithHHEM(Faithfulness):
         """
         create pairs of (question, answer) from the row
         """
-        premise = "\n".join(row["contexts"])
+        premise = "\n".join(row["retrieved_contexts"])
         pairs = [(premise, statement) for statement in statements]
         return pairs
 


### PR DESCRIPTION
The current implementation for evaluating FaithfullnessWithHHEM requires legacy 'contexts' key and would throw out key error. This simple fix would resolve the issue.