### PR TITLE
fix: return valid JSON output schema

### DIFF
--- a/src/ragas/prompt/pydantic_prompt.py
+++ b/src/ragas/prompt/pydantic_prompt.py
@@ -45,7 +45,7 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
         return (
             f"Please return the output in a JSON format that complies with the "
             f"following schema as specified in JSON Schema:\n"
-            f"{self.output_model.model_json_schema()}"
+            f"{json.dumps(self.output_model.model_json_schema())}"
             "Do not use single quotes in your response but double quotes,"
             "properly escaped with a backslash."
         )


### PR DESCRIPTION
Use json.dumps() on the dict output of Pydantics's BaseModel.model_json_schema() to ensure the string representation is valid JSON using double quotes instead of single quotes.