### PR TITLE
docs: match default `timeout` in `RunConfig`

### DIFF
--- a/src/ragas/run_config.py
+++ b/src/ragas/run_config.py
@@ -23,7 +23,7 @@ class RunConfig:
     Parameters
     ----------
     timeout : int, optional
-        Maximum time (in seconds) to wait for a single operation, by default 60.
+        Maximum time (in seconds) to wait for a single operation, by default 180.
     max_retries : int, optional
         Maximum number of retry attempts, by default 10.
     max_wait : int, optional


### PR DESCRIPTION
fix a minor mismatch of the default value in the docstring