### PR TITLE
Added parallel tool call evaluation to ToolCallAccuracy metric

### DIFF
--- a/docs/concepts/metrics/available_metrics/agents.md
+++ b/docs/concepts/metrics/available_metrics/agents.md
@@ -70,6 +70,8 @@ scorer = TopicAdherenceScore(mode="recall")
 
 `ToolCallAccuracy` is a metric that can be used to evaluate the performance of the LLM in identifying and calling the required tools to complete a given task. This metric needs `user_input` and `reference_tool_calls` to evaluate the performance of the LLM in identifying and calling the required tools to complete a given task. The metric is computed by comparing the `reference_tool_calls` with the Tool calls made by the AI. The values range between 0 and 1, with higher values indicating better performance. 
 
+By using the `mode` parameter, the evaluation can be customized to meet the specific requirements of your task. In `sequential` mode, the metric ensures that the agent adheres to a strict order of function calling, matching the sequence of the `reference_tool_calls`. In contrast, parallel mode evaluates the presence and correctness of tool calls without considering their order, allowing greater flexibility in scenarios where sequence is not critical.
+
 ```python
 from ragas.metrics import ToolCallAccuracy
 from ragas.dataset_schema import  MultiTurnSample
@@ -102,6 +104,23 @@ await scorer.multi_turn_ascore(sample)
 ```
 
 The tool call sequence specified in `reference_tool_calls` is used as the ideal outcome. If the tool calls made by the AI does not the the order or sequence of the `reference_tool_calls`, the metric will return a score of 0. This helps to ensure that the AI is able to identify and call the required tools in the correct order to complete a given task.
+
+The mode of evaluation for tool calling can be specified as either sequential or parallel. By default, the mode is sequential, meaning the order in which the tools are called must match the order in reference_tool_calls. In parallel mode, the order of tool calls does not matter; only the presence of the correct tools and their arguments is evaluated.
+
+```python
+# The same function calls as above, but the order of the tool calls is reversed in reference_tool_calls.
+sample = MultiTurnSample(
+    user_input=sample,
+    reference_tool_calls=[
+        ToolCall(name="temperature_conversion", args={"temperature_fahrenheit": 75}),
+        ToolCall(name="weather_check", args={"location": "New York"})
+    ]
+)
+
+scorer = ToolCallAccuracy(mode='parallel')
+scorer.llm = your_llm
+await scorer.multi_turn_ascore(sample)
+```
 
 By default the tool names and arguments are compared using exact string matching. But sometimes this might not be optimal, for example if the args are natural language strings. You can also use any ragas metrics (values between 0 and 1) as distance measure to identify if a retrieved context is relevant or not. For example,
 

--- a/src/ragas/metrics/_answer_similarity.py
+++ b/src/ragas/metrics/_answer_similarity.py
@@ -8,11 +8,7 @@ import numpy as np
 
 from ragas.dataset_schema import SingleTurnSample
 from ragas.embeddings.base import HuggingfaceEmbeddings
-from ragas.metrics.base import (
-    MetricType,
-    MetricWithEmbeddings,
-    SingleTurnMetric,
-)
+from ragas.metrics.base import MetricType, MetricWithEmbeddings, SingleTurnMetric
 
 if t.TYPE_CHECKING:
     from langchain_core.callbacks.base import Callbacks

--- a/src/ragas/metrics/_aspect_critic.py
+++ b/src/ragas/metrics/_aspect_critic.py
@@ -286,7 +286,7 @@ class AspectCriticWithReference(AspectCritic):
     )
 
     async def _ascore(self, row: t.Dict, callbacks: Callbacks) -> float:
-        
+
         if self.llm is None:
             raise ValueError("LLM is not set")
 
@@ -320,10 +320,10 @@ class AspectCriticWithReference(AspectCritic):
     async def _multi_turn_ascore(
         self, sample: MultiTurnSample, callbacks: Callbacks
     ) -> float:
-        
+
         if self.llm is None:
             raise ValueError("LLM is not set")
-        
+
         if sample.reference is None:
             raise ValueError("Reference is not set")
 

--- a/src/ragas/metrics/_noise_sensitivity.py
+++ b/src/ragas/metrics/_noise_sensitivity.py
@@ -98,10 +98,7 @@ class NoiseSensitivity(MetricWithLLM, SingleTurnMetric):
         assert self.sentence_segmenter is not None, "sentence_segmenter is not set"
 
         sentences = self.sentence_segmenter.segment(text)
-        sentences_with_index = {
-            i: sentence
-            for i, sentence in enumerate(sentences)
-        }
+        sentences_with_index = {i: sentence for i, sentence in enumerate(sentences)}
 
         statements_simplified = await self.statement_prompt.generate(
             llm=self.llm,

--- a/src/ragas/metrics/_tool_call_accuracy.py
+++ b/src/ragas/metrics/_tool_call_accuracy.py
@@ -98,7 +98,7 @@ class ToolCallAccuracy(MultiTurnMetric):
 
         if self.mode == "sequential":
             return score * sequence_aligned
-        elif self.mode == "parallel":
+        else:  # For self.mode == "parallel"
             return score
 
     async def _ascore(self, row: t.Dict, callbacks: Callbacks) -> float:

--- a/src/ragas/metrics/_tool_call_accuracy.py
+++ b/src/ragas/metrics/_tool_call_accuracy.py
@@ -24,6 +24,7 @@ class ToolCallAccuracy(MultiTurnMetric):
             }
         }
     )
+    mode: t.Literal["sequential", "parallel"] = "sequential"
 
     arg_comparison_metric: SingleTurnMetric = field(
         default_factory=lambda: ExactMatch()
@@ -95,7 +96,10 @@ class ToolCallAccuracy(MultiTurnMetric):
             warnings.warn("No tool calls found in the user input")
             return 0.0
 
-        return score * sequence_aligned
+        if self.mode == "sequential":
+            return score * sequence_aligned
+        elif self.mode == "parallel":
+            return score
 
     async def _ascore(self, row: t.Dict, callbacks: Callbacks) -> float:
         return await self._multi_turn_ascore(MultiTurnSample(**row), callbacks)

--- a/src/ragas/testset/transforms/__init__.py
+++ b/src/ragas/testset/transforms/__init__.py
@@ -1,4 +1,10 @@
-from .base import BaseGraphTransformation, Extractor, RelationshipBuilder, Splitter, NodeFilter
+from .base import (
+    BaseGraphTransformation,
+    Extractor,
+    NodeFilter,
+    RelationshipBuilder,
+    Splitter,
+)
 from .default import default_transforms
 from .engine import Parallel, Transforms, apply_transforms, rollback_transforms
 from .extractors import (
@@ -8,12 +14,12 @@ from .extractors import (
     SummaryExtractor,
     TitleExtractor,
 )
+from .filters import CustomNodeFilter
 from .relationship_builders.cosine import (
     CosineSimilarityBuilder,
     SummaryCosineSimilarityBuilder,
 )
 from .splitters import HeadlineSplitter
-from .filters import CustomNodeFilter
 
 __all__ = [
     # base

--- a/src/ragas/utils.py
+++ b/src/ragas/utils.py
@@ -233,6 +233,7 @@ def num_tokens_from_string(string: str, encoding_name: str = "cl100k_base") -> i
     num_tokens = len(encoding.encode(string))
     return num_tokens
 
+
 def batched(iterable: t.Iterable, n: int) -> t.Iterator[t.Tuple]:
     """Batch data from the iterable into tuples of length n. The last batch may be shorter than n."""
     # batched('ABCDEFG', 3) → ABC DEF G


### PR DESCRIPTION
- Fixes #1658 

- Introduced the `mode` parameter in the `ToolCallAccuracy` class to allow 
  selection between `sequential` and `parallel` evaluation modes.