### PR TITLE
fix: attempting a simple fix for #1718

### DIFF
--- a/src/ragas/executor.py
+++ b/src/ragas/executor.py
@@ -11,6 +11,9 @@ from tqdm.auto import tqdm
 from ragas.run_config import RunConfig
 from ragas.utils import batched
 
+import nest_asyncio
+nest_asyncio.apply()
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
I went through hoops the last hr to try a few things to fix the issue documented in #1718 (except `MultiHopAbstractQuerySynthesizer` and `MultiHopSpecificQuerySynthesizer`). 

This PR proposes the most trivial fix. But it fixes this test generation issue:

```
from langchain_community.document_loaders import DirectoryLoader
from ragas.testset import TestsetGenerator

from ragas.llms import LangchainLLMWrapper
from ragas.embeddings import LangchainEmbeddingsWrapper
from langchain_openai import ChatOpenAI
from langchain_openai import OpenAIEmbeddings

path = "Sample_Docs_Markdown/"
loader = DirectoryLoader(path, glob="**/*.md")
docs = loader.load()

generator_llm = LangchainLLMWrapper(ChatOpenAI(model="gpt-4o"))
generator_embeddings = LangchainEmbeddingsWrapper(OpenAIEmbeddings())

generator = TestsetGenerator(llm=generator_llm, embedding_model=generator_embeddings)
dataset = generator.generate_with_langchain_docs(docs, testset_size=10)
```

Also both `test_executor.py` and `test_executor_in_jupyter.ipynb` are passing.

cc: @jjmachan 