### PR TITLE
Fixed an issue where non-ASCII characters were changed to Unicode characters within the prompt

### DIFF
--- a/src/ragas/llms/output_parser.py
+++ b/src/ragas/llms/output_parser.py
@@ -47,7 +47,7 @@ def get_json_format_instructions(pydantic_object: t.Type[TBaseModel]) -> str:
     if "title" in reduced_schema:
         del reduced_schema["title"]
     # Ensure json in context is well-formed with double quotes.
-    schema_str = json.dumps(reduced_schema)
+    schema_str = json.dumps(reduced_schema, ensure_ascii=False)
 
     resp = JSON_FORMAT_INSTRUCTIONS.format(schema=schema_str)
     return resp

--- a/src/ragas/llms/prompt.py
+++ b/src/ragas/llms/prompt.py
@@ -160,7 +160,7 @@ class Prompt(BaseModel):
             )
         for key, value in kwargs.items():
             if isinstance(value, str):
-                kwargs[key] = json.dumps(value)
+                kwargs[key] = json.dumps(value, ensure_ascii=False).encode("utf8").decode()
 
         prompt = self.to_string()
         return PromptValue(prompt_str=prompt.format(**kwargs))


### PR DESCRIPTION
- There is an issue where non-ASCII characters are converted to Unicode characters within the prompt.
- Due to this issue, Users that use non-English characters will receive an abnormal response when communicating with LLM.
- This issue can be resolved by adding the ensure_ascii=False option when using the json.dumps function.