### PR TITLE
Fix Broken Test Case Due to Changed Error Message

### DIFF
--- a/src/ragas/dataset_schema.py
+++ b/src/ragas/dataset_schema.py
@@ -191,7 +191,9 @@ class RagasDataset(ABC, t.Generic[Sample]):
         first_sample_type = type(samples[0])
         for i, sample in enumerate(samples):
             if not isinstance(sample, first_sample_type):
-                raise ValueError(f"Sample at index {i} is of type {type(sample)}, expected {first_sample_type}")
+                raise ValueError(
+                    f"Sample at index {i} is of type {type(sample)}, expected {first_sample_type}"
+                )
 
         return samples
 

--- a/tests/unit/test_dataset_schema.py
+++ b/tests/unit/test_dataset_schema.py
@@ -130,8 +130,11 @@ def test_single_type_evaluation_dataset(eval_sample):
         EvaluationDataset(samples=[single_turn_sample, multi_turn_sample])
 
     error_message = str(exc_info.value)
-    assert "All samples must be of the same type" in error_message
-    assert "Sample at index 1 is of type <class 'ragas.dataset_schema.MultiTurnSample'>" in error_message
+
+    assert (
+        "Sample at index 1 is of type <class 'ragas.dataset_schema.MultiTurnSample'>"
+        in error_message
+    )
     assert "expected <class 'ragas.dataset_schema.SingleTurnSample'>" in error_message
 
 

--- a/tests/unit/test_dataset_schema.py
+++ b/tests/unit/test_dataset_schema.py
@@ -129,7 +129,10 @@ def test_single_type_evaluation_dataset(eval_sample):
     with pytest.raises(ValueError) as exc_info:
         EvaluationDataset(samples=[single_turn_sample, multi_turn_sample])
 
-    assert "All samples must be of the same type" in str(exc_info.value)
+    error_message = str(exc_info.value)
+    assert "All samples must be of the same type" in error_message
+    assert "Sample at index 1 is of type <class 'ragas.dataset_schema.MultiTurnSample'>" in error_message
+    assert "expected <class 'ragas.dataset_schema.SingleTurnSample'>" in error_message
 
 
 def test_base_eval_sample():


### PR DESCRIPTION
This PR addresses a failing test case caused by changes introduced in PR #1879, which modified the error message format. The test has been updated to reflect the new error message, ensuring it passes successfully.