### PR TITLE
docs: update summarization calculation

### DIFF
--- a/docs/concepts/metrics/available_metrics/summarization_score.md
+++ b/docs/concepts/metrics/available_metrics/summarization_score.md
@@ -23,8 +23,8 @@ We also provide a coefficient `coeff`(default value 0.5) to control the weightag
 The final summarization score is then calculated as:
 
 $$
-\text{Summarization Score} = \text{QA score}*\text{coeff} + \\
-\text{conciseness score}*\text{(1-coeff)}
+\text{Summarization Score} = \text{QA score}*\text{(1-coeff)} + \\
+\text{conciseness score}*\text{coeff}
 $$
 
 ## Example


### PR DESCRIPTION
There is mismatch how coeff is used in docs vs actual computation.

Related code is in:
https://github.com/explodinggradients/ragas/blob/889fe2b9181baf203ca96fa876a54c7d80989767/src/ragas/metrics/_summarization.py#L189

![Screenshot 2024-10-15 at 17 29 16](https://github.com/user-attachments/assets/3d987aaf-656f-4e10-ba84-1ee0bc2fa44a)
