### PR TITLE
Change save and load encode to utf-8

### DIFF
--- a/src/ragas/prompt/pydantic_prompt.py
+++ b/src/ragas/prompt/pydantic_prompt.py
@@ -328,13 +328,13 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
         }
         if os.path.exists(file_path):
             raise FileExistsError(f"The file '{file_path}' already exists.")
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
             print(f"Prompt saved to {file_path}")
 
     @classmethod
     def load(cls, file_path: str) -> "PydanticPrompt[InputModel, OutputModel]":
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             data = json.load(f)
 
         # You might want to add version compatibility checks here


### PR DESCRIPTION
After adapting files to Portuguese and saving.
When recovering, exceptions like these are common due to Portuguese symbols.
Fixing by changing to utf-8 standard

save (c:\Users\jmess\miniconda3\envs\rag\Lib\site-packages\ragas\prompt\pydantic_prompt.py:333)
save_prompts (c:\Users\jmess\miniconda3\envs\rag\Lib\site-packages\ragas\prompt\mixin.py:97)
<module> (d:\GitHub\rag_eval\Untitled-1.py:82)
_run_code (c:\Users\jmess\miniconda3\envs\rag\Lib\runpy.py:88)
_run_module_as_main (Current frame) (c:\Users\jmess\miniconda3\envs\rag\Lib\runpy.py:198)
[Chained Exc: 'charmap' codec can't decode byte 0x81 in position 470: character maps to <undefined>] <module> (d:\GitHub\rag_eval\Untitled-1.py:77)
[Chained Exc: 'charmap' codec can't decode byte 0x81 in position 470: character maps to <undefined>] load_prompts (c:\Users\jmess\miniconda3\envs\rag\Lib\site-packages\ragas\prompt\mixin.py:119)
[Chained Exc: 'charmap' codec can't decode byte 0x81 in position 470: character maps to <undefined>] load (c:\Users\jmess\miniconda3\envs\rag\Lib\site-packages\ragas\prompt\pydantic_prompt.py:341)
[Chained Exc: 'charmap' codec can't decode byte 0x81 in position 470: character maps to <undefined>] load (c:\Users\jmess\miniconda3\envs\rag\Lib\json\__init__.py:293)
[Chained Exc: 'charmap' codec can't decode byte 0x81 in position 470: character maps to <undefined>] decode (c:\Users\jmess\miniconda3\envs\rag\Lib\encodings\cp1252.py:23)