### PR TITLE
Adjustment when calculating hash | Adjustment of the hash calculation…

### DIFF
--- a/src/ragas/prompt/pydantic_prompt.py
+++ b/src/ragas/prompt/pydantic_prompt.py
@@ -17,7 +17,7 @@ from ragas._version import __version__
 from ragas.callbacks import ChainType, new_group
 from ragas.exceptions import RagasOutputParserException
 
-from .base import BasePrompt, StringIO, _check_if_language_is_supported
+from .base import BasePrompt, StringIO
 from .utils import extract_json, get_all_strings, update_strings
 
 if t.TYPE_CHECKING:
@@ -228,10 +228,7 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
         """
         Adapt the prompt to a new language.
         """
-
-        # throws ValueError if language is not supported
-        _check_if_language_is_supported(target_language)
-
+        
         strings = get_all_strings(self.examples)
         translated_strings = await translate_statements_prompt.generate(
             llm=llm,

--- a/src/ragas/prompt/pydantic_prompt.py
+++ b/src/ragas/prompt/pydantic_prompt.py
@@ -4,6 +4,8 @@ import copy
 import json
 import logging
 import os
+import hashlib
+
 import typing as t
 
 from langchain_core.exceptions import OutputParserException
@@ -15,7 +17,7 @@ from ragas._version import __version__
 from ragas.callbacks import ChainType, new_group
 from ragas.exceptions import RagasOutputParserException
 
-from .base import BasePrompt, StringIO
+from .base import BasePrompt, StringIO, _check_if_language_is_supported
 from .utils import extract_json, get_all_strings, update_strings
 
 if t.TYPE_CHECKING:
@@ -227,10 +229,8 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
         Adapt the prompt to a new language.
         """
 
-        # set the original hash, this is used to
-        # identify the original prompt object when loading from file
-        if self.original_hash is None:
-            self.original_hash = hash(self)
+        # throws ValueError if language is not supported
+        _check_if_language_is_supported(target_language)
 
         strings = get_all_strings(self.examples)
         translated_strings = await translate_statements_prompt.generate(
@@ -257,6 +257,8 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
             )
             new_prompt.instruction = translated_instruction.statements[0]
 
+        new_prompt.original_hash = hash(new_prompt)
+
         return new_prompt
 
     def __repr__(self):
@@ -276,7 +278,7 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
             ensure_ascii=False,
         )[1:-1]
         return f"{self.__class__.__name__}({json_str})"
-
+        
     def __hash__(self):
         # convert examples to json string for hashing
         examples = []
@@ -285,19 +287,23 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
             examples.append(
                 (input_model.model_dump_json(), output_model.model_dump_json())
             )
-
-        # not sure if input_model and output_model should be included
-        return hash(
-            (
-                self.name,
-                self.input_model,
-                self.output_model,
-                self.instruction,
-                *examples,
-                self.language,
-            )
-        )
-
+    
+        # create a SHA-256 hash object
+        hasher = hashlib.sha256()
+    
+        # update the hash object with the bytes of each attribute
+        hasher.update(self.name.encode('utf-8'))
+        hasher.update(self.input_model.__name__.encode('utf-8'))
+        hasher.update(self.output_model.__name__.encode('utf-8'))
+        hasher.update(self.instruction.encode('utf-8'))
+        for example in examples:
+            hasher.update(example[0].encode('utf-8'))
+            hasher.update(example[1].encode('utf-8'))
+        hasher.update(self.language.encode('utf-8'))
+    
+        # return the integer value of the hash
+        return int(hasher.hexdigest(), 16)
+    
     def __eq__(self, other):
         if not isinstance(other, PydanticPrompt):
             return False
@@ -328,13 +334,13 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
         }
         if os.path.exists(file_path):
             raise FileExistsError(f"The file '{file_path}' already exists.")
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding='utf-8') as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
             print(f"Prompt saved to {file_path}")
 
     @classmethod
     def load(cls, file_path: str) -> "PydanticPrompt[InputModel, OutputModel]":
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding='utf-8') as f:
             data = json.load(f)
 
         # You might want to add version compatibility checks here

--- a/src/ragas/prompt/pydantic_prompt.py
+++ b/src/ragas/prompt/pydantic_prompt.py
@@ -334,13 +334,13 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
         }
         if os.path.exists(file_path):
             raise FileExistsError(f"The file '{file_path}' already exists.")
-        with open(file_path, "w", encoding='utf-8') as f:
+        with open(file_path, "w") as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
             print(f"Prompt saved to {file_path}")
 
     @classmethod
     def load(cls, file_path: str) -> "PydanticPrompt[InputModel, OutputModel]":
-        with open(file_path, "r", encoding='utf-8') as f:
+        with open(file_path, "r") as f:
             data = json.load(f)
 
         # You might want to add version compatibility checks here


### PR DESCRIPTION
… method

When trying to load the saved models after adaptation, alerts like these were always triggered:

Loaded prompt hash does not match the saved hash.
Loaded prompt hash does not match the saved hash.

Furthermore, in Python, the default hash() function may yield different results for the same string across different sessions. To achieve consistent hash values, for tha i using the hashlib module to calculate de hash of prompt, which provides stable hashing algorithms.