### PR TITLE
fix(prompt/mixin): Add name property and add it to saving/loading path.

### DIFF
--- a/docs/howtos/customizations/metrics/_metrics_language_adaptation.md
+++ b/docs/howtos/customizations/metrics/_metrics_language_adaptation.md
@@ -35,18 +35,6 @@ from ragas.llms import llm_factory
 llm = llm_factory()
 ```
 
-To view the supported language codes
-
-
-```python
-from ragas.utils import RAGAS_SUPPORTED_LANGUAGE_CODES
-
-print(list(RAGAS_SUPPORTED_LANGUAGE_CODES.keys()))
-```
-
-    ['english', 'hindi', 'marathi', 'chinese', 'spanish', 'amharic', 'arabic', 'armenian', 'bulgarian', 'urdu', 'russian', 'polish', 'persian', 'dutch', 'danish', 'french', 'burmese', 'greek', 'italian', 'japanese', 'deutsch', 'kazakh', 'slovak']
-
-
 Now let's adapt it to 'hindi' as the target language using `adapt` method.
 Language adaptation in Ragas works by translating few shot examples given along with the prompts to the target language. Instructions remains in english. 
 

--- a/src/ragas/prompt/mixin.py
+++ b/src/ragas/prompt/mixin.py
@@ -20,8 +20,9 @@ class PromptMixin:
     eg: [BaseSynthesizer][ragas.testset.synthesizers.base.BaseSynthesizer], [MetricWithLLM][ragas.metrics.base.MetricWithLLM]
     """
 
-    def _get_prompts(self) -> t.Dict[str, PydanticPrompt]:
+    name: str = ""
 
+    def _get_prompts(self) -> t.Dict[str, PydanticPrompt]:
         prompts = {}
         for key, value in inspect.getmembers(self):
             if isinstance(value, PydanticPrompt):
@@ -91,7 +92,7 @@ class PromptMixin:
         for prompt_name, prompt in prompts.items():
             # hash_hex = f"0x{hash(prompt) & 0xFFFFFFFFFFFFFFFF:016x}"
             prompt_file_name = os.path.join(
-                path, f"{prompt_name}_{prompt.language}.json"
+                path, f"{self.name}_{prompt_name}_{prompt.language}.json"
             )
             prompt.save(prompt_file_name)
 
@@ -113,7 +114,9 @@ class PromptMixin:
 
         loaded_prompts = {}
         for prompt_name, prompt in self.get_prompts().items():
-            prompt_file_name = os.path.join(path, f"{prompt_name}_{language}.json")
+            prompt_file_name = os.path.join(
+                path, f"{self.name}_{prompt_name}_{language}.json"
+            )
             loaded_prompt = prompt.__class__.load(prompt_file_name)
             loaded_prompts[prompt_name] = loaded_prompt
         return loaded_prompts


### PR DESCRIPTION
This pull request includes several changes to the `PromptMixin` class in the `src/ragas/prompt/mixin.py` file. The changes focus on adding a `name` attribute to the class and using this attribute when saving and loading prompts. This solves the error when saving and loading several prompts of different Synthesizers (e.g. MultiHopAbstractQuerySynthesizer, MultiHopSpecificQuerySynthesizer, SingleHopSpecificQuerySynthesizer etc.) as they had the same path associated:

```
themes_personas_matching_prompt_english -> single_hop_specifc_query_synthesizer_themes_personas_matching_prompt_english
query_answer_generation_prompt_english -> single_hop_specifc_query_synthesizer_query_answer_generation_prompt_english
```

### Changes to `PromptMixin` class:

* Added a `name` attribute to the `PromptMixin` class.
* Modified the `save_prompts` method to include the `name` attribute in the prompt file name.
* Modified the `load_prompts` method to include the `name` attribute in the prompt file name.