### PR TITLE
fix error OpenAIEmbeddings' object has no attibute 'embed_text'

### DIFF
--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -48,7 +48,7 @@ class SemanticSimilarity(MetricWithLLM, MetricWithEmbeddings, SingleTurnMetric):
     )
     is_cross_encoder: bool = False
     threshold: t.Optional[float] = None
-
+        
     def __post_init__(self: t.Self):
         # only for cross encoder
         if isinstance(self.embeddings, HuggingfaceEmbeddings):
@@ -74,13 +74,15 @@ class SemanticSimilarity(MetricWithLLM, MetricWithEmbeddings, SingleTurnMetric):
                 "async score [ascore()] not implemented for HuggingFace embeddings"
             )
         else:
+            embcall_1: t.List[t.List[float]] = field(default_factory=list)
+            embcall_2: t.List[t.List[float]] = field(default_factory=list)
             try: 
-                embcall_1 = await self.embeddings.embed_text(ground_truth)
-                embcall_2 = await self.embeddings.embed_text(answer)
+                embcall_1: t.List[t.List[float]] = t.cast(list, await self.embeddings.embed_text(ground_truth))
+                embcall_2: t.List[t.List[float]] = t.cast(list, await self.embeddings.embed_text(answer))
             except AttributeError:
                 #reason: OpenAIEmbeddings' object has no attibute 'embed_text'
-                embcall_1 = self.embeddings.embed_query(ground_truth)
-                embcall_2 = self.embeddings.embed_query(answer)
+                embcall_1: t.List[t.List[float]] = t.cast(list, self.embeddings.embed_query(ground_truth))
+                embcall_2: t.List[t.List[float]] = t.cast(list, self.embeddings.embed_query(answer))
             finally:
                 embedding_1 = np.array(embcall_1)
                 embedding_2 = np.array(embcall_2)

--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -74,8 +74,16 @@ class SemanticSimilarity(MetricWithLLM, MetricWithEmbeddings, SingleTurnMetric):
                 "async score [ascore()] not implemented for HuggingFace embeddings"
             )
         else:
-            embedding_1 = np.array(await self.embeddings.embed_text(ground_truth))
-            embedding_2 = np.array(await self.embeddings.embed_text(answer))
+            try: 
+                embcall_1 = await self.embeddings.embed_text(ground_truth)
+                embcall_2 = await self.embeddings.embed_text(answer)
+            except AttributeError:
+                #reason: OpenAIEmbeddings' object has no attibute 'embed_text'
+                embcall_1 = self.embeddings.embed_query(ground_truth)
+                embcall_2 = self.embeddings.embed_query(answer)
+            finally:
+                embedding_1 = np.array(embcall_1)
+                embedding_2 = np.array(embcall_2)
             # Normalization factors of the above embeddings
             norms_1 = np.linalg.norm(embedding_1, keepdims=True)
             norms_2 = np.linalg.norm(embedding_2, keepdims=True)


### PR DESCRIPTION
Compatibility Between Different Embedding Interfaces:

We use the OpenAIEmbeddings API for embedding generation. However, there are variations in the API's interface across different versions and implementations.
In some versions, the embedding function is exposed as embed_text, while in others, it might be called embed_query.
Without this try-except block, calling the incorrect method would lead to an AttributeError, causing a failure in generating the necessary embeddings for the RAGAS computation.

Error Handling:

The try block first attempts to call the embed_text method, which is the expected API in some versions or implementations of the embeddings class.
If the embed_text method does not exist, an AttributeError is caught by the except block. In this case, we gracefully handle the error by switching to the alternative method, embed_query, which is expected to work in other versions.

Future-Proofing and Flexibility:

By adding this error handling, we make the code more resilient to future changes or variations in the API without requiring major refactoring.
This also improves the flexibility of the code by allowing it to work across different versions of the embedding libraries without modification.

Finalization with finally:

Regardless of which embedding method is called (embed_text or embed_query), the finally block ensures that the output (embeddings) is processed into the expected format (NumPy arrays).
This guarantees that the rest of the RAGAS pipeline remains unaffected by the variation in the embedding call.