### PR TITLE
fixbug: Expand sentence-ending punctuation check in _create_statements method

### DIFF
--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -243,7 +243,7 @@ class Faithfulness(MetricWithLLM, SingleTurnMetric):
         sentences_with_index = {
             i: sentence
             for i, sentence in enumerate(sentences)
-            if sentence.strip().endswith(".")
+            if sentence.strip().endswith(('.', '。', '!', '！'))
         }
 
         statements_simplified = await self.statement_prompt.generate(


### PR DESCRIPTION
**Description**

This pull request addresses an issue where non-English punctuation (e.g., "。", "！") was not properly handled in the `_create_statements` function, causing sentences in languages like Chinese to be ignored and potentially leading to incorrect faithfulness scores.

**Changes Made**

Updated the condition:

```python
if sentence.strip().endswith("."):
```

to

```python
if sentence.strip().endswith(('.', '。', '!', '！')):
```

This ensures that sentences with non-English punctuation are included in the processing.

**Impact**

This change allows the system to correctly process sentences in languages like Chinese, preventing empty `sentences_with_index` variables and ensuring accurate faithfulness scores.

---

Let me know if this works or if you need further edits! Thanks!