### PR TITLE
Ndarray dtype fix, improve error wording

### DIFF
--- a/src/ragas/exceptions.py
+++ b/src/ragas/exceptions.py
@@ -37,7 +37,7 @@ class LLMDidNotFinishException(RagasException):
     """
 
     def __init__(self):
-        msg = "The LLM generation was not completed. Please increase try increasing the max_tokens and try again."
+        msg = "The LLM generation was not completed. Please increase the max_tokens and try again."
         super().__init__(msg)
 
 

--- a/src/ragas/metrics/_factual_correctness.py
+++ b/src/ragas/metrics/_factual_correctness.py
@@ -233,7 +233,13 @@ class FactualCorrectness(MetricWithLLM, SingleTurnMetric):
         response = await self.nli_prompt.generate(
             data=prompt_input, llm=self.llm, callbacks=callbacks
         )
-        return np.array([bool(result.verdict) for result in response.statements])
+        if response.statements:
+            claim_verifications = np.array(
+                [bool(result.verdict) for result in response.statements]
+            )
+        else:
+            claim_verifications = np.array([], dtype=bool)
+        return claim_verifications
 
     async def _single_turn_ascore(
         self, sample: SingleTurnSample, callbacks: Callbacks
@@ -255,9 +261,8 @@ class FactualCorrectness(MetricWithLLM, SingleTurnMetric):
                 premise=response, hypothesis_list=reference_claims, callbacks=callbacks
             )
         else:
-            response_reference = np.array([])
+            response_reference = np.array([], dtype=bool)
 
-        response_reference = np.array(response_reference, dtype=bool)
         tp = sum(reference_response)
         fp = sum(~reference_response)
         if self.mode != "precision":


### PR DESCRIPTION
1. I have noticed that if `response.statements` is an empty list, then the output of `verify_claims` function is `array([], dtype=float64)`, which raises a type error when `~` operation is applied to `reference_response` variable. This occurs in a rare case when hypothesis_list is empty (when there are no claims in the response).
2. A small change is the choice of words in `LLMDidNotFinishException`