### PR TITLE
chore: add verbose option (V=1) to make targets

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,6 +21,7 @@ This document provides guidelines for developing and contributing to the ragas p
 
 4. **Install Dependencies**
    ```
+   pip install -U setuptools  # Required on newer Python versions (e.g., 3.11)
    pip install -e ".[dev]"
    ```
 
@@ -55,6 +56,11 @@ This document provides guidelines for developing and contributing to the ragas p
 You can run the following command to check for code style issues:
 ```bash
 make run-ci
+```
+
+Adding a `V=1` option makes the output more verbose, showing normally hidden commands, like so:
+```bash
+make run-ci V=1
 ```
 
 ## Running Tests

--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,59 @@
 GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
 
+# Optionally show commands being executed with V=1
+Q := $(if $(V),,@)
+
 help: ## Show all Makefile targets
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+	$(Q)grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: format lint type style clean run-benchmarks
 format: ## Running code formatter: black and isort
 	@echo "(isort) Ordering imports..."
-	@isort .
+	$(Q)isort .
 	@echo "(black) Formatting codebase..."
-	@black --config pyproject.toml src tests docs
+	$(Q)black --config pyproject.toml src tests docs
 	@echo "(black) Formatting stubs..."
-	@find src -name "*.pyi" ! -name "*_pb2*" -exec black --pyi --config pyproject.toml {} \;
+	$(Q)find src -name "*.pyi" ! -name "*_pb2*" -exec black --pyi --config pyproject.toml {} \;
 	@echo "(ruff) Running fix only..."
-	@ruff check src docs tests --fix-only
+	$(Q)ruff check src docs tests --fix-only
 lint: ## Running lint checker: ruff
 	@echo "(ruff) Linting development project..."
-	@ruff check src docs tests
+	$(Q)ruff check src docs tests
 type: ## Running type checker: pyright
 	@echo "(pyright) Typechecking codebase..."
 	PYRIGHT_PYTHON_FORCE_VERSION=latest pyright src/ragas
 clean: ## Clean all generated files
 	@echo "Cleaning all generated files..."
-	@cd $(GIT_ROOT)/docs && make clean
-	@cd $(GIT_ROOT) || exit 1
-	@find . -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
+	$(Q)cd $(GIT_ROOT)/docs && $(MAKE) clean
+	$(Q)cd $(GIT_ROOT) || exit 1
+	$(Q)find . -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
 test: ## Run tests
 	@echo "Running tests..."
-	@pytest --nbmake tests/unit $(shell if [ -n "$(k)" ]; then echo "-k $(k)"; fi)
+	$(Q)pytest --nbmake tests/unit $(shell if [ -n "$(k)" ]; then echo "-k $(k)"; fi)
 test-e2e: ## Run end2end tests
 	echo "running end2end tests..."
-	@pytest --nbmake tests/e2e -s
+	$(Q)pytest --nbmake tests/e2e -s
 run-ci: format lint type test ## Running all CI checks
 
 # Docs
 rewrite-docs: ## Use GPT4 to rewrite the documentation
 	@echo "Rewriting the documentation in directory $(DIR)..."
-	@python $(GIT_ROOT)/docs/python alphred.py --directory $(DIR)
+	$(Q)python $(GIT_ROOT)/docs/python alphred.py --directory $(DIR)
 ipynb-to-md: ## Convert ipynb files to md files
-	@python $(GIT_ROOT)/scripts/ipynb_to_md.py
+	$(Q)python $(GIT_ROOT)/scripts/ipynb_to_md.py
 docsite: ## Build and serve documentation
-	@$(MAKE) ipynb-to-md
-	@mkdocs serve
+	$(Q)$(MAKE) ipynb-to-md
+	$(Q)mkdocs serve
 
 # Benchmarks
 run-benchmarks-eval: ## Run benchmarks for Evaluation
 	@echo "Running benchmarks for Evaluation..."
-	@cd $(GIT_ROOT)/tests/benchmarks && python benchmark_eval.py
+	$(Q)cd $(GIT_ROOT)/tests/benchmarks && python benchmark_eval.py
 run-benchmarks-testset: ## Run benchmarks for TestSet Generation
 	@echo "Running benchmarks for TestSet Generation..."
-	@cd $(GIT_ROOT)/tests/benchmarks && python benchmark_testsetgen.py
+	$(Q)cd $(GIT_ROOT)/tests/benchmarks && python benchmark_testsetgen.py
 run-benchmarks-in-docker: ## Run benchmarks in docker
 	@echo "Running benchmarks in docker..."
-	@cd $(GIT_ROOT)
-	docker buildx build --build-arg OPENAI_API_KEY=$(OPENAI_API_KEY) -t ragas-benchmark -f $(GIT_ROOT)/tests/benchmarks/Dockerfile . 
+	$(Q)cd $(GIT_ROOT)
+	docker buildx build --build-arg OPENAI_API_KEY=$(OPENAI_API_KEY) -t ragas-benchmark -f $(GIT_ROOT)/tests/benchmarks/Dockerfile .
 	docker inspect ragas-benchmark:latest | jq ".[0].Size" | numfmt --to=si


### PR DESCRIPTION
Like the Linux kernel and a few other make based projects, adds `V=1` option to easily make `make` more verbose, revealing commands being executed, for example:

    make test V=1

Also:

- Used `$(MAKE)` instead of `make` for recursive calls.
- Added docs for updating setuptools to work on Python 3.11 on Ubuntu 24.04.