### PR TITLE
Fixed simple criteria metric

### DIFF
--- a/src/ragas/metrics/_simple_criteria.py
+++ b/src/ragas/metrics/_simple_criteria.py
@@ -58,7 +58,7 @@ class MultiTurnSimpleCriteriaInput(BaseModel):
 class SingleTurnSimpleCriteriaPrompt(
     PydanticPrompt[SingleTurnSimpleCriteriaInput, SimpleCriteriaOutput]
 ):
-    instruction = "Evaluate the input based on the criteria defined."
+    instruction = ""
     input_model = SingleTurnSimpleCriteriaInput
     output_model = SimpleCriteriaOutput
 
@@ -66,7 +66,7 @@ class SingleTurnSimpleCriteriaPrompt(
 class MultiTurnSimpleCriteriaPrompt(
     PydanticPrompt[MultiTurnSimpleCriteriaInput, SimpleCriteriaOutput]
 ):
-    instruction = "Evaluate the input based on the criteria defined."
+    instruction = ""
     input_model = MultiTurnSimpleCriteriaInput
     output_model = SimpleCriteriaOutput
 
@@ -123,6 +123,11 @@ class SimpleCriteriaScore(MetricWithLLM, SingleTurnMetric, MultiTurnMetric):
         self.single_turn_prompt = single_turn_prompt or SingleTurnSimpleCriteriaPrompt()
         self.multi_turn_prompt = multi_turn_prompt or MultiTurnSimpleCriteriaPrompt()
 
+        # update the instruction for the prompts with the definition
+        instruction = f"Evaluate the input based on the criteria defined.\nCriteria Definition: {self._definition}"
+        self.single_turn_prompt.instruction = instruction
+        self.multi_turn_prompt.instruction = instruction
+
         # ensure odd number of checks to avoid tie in majority vote.
         self.strictness = strictness
         self.strictness = (
@@ -140,9 +145,9 @@ class SimpleCriteriaScore(MetricWithLLM, SingleTurnMetric, MultiTurnMetric):
     def definition(self, value: str) -> None:
         self._definition = value
         # Update the instruction for both prompts with the new definition
-        instruction = f"\nCriteria Definition: {self._definition}"
-        self.single_turn_prompt.instruction += instruction
-        self.multi_turn_prompt.instruction += instruction
+        instruction = f"Evaluate the input based on the criteria defined.\nCriteria Definition: {self._definition}"
+        self.single_turn_prompt.instruction = instruction
+        self.multi_turn_prompt.instruction = instruction
 
     def _compute_score(
         self, safe_loaded_responses: t.List[SimpleCriteriaOutput]

--- a/src/ragas/sdk.py
+++ b/src/ragas/sdk.py
@@ -1,8 +1,10 @@
 """
 SDK module for interacting with the Ragas API service.
 """
+
 import json
 import os
+from datetime import datetime, timezone
 from functools import lru_cache
 
 import requests
@@ -11,7 +13,6 @@ from ragas._analytics import get_userid
 from ragas._version import __version__
 from ragas.exceptions import UploadException
 from ragas.utils import base_logger
-from datetime import datetime, timezone
 
 # endpoint for uploading results
 RAGAS_API_URL = "https://api.ragas.io"
@@ -102,7 +103,7 @@ def upload_packet(path: str, data_json_string: str):
         f"{base_url}/api/v1{path}",
         data=data_json_string,
         headers=headers,
-        timeout=(connection_timeout, read_timeout)
+        timeout=(connection_timeout, read_timeout),
     )
 
     if enable_http_log:
@@ -118,7 +119,11 @@ def upload_packet(path: str, data_json_string: str):
             print(f"    {json.dumps(response_data, indent=2)}")
         except Exception:
             print("\nresponse:")
-            print("  status: ERROR" if response.status_code >= 400 else "  status: SUCCESS")
+            print(
+                "  status: ERROR"
+                if response.status_code >= 400
+                else "  status: SUCCESS"
+            )
             print(f"  status_code: {response.status_code}")
             print("  data:")
             print(f"    {response.text}")


### PR DESCRIPTION
The issue arises because `self.single_turn_prompt.instruction` and `self.multi_turn_prompt.instruction` were not being properly assigned during the initialization of `SimpleCriteriaScore()`.