### PR TITLE
doc: Update modifying prompts metrics doc

### DIFF
--- a/docs/howtos/customizations/metrics/_modifying-prompts-metrics.md
+++ b/docs/howtos/customizations/metrics/_modifying-prompts-metrics.md
@@ -34,7 +34,7 @@ print(prompts["single_turn_prompt"].to_string())
 
 
 ### Modifying instruction in default prompt
-It is highly likely that one might to modify the prompt to suit ones needs. Ragas provides `set_prompts` methods to allow you to do so. Let's change the one of the prompts used in `FactualCorrectness` metrics
+It is highly likely that one might want to modify the prompt to suit ones needs. Ragas provides `set_prompts` methods to allow you to do so. Let's change the one of the prompts used in `FactualCorrectness` metrics
 
 
 ```python
@@ -55,7 +55,6 @@ print(scorer.get_prompts()["single_turn_prompt"].instruction)
 ```
 
     Given a input, system response and reference. Evaluate and score the response against the reference only using the given criteria.
-    Only output valid JSON.
     Only output valid JSON.
 
 

--- a/docs/howtos/customizations/metrics/modifying-prompts-metrics.ipynb
+++ b/docs/howtos/customizations/metrics/modifying-prompts-metrics.ipynb
@@ -72,7 +72,7 @@
    "metadata": {},
    "source": [
     "### Modifying instruction in default prompt\n",
-    "It is highly likely that one might to modify the prompt to suit ones needs. Ragas provides `set_prompts` methods to allow you to do so. Let's change the one of the prompts used in `FactualCorrectness` metrics"
+    "It is highly likely that one might want to modify the prompt to suit ones needs. Ragas provides `set_prompts` methods to allow you to do so. Let's change the one of the prompts used in `FactualCorrectness` metrics"
    ]
   },
   {


### PR DESCRIPTION
## Description
- Remove extra text from output example
- Add missing `want` into the sentence

### Target Document
`docs/howtos/customizations/metrics/_modifying-prompts-metrics.md`

## Screenshots
- Only 1 `Only output valid JSON.` should be part of the output.

![image](https://github.com/user-attachments/assets/6428f8c6-4835-4681-8f1f-8af8f3c9709f)
