### PR TITLE
Update default.py - Missing `cosine_similarity` transform for docs with Token Count 101–500

### DIFF
--- a/src/ragas/testset/transforms/default.py
+++ b/src/ragas/testset/transforms/default.py
@@ -154,7 +154,7 @@ def default_transforms(
             summary_extractor,
             node_filter,
             Parallel(summary_emb_extractor, theme_extractor, ner_extractor),
-            ner_overlap_sim,
+            Parallel(cosine_sim_builder, ner_overlap_sim),
         ]
     else:
         raise ValueError(


### PR DESCRIPTION
The `default_ transforms`  function defined at  `src/ragas/testset/transforms/default.py` has a problem with handling transforms for documents with 101-500 tokens.

The code divides the `transforms` configurations based on the document's token count.  Several transforms are instantiated when the ["101-500" token count bins the first quartile (Q1](https://github.com/explodinggradients/ragas/blob/2bc29a2b8358ddb6b167fdf7ab0518ad9371463c/src/ragas/testset/transforms/default.py#L128), among them the `cosine_sim_builder`.  While `cosine_sim_builder` is correctly **instantiated** (line 139), it's then **not included** in the list of transforms that are actually returned (line 153).

It appears that `cosine_sim_builder` was likely unintentionally omitted from the returned transforms list.  The intended behavior should probably mirror how `ner_overlap_sim` is handled (line 120), where `cosine_sim_builder` is instantiated and added to the returned list.  The current code effectively instantiates `cosine_sim_builder` but then discards it. This omission might impact the number of relationships created in the knowledge graph. 