### PR TITLE
fix: Update error handling in Faithfulness metric to return 0.0 instead of np.nan on failure

### DIFF
--- a/src/ragas/metrics/_faithfulness.py
+++ b/src/ragas/metrics/_faithfulness.py
@@ -262,7 +262,8 @@ class Faithfulness(MetricWithLLM, SingleTurnMetric):
 
         statements_simplified = await self._create_statements(row, callbacks)
         if statements_simplified is None:
-            return np.nan
+            logger.warning("Failed to create statements from the answer.")
+            return 0.0  # Return 0.0 instead of np.nan
 
         # unwrap the statements
         statements = []


### PR DESCRIPTION
This PR fixes a KeyError: 0 issue that occurs when running RAG evaluation metrics, specifically in the faithfulness metric computation.

Fixes #1770