### PR TITLE
Fix: Add instance check before casting ChatGeneration object

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -157,7 +157,7 @@ class LangchainLLMWrapper(BaseRagasLLM):
 
             # if generation_info is empty, we parse the response_metadata
             # this is less reliable
-            elif t.cast(ChatGeneration, resp).message is not None:
+            elif isinstance(resp, ChatGeneration) and t.cast(ChatGeneration, resp).message is not None:
                 resp_message: BaseMessage = t.cast(ChatGeneration, resp).message
                 if resp_message.response_metadata.get("finish_reason") is not None:
                     is_finished_list.append(


### PR DESCRIPTION
My case
- When receiving responses from headline and summary extractors, etc., they are delivered as a Generation object, not ChatGeneration.
```
{
  "generations": [
    [
      {
        "text": "{\"text\": \"ABCD\"}",
        "generation_info": null,
        "type": "Generation"
      }
    ]
  ],
  "llm_output": null,
  "run": null,
  "type": "LLMResult"
}
```


Occurrence message
- unable to apply transformation: 'Generation' object has no attribute 'message'

How to fix
- Add code to first check if it is an instance of that object before casting to a ChatGeneration object.