### PR TITLE
Enable Runtime Checks for ModeMetric Protocol

### DIFF
--- a/src/ragas/metrics/base.py
+++ b/src/ragas/metrics/base.py
@@ -732,7 +732,7 @@ class Ensember:
 
         return verdict_agg
 
-
+@t.runtime_checkable
 class ModeMetric(t.Protocol):
     name: str
     mode: str


### PR DESCRIPTION
Add @t.runtime_checkable to the ModeMetric protocol to allow runtime type checking using isinstance() and issubclass().