### PR TITLE
removed MetricWithLLM from SemanticSimilarity

### DIFF
--- a/src/ragas/metrics/_answer_correctness.py
+++ b/src/ragas/metrics/_answer_correctness.py
@@ -195,9 +195,7 @@ class AnswerCorrectness(MetricWithLLM, MetricWithEmbeddings, SingleTurnMetric):
     def init(self, run_config: RunConfig):
         super().init(run_config)
         if self.answer_similarity is None and self.weights[1] != 0:
-            self.answer_similarity = AnswerSimilarity(
-                llm=self.llm, embeddings=self.embeddings
-            )
+            self.answer_similarity = AnswerSimilarity(embeddings=self.embeddings)
 
     def _compute_statement_presence(
         self, prediction: ClassificationWithReason

--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -11,7 +11,6 @@ from ragas.embeddings.base import HuggingfaceEmbeddings
 from ragas.metrics.base import (
     MetricType,
     MetricWithEmbeddings,
-    MetricWithLLM,
     SingleTurnMetric,
 )
 
@@ -23,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class SemanticSimilarity(MetricWithLLM, MetricWithEmbeddings, SingleTurnMetric):
+class SemanticSimilarity(MetricWithEmbeddings, SingleTurnMetric):
     """
     Scores the semantic similarity of ground truth with generated answer.
     cross encoder score is used to quantify semantic similarity.


### PR DESCRIPTION
- `SemanticSimilarity` is not an LLM metric, so it doesn't have to extend `MetricWithLLM`