### PR TITLE
fix: import of EvaluationDataset in testset_schema

### DIFF
--- a/src/ragas/testset/synthesizers/testset_schema.py
+++ b/src/ragas/testset/synthesizers/testset_schema.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import typing as t
 
-from ragas.dataset_schema import BaseSample, RagasDataset
+from ragas.dataset_schema import BaseSample, RagasDataset, EvaluationDataset
 
 if t.TYPE_CHECKING:
     from ragas.dataset_schema import (
-        EvaluationDataset,
         MultiTurnSample,
         SingleTurnSample,
     )


### PR DESCRIPTION
`EvaluationDataset` is imported only for type checking, but it is required in runtime for `Testset.to_evaluation_dataset`.

fixes #1515