### PR TITLE
fix: treat anthropic-direct API the same as bedrock in llamaindex wrapper

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -267,6 +267,8 @@ class LlamaIndexLLMWrapper(BaseRagasLLM):
         self.llm = llm
 
         self._signature = ""
+        if type(self.llm).__name__.lower() == "anthropic":
+            self._signature = "anthropic"
         if type(self.llm).__name__.lower() == "bedrock":
             self._signature = "bedrock"
         if run_config is None:
@@ -290,7 +292,7 @@ class LlamaIndexLLMWrapper(BaseRagasLLM):
             logger.info(
                 "callbacks not supported for LlamaIndex LLMs, ignoring callbacks"
             )
-        if self._signature == "bedrock":
+        if self._signature in ["anthropic", "bedrock"]:
             return {"temperature": temperature}
         else:
             return {

--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -266,11 +266,11 @@ class LlamaIndexLLMWrapper(BaseRagasLLM):
     ):
         self.llm = llm
 
-        self._signature = ""
-        if type(self.llm).__name__.lower() == "anthropic":
-            self._signature = "anthropic"
-        if type(self.llm).__name__.lower() == "bedrock":
-            self._signature = "bedrock"
+        try:
+            self._signature = type(self.llm).__name__.lower()
+        except AttributeError:
+            self._signature = ""
+
         if run_config is None:
             run_config = RunConfig()
         self.set_run_config(run_config)


### PR DESCRIPTION
Add Anthropic signature to LlamaIndexLLMWrapper.  Fixes #1468.

Question for maintainers -- would it make sense to always set `LlamaIndexLLMWrapper._signature` for all models rather than having a series of conditionals?  i.e. (line 269):

```py
269 | self._signature = type(self.llm).__name__.lower()
```

The rest of the logic in `check_args` to handle different param dicts can remain.