### PR TITLE
docs: be consistent with the variable naming of `evaluator_embeddings`

### DIFF
--- a/docs/concepts/metrics/available_metrics/answer_relevance.md
+++ b/docs/concepts/metrics/available_metrics/answer_relevance.md
@@ -39,7 +39,7 @@ sample = SingleTurnSample(
         ]
     )
 
-scorer = ResponseRelevancy(llm=evaluator_llm, embeddings=evaluator_embedding)
+scorer = ResponseRelevancy(llm=evaluator_llm, embeddings=evaluator_embeddings)
 await scorer.single_turn_ascore(sample)
 ```
 Output


### PR DESCRIPTION
small, but helps with copy/paste 😝 