### PR TITLE
fix: typo: ROUGE is a metric, ROGUE is a scoundrel

### DIFF
--- a/src/ragas/metrics/__init__.py
+++ b/src/ragas/metrics/__init__.py
@@ -53,7 +53,7 @@ from ragas.metrics._multi_modal_relevance import (
     multimodal_relevance,
 )
 from ragas.metrics._noise_sensitivity import NoiseSensitivity
-from ragas.metrics._rogue_score import RougeScore
+from ragas.metrics._rouge_score import RougeScore
 from ragas.metrics._sql_semantic_equivalence import LLMSQLEquivalence
 from ragas.metrics._string import (
     DistanceMeasure,

--- a/src/ragas/metrics/_rouge_score.py
+++ b/src/ragas/metrics/_rouge_score.py
@@ -14,7 +14,7 @@ class RougeScore(SingleTurnMetric):
     _required_columns: t.Dict[MetricType, t.Set[str]] = field(
         default_factory=lambda: {MetricType.SINGLE_TURN: {"reference", "response"}}
     )
-    rogue_type: t.Literal["rouge1", "rougeL"] = "rougeL"
+    rouge_type: t.Literal["rouge1", "rougeL"] = "rougeL"
     measure_type: t.Literal["fmeasure", "precision", "recall"] = "fmeasure"
 
     def __post_init__(self):
@@ -34,9 +34,9 @@ class RougeScore(SingleTurnMetric):
     ) -> float:
         assert isinstance(sample.reference, str), "Sample reference must be a string"
         assert isinstance(sample.response, str), "Sample response must be a string"
-        scorer = self.rouge_scorer.RougeScorer([self.rogue_type], use_stemmer=True)
+        scorer = self.rouge_scorer.RougeScorer([self.rouge_type], use_stemmer=True)
         scores = scorer.score(sample.reference, sample.response)
-        return getattr(scores[self.rogue_type], self.measure_type)
+        return getattr(scores[self.rouge_type], self.measure_type)
 
     async def _ascore(self, row: t.Dict, callbacks: Callbacks) -> float:
         return await self._single_turn_ascore(SingleTurnSample(**row), callbacks)


### PR DESCRIPTION
Fixes the typo 'rogue' with referring to 'rouge' score.

Because this changes a file name and param name, it can be considered a breaking change