### PR TITLE
Docs improvements

### DIFF
--- a/docs/concepts/metrics/available_metrics/general_purpose.md
+++ b/docs/concepts/metrics/available_metrics/general_purpose.md
@@ -98,10 +98,10 @@ Instance specific evaluation metric is a rubric-based evaluation metric that is 
 #### Example
 ```python
 from ragas.dataset_schema import SingleTurnSample
-from ragas.metrics import InstanceRubricsScore
+from ragas.metrics import InstanceRubrics
 
 
-SingleTurnSample(
+sample = SingleTurnSample(
     user_input="Where is the Eiffel Tower located?",
     response="The Eiffel Tower is located in Paris.",
     rubrics = {
@@ -113,6 +113,6 @@ SingleTurnSample(
 }
 )
 
-scorer =  InstanceRubricsScore(llm=evaluator_llm)
+scorer =  InstanceRubrics(llm=evaluator_llm)
 await scorer.single_turn_ascore(sample)
 ```


### PR DESCRIPTION
Issue: Differences between tutorials and source code in **General Purpose Metrics**
link : https://docs.ragas.io/en/latest/concepts/metrics/available_metrics/general_purpose/

Two updates:

1. Changing library calls
before
```python
from ragas.metrics import InstanceRubricsScore
...

scorer =  InstanceRubricsScore(llm=evaluator_llm)
```

after
```python
from ragas.metrics import InstanceRubrics
...

scorer =  InstanceRubrics(llm=evaluator_llm)
```

2. Sample define
before
```
SingleTurnSample(
```

after
```
sample = SingleTurnSample(
```