### PR TITLE
Implemented Support Another Languages - Portugue tested | Add Google Translation

### DIFF
--- a/src/ragas/prompt/mixin.py
+++ b/src/ragas/prompt/mixin.py
@@ -53,7 +53,8 @@ class PromptMixin:
             setattr(self, key, value)
 
     async def adapt_prompts(
-        self, language: str, llm: BaseRagasLLM, adapt_instruction: bool = False
+        self, language: str, llm: BaseRagasLLM, adapt_instruction: bool = False,
+        google_translate: bool = False
     ) -> t.Dict[str, PydanticPrompt]:
         """
         Adapts the prompts in the class to the given language and using the given LLM.
@@ -67,7 +68,7 @@ class PromptMixin:
         prompts = self.get_prompts()
         adapted_prompts = {}
         for name, prompt in prompts.items():
-            adapted_prompt = await prompt.adapt(language, llm, adapt_instruction)
+            adapted_prompt = await prompt.adapt(language, llm, adapt_instruction, google_translate)
             adapted_prompts[name] = adapted_prompt
 
         return adapted_prompts


### PR DESCRIPTION
Some small models, such as llama 3.1 or 3.2 3b or 2B. Mainly quantized, have difficulties with prompts in Portuguese, occasionally generating text in English, which is accented with part of the prompts in English.
In this way, translating all parts of the prompt is interesting.
In addition, for small models, translating can be a poorly executed task.
In this way, being able to have support from Google Translate is a quick and practical way to translate the prompts without worrying about getting a more robust model.
In addition, there was no support in English, so I added support for some more languages ​​using the NLTK segmenter implementation.