### PR TITLE
feat: use ensure_ascii=False for KnowledgeGraph files

### DIFF
--- a/src/ragas/testset/graph.py
+++ b/src/ragas/testset/graph.py
@@ -181,7 +181,7 @@ class KnowledgeGraph:
             "relationships": [rel.model_dump() for rel in self.relationships],
         }
         with open(path, "w") as f:
-            json.dump(data, f, cls=UUIDEncoder, indent=2)
+            json.dump(data, f, cls=UUIDEncoder, indent=2, ensure_ascii=False)
 
     @classmethod
     def load(cls, path: t.Union[str, Path]) -> "KnowledgeGraph":


### PR DESCRIPTION
To avoid \u escape sequences in KnowledgeGraph json files and have clean readable text for non-ASCII chars.

related to #1022