### PR TITLE
fix: add `reference_topics` as default required columns in `TopicAdherenceScore` #1564

### DIFF
--- a/src/ragas/metrics/_topic_adherence.py
+++ b/src/ragas/metrics/_topic_adherence.py
@@ -135,7 +135,12 @@ AI: You're welcome! Feel free to ask if you need more information."""
 class TopicAdherenceScore(MetricWithLLM, MultiTurnMetric):
     name: str = "topic_adherence"  # type: ignore
     _required_columns: t.Dict[MetricType, t.Set[str]] = field(
-        default_factory=lambda: {MetricType.MULTI_TURN: {"user_input"}}
+        default_factory=lambda: {
+            MetricType.MULTI_TURN: {
+                "user_input",
+                "reference_topics",
+            }
+        }
     )
     mode: t.Literal["precision", "recall", "f1"] = "f1"
     topic_extraction_prompt: PydanticPrompt = TopicExtractionPrompt()


### PR DESCRIPTION
An attempt to fix https://github.com/explodinggradients/ragas/issues/1564
Let me know if my PR is lack of something else