### PR TITLE
Changed the parse_run_traces to include last 4 letters of run_id

### DIFF
--- a/src/ragas/callbacks.py
+++ b/src/ragas/callbacks.py
@@ -164,7 +164,7 @@ def parse_run_traces(
                 prompt_trace = traces[prompt_uuid]
                 output = prompt_trace.outputs.get("output", {})
                 output = output[0] if isinstance(output, list) else output
-                prompt_traces[f"{prompt_trace.name}"] = {
+                prompt_traces[f"{prompt_trace.name}_{prompt_trace.run_id[:4]}"] = {
                     "input": prompt_trace.inputs.get("data", {}),
                     "output": output,
                 }


### PR DESCRIPTION
#1871 
Changed the parse_run_traces function, to include the last 4 letter of the run_id of the trace, result of which is a unique key for every call. 