### PR TITLE
Fix: Limit number of retries for parse failures

### DIFF
--- a/src/ragas/exceptions.py
+++ b/src/ragas/exceptions.py
@@ -26,9 +26,9 @@ class RagasOutputParserException(RagasException):
     Exception raised when the output parser fails to parse the output.
     """
 
-    def __init__(self, num_retries: int):
+    def __init__(self):
         msg = (
-            f"The output parser failed to parse the output after {num_retries} retries."
+            "The output parser failed to parse the output including retries."
         )
         super().__init__(msg)
 

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -3,6 +3,7 @@ import copy
 import pytest
 from langchain_core.outputs import Generation, LLMResult
 from langchain_core.prompt_values import StringPromptValue
+from pydantic import BaseModel
 
 from ragas.llms.base import BaseRagasLLM
 from ragas.prompt import StringIO, StringPrompt
@@ -203,3 +204,25 @@ def test_prompt_class_attributes():
     p.examples = []
     assert p.instruction != p_another_instance.instruction
     assert p.examples != p_another_instance.examples
+
+
+@pytest.mark.asyncio
+async def test_prompt_parse_retry():
+    from ragas.prompt import PydanticPrompt, StringIO
+    from ragas.exceptions import RagasOutputParserException
+
+    class OutputModel(BaseModel):
+        example: str
+
+    class Prompt(PydanticPrompt[StringIO, OutputModel]):
+        instruction = ""
+        input_model = StringIO
+        output_model = OutputModel
+
+    echo_llm = EchoLLM(run_config=RunConfig())
+    prompt = Prompt()
+    with pytest.raises(RagasOutputParserException):
+        await prompt.generate(
+            data=StringIO(text="this prompt will be echoed back as invalid JSON"),
+            llm=echo_llm,
+        )


### PR DESCRIPTION
When parsing of an LLM response fails, the invalid output is sent to the LLM to be fixed.

This PR threads the number of retries through this call, preventing unbounded recursion.

The old `max_retries` wasn't preventing this due to `generate()` and `parse_output_string()` being co-recursive via the call to `generate()` here
https://github.com/explodinggradients/ragas/blob/ade46fb7c0b5dffb76ef26d876ff021ded9dfa96/src/ragas/prompt/pydantic_prompt.py#L406
The result was a prompt that would keep growing through recursive calls (with nested versions becoming increasingly more deeply quoted) until the prompt was too big for the LLM to process.

Addresses https://github.com/explodinggradients/ragas/issues/1538