### PR TITLE
feat: translate instruction when adapting prompt

### DIFF
--- a/src/ragas/prompt/mixin.py
+++ b/src/ragas/prompt/mixin.py
@@ -53,7 +53,7 @@ class PromptMixin:
             setattr(self, key, value)
 
     async def adapt_prompts(
-        self, language: str, llm: BaseRagasLLM
+        self, language: str, llm: BaseRagasLLM, adapt_instruction: bool = False
     ) -> t.Dict[str, PydanticPrompt]:
         """
         Adapts the prompts in the class to the given language and using the given LLM.
@@ -67,7 +67,7 @@ class PromptMixin:
         prompts = self.get_prompts()
         adapted_prompts = {}
         for name, prompt in prompts.items():
-            adapted_prompt = await prompt.adapt(language, llm)
+            adapted_prompt = await prompt.adapt(language, llm, adapt_instruction)
             adapted_prompts[name] = adapted_prompt
 
         return adapted_prompts

--- a/src/ragas/prompt/pydantic_prompt.py
+++ b/src/ragas/prompt/pydantic_prompt.py
@@ -241,7 +241,15 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
             new_strings=translated_strings.statements,
         )
 
+        translated_instruction = await translate_statements_prompt.generate(
+            llm=llm,
+            data=ToTranslate(
+                target_language=target_language, statements=[self.instruction]
+            ),
+        )
+
         new_prompt = copy.deepcopy(self)
+        new_prompt.instruction = translated_instruction.statements[0]
         new_prompt.examples = translated_examples
         new_prompt.language = target_language
         return new_prompt


### PR DESCRIPTION
When adapting prompts, both the examples and the corresponding instructions are important and need to be translated.