### PR TITLE
added the end of sequence token for the WatsonX family of models

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -159,8 +159,9 @@ class LangchainLLMWrapper(BaseRagasLLM):
                 if finish_reason is not None:
                     # OpenAI uses "stop"
                     # Vertex AI uses "STOP" or "MAX_TOKENS"
+                    # WatsonX AI uses "eos_token"
                     is_finished_list.append(
-                        finish_reason in ["stop", "STOP", "MAX_TOKENS"]
+                        finish_reason in ["stop", "STOP", "MAX_TOKENS", "eos_token"]
                     )
 
                 # provied more conditions here
@@ -177,12 +178,12 @@ class LangchainLLMWrapper(BaseRagasLLM):
                 if resp_message.response_metadata.get("finish_reason") is not None:
                     finish_reason = resp_message.response_metadata.get("finish_reason")
                     is_finished_list.append(
-                        finish_reason in ["stop", "STOP", "MAX_TOKENS"]
+                        finish_reason in ["stop", "STOP", "MAX_TOKENS", "eos_token"]
                     )
                 elif resp_message.response_metadata.get("stop_reason") is not None:
                     stop_reason = resp_message.response_metadata.get("stop_reason")
                     is_finished_list.append(
-                        stop_reason in ["end_turn", "stop", "STOP", "MAX_TOKENS"]
+                        stop_reason in ["end_turn", "stop", "STOP", "MAX_TOKENS", "eos_token"]
                     )
             # default to True
             else:


### PR DESCRIPTION
This modification allows ragas to handle generations from WatsonX.ai models. The change simply adds the token "eos_token" to the is_finished function.