### PR TITLE
Updated return type description for evaluate function

### DIFF
--- a/src/ragas/evaluation.py
+++ b/src/ragas/evaluation.py
@@ -113,9 +113,9 @@ def evaluate(
 
     Returns
     -------
-    Result
-        Result object containing the scores of each metric. You can use this do analysis
-        later.
+    EvaluationResult
+        EvaluationResult object containing the final scores of each metric. 
+        You can use this do analysis later.
 
     Raises
     ------

--- a/src/ragas/evaluation.py
+++ b/src/ragas/evaluation.py
@@ -114,7 +114,7 @@ def evaluate(
     Returns
     -------
     EvaluationResult
-        EvaluationResult object containing the final scores of each metric. 
+        EvaluationResult object containing the scores of each metric. 
         You can use this do analysis later.
 
     Raises


### PR DESCRIPTION
The evaluate function doc-string is still showing the old Result object as its return type. Updated it to the EvaluationResult object