### PR TITLE
fix: remove `.` as a split condition in noise_sensitivity.py

### DIFF
--- a/src/ragas/metrics/_noise_sensitivity.py
+++ b/src/ragas/metrics/_noise_sensitivity.py
@@ -101,7 +101,6 @@ class NoiseSensitivity(MetricWithLLM, SingleTurnMetric):
         sentences_with_index = {
             i: sentence
             for i, sentence in enumerate(sentences)
-            if sentence.strip().endswith(".")
         }
 
         statements_simplified = await self.statement_prompt.generate(


### PR DESCRIPTION
Fix #1626 to support more languages.