### PR TITLE
fix numpy invert error in metrics

### DIFF
--- a/src/ragas/metrics/_factual_correctness.py
+++ b/src/ragas/metrics/_factual_correctness.py
@@ -260,6 +260,7 @@ class FactualCorrectness(MetricWithLLM, SingleTurnMetric):
         tp = sum(reference_response)
         fp = sum(~reference_response)
         if self.mode != "precision":
+            response_reference = np.array(response_reference, dtype=bool)
             fn = sum(~response_reference)
         else:
             fn = 0


### PR DESCRIPTION
#1796 TypeError(ufunc 'invert' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe'') will trigger when evaluating by `FactualCorrectness`