### PR TITLE
Fix: Prevent 'temperature' Attribute Error for Models That Don't Support It

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -204,7 +204,7 @@ class LangchainLLMWrapper(BaseRagasLLM):
         old_temperature: float | None = None
         if temperature is None:
             temperature = self.get_temperature(n=n)
-        if hasattr(self.langchain_llm, "temperature"):
+        if hasattr(self.langchain_llm, "temperature") and temperature is not None:
             self.langchain_llm.temperature = temperature  # type: ignore
             old_temperature = temperature
 
@@ -244,7 +244,7 @@ class LangchainLLMWrapper(BaseRagasLLM):
         old_temperature: float | None = None
         if temperature is None:
             temperature = self.get_temperature(n=n)
-        if hasattr(self.langchain_llm, "temperature"):
+        if hasattr(self.langchain_llm, "temperature") and temperature is not None:
             self.langchain_llm.temperature = temperature  # type: ignore
             old_temperature = temperature
 


### PR DESCRIPTION
This PR fixes an issue where specifying a model that does not support the temperature parameter in LangchainLLMWrapper resulted in an API error and prevented responses from being generated.

Changes Made:
Modified the attribute check for temperature in LangchainLLMWrapper.
Now, the check ensures that temperature is both present and not None before applying it.
Fixes #1945 