### PR TITLE
Update Bedrock modules for LangChain v0.3.x

### DIFF
--- a/docs/extra/components/choose_evaluvator_llm.md
+++ b/docs/extra/components/choose_evaluvator_llm.md
@@ -21,19 +21,20 @@
     config = {
         "credentials_profile_name": "your-profile-name",  # E.g "default"
         "region_name": "your-region-name",  # E.g. "us-east-1"
-        "model_id": "your-model-id",  # E.g "anthropic.claude-v2"
-        "model_kwargs": {"temperature": 0.4},
+        "llm": "your-llm-model-id",  # E.g "anthropic.claude-v2"
+        "embeddings": "your-embedding-model-id",  # E.g "amazon.titan-embed-text-v2:0"
+        "temperature": 0.4,
     }
     ```
     define you LLMs
     ```python
-    from langchain_aws.chat_models import BedrockChat
+    from langchain_aws import ChatBedrockConverse
     from ragas.llms import LangchainLLMWrapper
-    evaluator_llm = LangchainLLMWrapper(BedrockChat(
+    evaluator_llm = LangchainLLMWrapper(ChatBedrockConverse(
         credentials_profile_name=config["credentials_profile_name"],
         region_name=config["region_name"],
-        endpoint_url=f"https://bedrock-runtime.{config['region_name']}.amazonaws.com",
-        model_id=config["model_id"],
-        model_kwargs=config["model_kwargs"],
+        base_url=f"https://bedrock-runtime.{config['region_name']}.amazonaws.com",
+        model=config["llm"],
+        temperature=config["temperature"],
     ))
     ```

--- a/docs/extra/components/choose_evaluvator_llm.md
+++ b/docs/extra/components/choose_evaluvator_llm.md
@@ -21,7 +21,7 @@
     config = {
         "credentials_profile_name": "your-profile-name",  # E.g "default"
         "region_name": "your-region-name",  # E.g. "us-east-1"
-        "llm": "your-llm-model-id",  # E.g "anthropic.claude-v2"
+        "llm": "your-llm-model-id",  # E.g "anthropic.claude-3-5-sonnet-20240620-v1:0"
         "embeddings": "your-embedding-model-id",  # E.g "amazon.titan-embed-text-v2:0"
         "temperature": 0.4,
     }

--- a/docs/howtos/customizations/customize_models.md
+++ b/docs/howtos/customizations/customize_models.md
@@ -96,9 +96,13 @@ Yay! Now are you ready to use ragas with Google VertexAI endpoints
 
 ### AWS Bedrock
 
+```bash
+pip install langchain_aws
+```
+
 ```python
-from langchain_community.chat_models import BedrockChat
-from langchain_community.embeddings import BedrockEmbeddings
+from langchain_aws import ChatBedrock
+from langchain_aws import BedrockEmbeddings
 from ragas.llms import LangchainLLMWrapper
 from ragas.embeddings import LangchainEmbeddingsWrapper
 
@@ -109,7 +113,7 @@ config = {
     "model_kwargs": {"temperature": 0.4},
 }
 
-bedrock_llm = BedrockChat(
+bedrock_llm = ChatBedrock(
     credentials_profile_name=config["credentials_profile_name"],
     region_name=config["region_name"],
     endpoint_url=f"https://bedrock-runtime.{config['region_name']}.amazonaws.com",

--- a/docs/howtos/customizations/customize_models.md
+++ b/docs/howtos/customizations/customize_models.md
@@ -101,7 +101,7 @@ pip install langchain_aws
 ```
 
 ```python
-from langchain_aws import ChatBedrock
+from langchain_aws import ChatBedrockConverse
 from langchain_aws import BedrockEmbeddings
 from ragas.llms import LangchainLLMWrapper
 from ragas.embeddings import LangchainEmbeddingsWrapper
@@ -109,22 +109,24 @@ from ragas.embeddings import LangchainEmbeddingsWrapper
 config = {
     "credentials_profile_name": "your-profile-name",  # E.g "default"
     "region_name": "your-region-name",  # E.g. "us-east-1"
-    "model_id": "your-model-id",  # E.g "anthropic.claude-v2"
-    "model_kwargs": {"temperature": 0.4},
+    "llm": "your-llm-model-id",  # E.g "anthropic.claude-v2"
+    "embeddings": "your-embedding-model-id",  # E.g "amazon.titan-embed-text-v2:0"
+    "temperature": 0.4,
 }
 
-bedrock_llm = ChatBedrock(
+bedrock_llm = ChatBedrockConverse(
     credentials_profile_name=config["credentials_profile_name"],
     region_name=config["region_name"],
-    endpoint_url=f"https://bedrock-runtime.{config['region_name']}.amazonaws.com",
-    model_id=config["model_id"],
-    model_kwargs=config["model_kwargs"],
+    base_url=f"https://bedrock-runtime.{config['region_name']}.amazonaws.com",
+    model=config["llm"],
+    temperature=config["temperature"],
 )
 
 # init the embeddings
 bedrock_embeddings = BedrockEmbeddings(
     credentials_profile_name=config["credentials_profile_name"],
     region_name=config["region_name"],
+    model_id=config["embeddings"],
 )
 
 bedrock_llm = LangchainLLMWrapper(bedrock_llm)

--- a/docs/howtos/customizations/customize_models.md
+++ b/docs/howtos/customizations/customize_models.md
@@ -109,7 +109,7 @@ from ragas.embeddings import LangchainEmbeddingsWrapper
 config = {
     "credentials_profile_name": "your-profile-name",  # E.g "default"
     "region_name": "your-region-name",  # E.g. "us-east-1"
-    "llm": "your-llm-model-id",  # E.g "anthropic.claude-v2"
+    "llm": "your-llm-model-id",  # E.g "anthropic.claude-3-5-sonnet-20240620-v1:0"
     "embeddings": "your-embedding-model-id",  # E.g "amazon.titan-embed-text-v2:0"
     "temperature": 0.4,
 }


### PR DESCRIPTION
Updating LangChain modules for Amazon Bedrock (AWS) in "customizations" section.

- Use `langchain_aws` instead of `langchain_community.`
- Use `ChatBedrock` instead of `BedrockChat`