### PR TITLE
fix: propagate callbacks in RagasOutputParser

### DIFF
--- a/src/ragas/prompt/pydantic_prompt.py
+++ b/src/ragas/prompt/pydantic_prompt.py
@@ -396,6 +396,7 @@ class RagasOutputParser(PydanticOutputParser[OutputModel]):
                         output_string=output_string,
                         prompt_value=prompt_value.to_string(),
                     ),
+                    callbacks=retry_cb
                 )
                 retry_rm.on_chain_end({"fixed_output_string": fixed_output_string})
                 return await self.parse_output_string(

--- a/src/ragas/prompt/pydantic_prompt.py
+++ b/src/ragas/prompt/pydantic_prompt.py
@@ -396,7 +396,7 @@ class RagasOutputParser(PydanticOutputParser[OutputModel]):
                         output_string=output_string,
                         prompt_value=prompt_value.to_string(),
                     ),
-                    callbacks=retry_cb
+                    callbacks=retry_cb,
                 )
                 retry_rm.on_chain_end({"fixed_output_string": fixed_output_string})
                 return await self.parse_output_string(


### PR DESCRIPTION
Callbacks are now correctly passed to `fix_output_format_prompt.generate()` during output format fixing in `RagasOutputParser`.