### PR TITLE
fixed wrong variable names in starter guide using azure openai

### DIFF
--- a/docs/extra/components/choose_evaluator_llm.md
+++ b/docs/extra/components/choose_evaluator_llm.md
@@ -100,18 +100,18 @@
     from ragas.embeddings import LangchainEmbeddingsWrapper
     evaluator_llm = LangchainLLMWrapper(AzureChatOpenAI(
         openai_api_version="2023-05-15",
-        azure_endpoint=azure_configs["base_url"],
-        azure_deployment=azure_configs["model_deployment"],
-        model=azure_configs["model_name"],
+        azure_endpoint=azure_config["base_url"],
+        azure_deployment=azure_config["model_deployment"],
+        model=azure_config["model_name"],
         validate_base_url=False,
     ))
 
     # init the embeddings for answer_relevancy, answer_correctness and answer_similarity
     evaluator_embeddings = LangchainEmbeddingsWrapper(AzureOpenAIEmbeddings(
         openai_api_version="2023-05-15",
-        azure_endpoint=azure_configs["base_url"],
-        azure_deployment=azure_configs["embedding_deployment"],
-        model=azure_configs["embedding_name"],
+        azure_endpoint=azure_config["base_url"],
+        azure_deployment=azure_config["embedding_deployment"],
+        model=azure_config["embedding_name"],
     ))
     ```
 


### PR DESCRIPTION
found this small error while trying to use ragas following the starter guide using azure openai
previously set azure_config should be referenced instead of azure_configs (which doesn't exist) 