### PR TITLE
OpenAI model cost based on model name fix

### DIFF
--- a/src/ragas/cost.py
+++ b/src/ragas/cost.py
@@ -67,8 +67,10 @@ def get_token_usage_for_openai(
         return TokenUsage(input_tokens=0, output_tokens=0)
     output_tokens = get_from_dict(llm_output, "token_usage.completion_tokens", 0)
     input_tokens = get_from_dict(llm_output, "token_usage.prompt_tokens", 0)
+    model_name = get_from_dict(llm_output, "model_name", "")
 
-    return TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens)
+
+    return TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens, model=model_name)
 
 
 def get_token_usage_for_anthropic(

--- a/src/ragas/cost.py
+++ b/src/ragas/cost.py
@@ -70,7 +70,6 @@ def get_token_usage_for_openai(
     input_tokens = get_from_dict(llm_output, "token_usage.prompt_tokens", 0)
     model_name = get_from_dict(llm_output, "model_name", "")
 
-
     return TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens, model=model_name)
 
 
@@ -95,10 +94,14 @@ def get_token_usage_for_anthropic(
                                 "usage.output_tokens",
                                 0,
                             ),
+                            model=get_from_dict(
+                                g.message.response_metadata,
+                                "model",
+                                "")
                         )
                     )
 
-        return sum(token_usages, TokenUsage(input_tokens=0, output_tokens=0))
+        return sum(token_usages, TokenUsage(input_tokens=0, output_tokens=0, model=token_usages[0].model))
     else:
         return TokenUsage(input_tokens=0, output_tokens=0)
 
@@ -123,10 +126,15 @@ def get_token_usage_for_bedrock(
                                 "usage.completion_tokens",
                                 0,
                             ),
+                            model=get_from_dict(
+                                g.message.response_metadata,
+                                "model_id"
+                            )
+
                         )
                     )
 
-        return sum(token_usages, TokenUsage(input_tokens=0, output_tokens=0))
+        return sum(token_usages, TokenUsage(input_tokens=0, output_tokens=0, model=token_usages[0].model))
     return TokenUsage(input_tokens=0, output_tokens=0)
 
 

--- a/src/ragas/cost.py
+++ b/src/ragas/cost.py
@@ -22,6 +22,7 @@ class TokenUsage(BaseModel):
             return TokenUsage(
                 input_tokens=self.input_tokens + y.input_tokens,
                 output_tokens=self.output_tokens + y.output_tokens,
+                model=self.model
             )
         else:
             raise ValueError("Cannot add TokenUsage objects with different models")

--- a/src/ragas/cost.py
+++ b/src/ragas/cost.py
@@ -68,9 +68,9 @@ def get_token_usage_for_openai(
         return TokenUsage(input_tokens=0, output_tokens=0)
     output_tokens = get_from_dict(llm_output, "token_usage.completion_tokens", 0)
     input_tokens = get_from_dict(llm_output, "token_usage.prompt_tokens", 0)
-    model_name = get_from_dict(llm_output, "model_name", "")
+    model = get_from_dict(llm_output, "model_name", "")
 
-    return TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens, model=model_name)
+    return TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens, model=model)
 
 
 def get_token_usage_for_anthropic(
@@ -100,8 +100,10 @@ def get_token_usage_for_anthropic(
                                 "")
                         )
                     )
-
-        return sum(token_usages, TokenUsage(input_tokens=0, output_tokens=0, model=token_usages[0].model))
+        model = next(
+        (usage.model for usage in token_usages if usage.model), ""
+        )
+        return sum(token_usages, TokenUsage(input_tokens=0, output_tokens=0, model=model))
     else:
         return TokenUsage(input_tokens=0, output_tokens=0)
 
@@ -128,13 +130,15 @@ def get_token_usage_for_bedrock(
                             ),
                             model=get_from_dict(
                                 g.message.response_metadata,
-                                "model_id"
+                                "model_id",
+                                ""
                             )
-
                         )
                     )
-
-        return sum(token_usages, TokenUsage(input_tokens=0, output_tokens=0, model=token_usages[0].model))
+        model = next(
+        (usage.model for usage in token_usages if usage.model), ""
+        )
+        return sum(token_usages, TokenUsage(input_tokens=0, output_tokens=0, model=model))
     return TokenUsage(input_tokens=0, output_tokens=0)
 
 

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -133,19 +133,19 @@ bedrock_claude_result = LLMResult(
 def test_parse_llm_results():
     # openai
     token_usage = get_token_usage_for_openai(openai_llm_result)
-    assert token_usage == TokenUsage(input_tokens=10, output_tokens=10)
+    assert token_usage == TokenUsage(input_tokens=10, output_tokens=10, model="gpt-4o")
 
     # anthropic
     token_usage = get_token_usage_for_anthropic(anthropic_llm_result)
-    assert token_usage == TokenUsage(input_tokens=9, output_tokens=12)
+    assert token_usage == TokenUsage(input_tokens=9, output_tokens=12, model="claude-3-opus-20240229")
 
     # Bedrock LLaMa
     token_usage = get_token_usage_for_bedrock(bedrock_llama_result)
-    assert token_usage == TokenUsage(input_tokens=10, output_tokens=10)
+    assert token_usage == TokenUsage(input_tokens=10, output_tokens=10, model="us.meta.llama3-1-70b-instruct-v1:0")
 
     # Bedrock Claude
     token_usage = get_token_usage_for_bedrock(bedrock_claude_result)
-    assert token_usage == TokenUsage(input_tokens=10, output_tokens=10)
+    assert token_usage == TokenUsage(input_tokens=10, output_tokens=10, model="us.anthropic.claude-3-5-sonnet-20240620-v1:0")
 
 
 def test_cost_callback_handler():
@@ -153,7 +153,7 @@ def test_cost_callback_handler():
     cost_cb.on_llm_end(openai_llm_result)
 
     # cost
-    assert cost_cb.total_tokens() == TokenUsage(input_tokens=10, output_tokens=10)
+    assert cost_cb.total_tokens() == TokenUsage(input_tokens=10, output_tokens=10, model="gpt-4o")
 
     assert cost_cb.total_cost(0.1) == 2.0
     assert (


### PR DESCRIPTION
the `CostCallbackHandler.total_cost` method can take a dictionary of models and associated cost per i/o tokens. However, this was not functional because the token usage parser did not save the model's name. The model's name was also removed after adding TokenUsage objects together. I fixed these issues for the OpenAI parser. 

Note that the same problem still exists for the anthropic and bedrock parsers. I did not update this, since I don't use these API's and would not be able to test my implementation.