### PR TITLE
Fix for #1150:  Update prompt to ensure reason and verdict fields are present for custom model evaluation

### DIFF
--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -101,7 +101,7 @@ class NLIStatementInput(BaseModel):
 
 
 class NLIStatementPrompt(PydanticPrompt[NLIStatementInput, NLIStatementOutput]):
-    instruction = "Your task is to judge the faithfulness of a series of statements based on a given context. For each statement you must return verdict as 1 if the statement can be directly inferred based on the context or 0 if the statement can not be directly inferred based on the context."
+    instruction = "Your task is to judge the faithfulness of a series of statements based on a given context. For each statement you must return verdict as 1 if the statement can be directly inferred based on the context or 0 if the statement can not be directly inferred based on the context. Ensure that each statement includes both a reason and a verdict. Do not omit any fields."
     input_model = NLIStatementInput
     output_model = NLIStatementOutput
     examples = [


### PR DESCRIPTION
#### Summary
* This pull request addresses [Issue #1150](https://github.com/explodinggradients/ragas/issues/1150) by updating the faithfulness instruction prompt to ensure that the reason and verdict fields are always included when evaluating with custom models.

#### Changes
* Updated the evaluation prompt to explicitly guarantee the presence of reason and verdict fields.
* Improved prompt clarity to align with expected evaluation outcomes.
#### Context
* It was observed by many users that the reason and verdict fields often gets cut off, resulting in "failed to parse error". This fix ensures that all statements, contain these necessary fields.
* For more details on the issue, refer to the discussion in [Issue #1150](https://github.com/explodinggradients/ragas/issues/1150).

#### Testing
* Verified for Mixtral8x7b and Mistral 7b hosted internally using vllm 
* Ensured no missing fields in the evaluation results.