### PR TITLE
Fix: add LLMContextPrecisionWithReference to __init__.py

### DIFF
--- a/src/ragas/metrics/__init__.py
+++ b/src/ragas/metrics/__init__.py
@@ -21,6 +21,7 @@ from ragas.metrics._context_entities_recall import (
 from ragas.metrics._context_precision import (
     ContextPrecision,
     ContextUtilization,
+    LLMContextPrecisionWithReference,
     LLMContextPrecisionWithoutReference,
     NonLLMContextPrecisionWithReference,
     context_precision,
@@ -82,6 +83,7 @@ __all__ = [
     "NoiseSensitivity",
     "RubricsScoreWithoutReference",
     "RubricsScoreWithReference",
+    "LLMContextPrecisionWithReference",
     "LLMContextPrecisionWithoutReference",
     "NonLLMContextPrecisionWithReference",
     "LLMContextPrecisionWithoutReference",


### PR DESCRIPTION
To use LLMContextPrecisionWithReference metric from user program, add "LLMContextPrecisionWithReference" to __init__.py in metrics directory.