### PR TITLE
fix SingleHopQuerySynthesizer::prepare_combinations()

### DIFF
--- a/src/ragas/testset/synthesizers/single_hop/base.py
+++ b/src/ragas/testset/synthesizers/single_hop/base.py
@@ -64,9 +64,9 @@ class SingleHopQuerySynthesizer(BaseSynthesizer[Scenario]):
             if any(term.lower() in concepts for term in terms):
                 if persona_list[persona]:
                     valid_personas.append(persona_list[persona])
-            sample["personas"] = valid_personas
-            sample["styles"] = list(QueryStyle)
-            sample["lengths"] = list(QueryLength)
+        sample["personas"] = valid_personas
+        sample["styles"] = list(QueryStyle)
+        sample["lengths"] = list(QueryLength)
 
         return [sample]
 


### PR DESCRIPTION
This bug probably raise a KeyError since `personas` is not set.

This could be a bug due to an oversight.

Related to #1917 