### PR TITLE
fix: optimize knowledge graph clustering for large corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,10 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# Cursor
+.cursorignore
+.cursor/
+
 # Ragas specific
 experiments/
 **/fil-result/

--- a/src/ragas/testset/graph.py
+++ b/src/ragas/testset/graph.py
@@ -320,7 +320,7 @@ class KnowledgeGraph:
         depth_limit: int = 3,
     ) -> t.List[t.Set[Node]]:
         """
-        Finds up to n indirect clusters of nodes in the knowledge graph based on a relationship condition.
+        Return n indirect clusters of nodes in the knowledge graph based on a relationship condition.
         Optimized for large datasets by using an adjacency index for lookups and limiting path exploration
         relative to n.
 
@@ -342,7 +342,8 @@ class KnowledgeGraph:
         Parameters
         ----------
         n : int
-            Maximum number of clusters to return. Must be at least 1.
+            Target number of clusters to return. Must be at least 1. Should return n clusters unless the graph is 
+            extremely sparse.
         relationship_condition : Callable[[Relationship], bool], optional
             A function that takes a Relationship and returns a boolean, by default lambda _: True
         depth_limit : int, optional

--- a/src/ragas/testset/graph.py
+++ b/src/ragas/testset/graph.py
@@ -342,7 +342,7 @@ class KnowledgeGraph:
         Parameters
         ----------
         n : int
-            Target number of clusters to return. Must be at least 1. Should return n clusters unless the graph is 
+            Target number of clusters to return. Must be at least 1. Should return n clusters unless the graph is
             extremely sparse.
         relationship_condition : Callable[[Relationship], bool], optional
             A function that takes a Relationship and returns a boolean, by default lambda _: True
@@ -452,7 +452,9 @@ class KnowledgeGraph:
             # Cycle through the start node clusters
             current_index = i % len(start_node_clusters_list)
 
-            current_start_node_clusters: set[frozenset[Node]] = start_node_clusters_list[current_index]
+            current_start_node_clusters: set[frozenset[Node]] = (
+                start_node_clusters_list[current_index]
+            )
             cluster: frozenset[Node] = current_start_node_clusters.pop()
 
             # Check if the new cluster is a subset of any existing cluster

--- a/src/ragas/testset/synthesizers/multi_hop/abstract.py
+++ b/src/ragas/testset/synthesizers/multi_hop/abstract.py
@@ -42,9 +42,10 @@ class MultiHopAbstractQuerySynthesizer(MultiHopQuerySynthesizer):
     concept_combination_prompt: PydanticPrompt = ConceptCombinationPrompt()
     theme_persona_matching_prompt: PydanticPrompt = ThemesPersonasMatchingPrompt()
 
-    def get_node_clusters(self, knowledge_graph: KnowledgeGraph) -> t.List[t.Set[Node]]:
+    def get_node_clusters(self, n: int, knowledge_graph: KnowledgeGraph) -> t.List[t.Set[Node]]:
 
-        node_clusters = knowledge_graph.find_indirect_clusters(
+        node_clusters = knowledge_graph.find_n_indirect_clusters(
+            n,
             relationship_condition=lambda rel: (
                 True if rel.get_property("summary_similarity") else False
             ),
@@ -72,7 +73,7 @@ class MultiHopAbstractQuerySynthesizer(MultiHopQuerySynthesizer):
         4. Sample diverse combinations of scenarios to get n samples
         """
 
-        node_clusters = self.get_node_clusters(knowledge_graph)
+        node_clusters = self.get_node_clusters(n, knowledge_graph)
         scenarios = []
 
         if len(node_clusters) == 0:

--- a/src/ragas/testset/synthesizers/multi_hop/abstract.py
+++ b/src/ragas/testset/synthesizers/multi_hop/abstract.py
@@ -42,7 +42,9 @@ class MultiHopAbstractQuerySynthesizer(MultiHopQuerySynthesizer):
     concept_combination_prompt: PydanticPrompt = ConceptCombinationPrompt()
     theme_persona_matching_prompt: PydanticPrompt = ThemesPersonasMatchingPrompt()
 
-    def get_node_clusters(self, n: int, knowledge_graph: KnowledgeGraph) -> t.List[t.Set[Node]]:
+    def get_node_clusters(
+        self, n: int, knowledge_graph: KnowledgeGraph
+    ) -> t.List[t.Set[Node]]:
 
         node_clusters = knowledge_graph.find_n_indirect_clusters(
             n,

--- a/src/ragas/testset/synthesizers/multi_hop/abstract.py
+++ b/src/ragas/testset/synthesizers/multi_hop/abstract.py
@@ -45,6 +45,7 @@ class MultiHopAbstractQuerySynthesizer(MultiHopQuerySynthesizer):
     def get_node_clusters(
         self, n: int, knowledge_graph: KnowledgeGraph
     ) -> t.List[t.Set[Node]]:
+        """Find n indirect clusters of nodes based on relationship condition"""
 
         node_clusters = knowledge_graph.find_n_indirect_clusters(
             n,
@@ -66,7 +67,7 @@ class MultiHopAbstractQuerySynthesizer(MultiHopQuerySynthesizer):
         """
         Generates a list of scenarios on type MultiHopAbstractQuerySynthesizer
         Steps to generate scenarios:
-        1. Find indirect clusters of nodes based on relationship condition
+        1. Find n indirect clusters of nodes based on relationship condition
         2. Calculate the number of samples that should be created per cluster to get n samples in total
         3. For each cluster of nodes
             a. Find the child nodes of the cluster nodes
@@ -84,12 +85,14 @@ class MultiHopAbstractQuerySynthesizer(MultiHopQuerySynthesizer):
             )
         num_sample_per_cluster = int(np.ceil(n / len(node_clusters)))
 
+        child_relationships = [rel for rel in knowledge_graph.relationships if rel.type == "child"]
+        
         for cluster in node_clusters:
             if len(scenarios) >= n:
                 break
             nodes = []
             for node in cluster:
-                child_nodes = get_child_nodes(node, knowledge_graph, level=1)
+                child_nodes = [rel.target for rel in child_relationships if rel.source == node]
                 if child_nodes:
                     nodes.extend(child_nodes)
                 else:

--- a/src/ragas/testset/synthesizers/multi_hop/abstract.py
+++ b/src/ragas/testset/synthesizers/multi_hop/abstract.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from ragas.prompt import PydanticPrompt
 from ragas.testset.graph import KnowledgeGraph, Node
-from ragas.testset.graph_queries import get_child_nodes
 from ragas.testset.persona import Persona
 from ragas.testset.synthesizers.multi_hop.base import (
     MultiHopQuerySynthesizer,
@@ -85,14 +84,18 @@ class MultiHopAbstractQuerySynthesizer(MultiHopQuerySynthesizer):
             )
         num_sample_per_cluster = int(np.ceil(n / len(node_clusters)))
 
-        child_relationships = [rel for rel in knowledge_graph.relationships if rel.type == "child"]
-        
+        child_relationships = [
+            rel for rel in knowledge_graph.relationships if rel.type == "child"
+        ]
+
         for cluster in node_clusters:
             if len(scenarios) >= n:
                 break
             nodes = []
             for node in cluster:
-                child_nodes = [rel.target for rel in child_relationships if rel.source == node]
+                child_nodes = [
+                    rel.target for rel in child_relationships if rel.source == node
+                ]
                 if child_nodes:
                     nodes.extend(child_nodes)
                 else:

--- a/tests/unit/test_knowledge_graph_clusters.py
+++ b/tests/unit/test_knowledge_graph_clusters.py
@@ -39,8 +39,8 @@ def create_document_node(name: str) -> Node:
             "summary": f"{name} summary",
             "document_metadata": {},
             "summary_embedding": [0.001, 0.002, 0.003],
-            "themes": [],
-            "entities": [],
+            "themes": [f"T_{name}"],
+            "entities": [f"E_d_{name}"],
         },
     )
 
@@ -54,8 +54,8 @@ def create_chunk_node(name: str) -> Node:
             "page_content": f"{name} content",
             "summary": f"{name} summary",
             "summary_embedding": [0.001, 0.002, 0.003],
-            "themes": [],
-            "entities": [],
+            "themes": [f"T_{name}"],
+            "entities": [f"E_c_{name}"],
         },
     )
 
@@ -133,7 +133,8 @@ def create_chain_of_overlaps(starting_node: Node, node_count: int = 3, cycle: bo
     relationships: list[Relationship] = []
 
     # Use starting_node as the first node and set its entity
-    starting_node.properties["entities"] = [f"E_{starting_node.id}_1"]
+    first_entity = f"E_{starting_node.id}_1"
+    starting_node.properties["entities"] = [first_entity, *starting_node.properties["entities"]]
     nodes.append(starting_node)
 
     # Create relationships and remaining node
@@ -164,7 +165,6 @@ def create_chain_of_overlaps(starting_node: Node, node_count: int = 3, cycle: bo
 
     if cycle and node_count > 1:
         # For the cycle, the last node should share an entity with the first node
-        first_entity = f"E_{starting_node.id}_1"
         nodes[-1].properties["entities"].append(first_entity)
 
         cycle_rel = Relationship(

--- a/tests/unit/test_knowledge_graph_clusters.py
+++ b/tests/unit/test_knowledge_graph_clusters.py
@@ -1,0 +1,664 @@
+import pytest
+import uuid
+from ragas.testset.graph import KnowledgeGraph, Node, NodeType, Relationship
+
+
+class DebugUUID(uuid.UUID):
+    """
+    A UUID subclass that displays a debug name instead of the UUID value.
+    Creates a more readable graph representation in logs/debuggers while maintaining UUID compatibility.
+    """
+
+    def __init__(self, debug_name):
+        # Create a random UUID internally
+        self.debug = debug_name
+        super().__init__(hex=str(uuid.uuid4()))
+
+    def __str__(self):
+        return self.debug
+
+    def __repr__(self):
+        return f"DebugUUID('{self.debug}')"
+
+    def __setattr__(self, name, value):
+        object.__setattr__(self, name, value)
+
+
+def create_document_node(name):
+    """Helper function to create a document node with proper structure."""
+    return Node(
+        id=DebugUUID(name),
+        type=NodeType.DOCUMENT,
+        properties={
+            "page_content": f"{name} content",
+            "summary": f"{name} summary",
+            "document_metadata": {},
+            "summary_embedding": [0.001, 0.002, 0.003],
+            "themes": [],
+            "entities": [],
+        },
+    )
+
+
+def create_chunk_node(name):
+    """Helper function to create a chunk node with proper structure."""
+    return Node(
+        id=DebugUUID(name),
+        type=NodeType.CHUNK,
+        properties={
+            "page_content": f"{name} content",
+            "summary": f"{name} summary",
+            "summary_embedding": [0.001, 0.002, 0.003],
+            "themes": [],
+            "entities": [],
+        },
+    )
+
+
+def create_chain_of_similarities(starting_node, node_count=5):
+    """
+    Create a chain of document nodes with cosine similarity relationships.
+
+    Parameters
+    ----------
+    starting_node : Node
+        Node to start the chain from. This will be the first node in the chain.
+    node_count : int
+        Number of nodes to create
+
+    Returns
+    -------
+    tuple
+        (list of nodes, list of relationships)
+    """
+    # Create document nodes
+    nodes = []
+
+    # Use starting_node as the first node
+    nodes.append(starting_node)
+
+    # Create remaining nodes
+    for i in range(node_count - 1):
+        nodes.append(create_document_node(name=f"sim_from_{starting_node.id}_{i + 1}"))
+
+    # Create chain of cosine similarity relationships
+    relationships = []
+    for i in range(node_count - 1):
+        rel = Relationship(
+            source=nodes[i],
+            target=nodes[i + 1],
+            type="cosine_similarity",
+            bidirectional=True,
+            properties={"summary_similarity": 0.9},
+        )
+        relationships.append(rel)
+
+    return nodes, relationships
+
+
+def create_chain_of_overlap_nodes(starting_node, node_count=3):
+    """
+    Create a chain of nodes with entity overlap relationships.
+
+    Parameters
+    ----------
+    starting_node : Node
+        Node to start the chain from. This will be the first node in the chain.
+    node_count : int
+        Number of nodes to create
+
+    Returns
+    -------
+    tuple
+        (list of nodes, list of relationships)
+    """
+    # Create nodes (mix of document and chunk nodes)
+    nodes = []
+    relationships = []
+
+    # Use starting_node as the first node and set its entity
+    starting_node.properties["entities"] = [f"E_{starting_node.id}_1"]
+    nodes.append(starting_node)
+
+    # Create relationships and remaining node
+    prev_node = starting_node
+    for i in range(node_count - 1):
+        # Realistic entity assignment
+        prev_entity = f"E_{starting_node.id}_{i + 1}"
+        new_entity = f"E_{starting_node.id}_{i + 2}"
+
+        new_node = create_document_node(name=f"overlap_from_{starting_node.id}_{i + 1}")
+
+        # Add entities to the new node, including overlap w/ previous node
+        new_node.properties["entities"] = [prev_entity, new_entity]
+        nodes.append(new_node)
+
+        rel = Relationship(
+            source=prev_node,
+            target=new_node,
+            type="entities_overlap",
+            bidirectional=False,
+            properties={
+                "entities_overlap_score": 0.1,
+                "overlapped_items": [[prev_entity, prev_entity]],
+            },
+        )
+        relationships.append(rel)
+        prev_node = new_node
+
+    return nodes, relationships
+
+
+def create_document_and_child_nodes():
+    """
+    Create a document node and its child chunk nodes with the same structure as create_branched_graph.
+
+    Returns
+    -------
+    tuple
+        (dict of nodes, list of relationships)
+    """
+    # Create nodes - A is a document, the rest are chunks
+    nodes = {
+        "A": create_document_node("A"),
+        "B": create_chunk_node("B"),
+        "C": create_chunk_node("C"),
+        "D": create_chunk_node("D"),
+        "E": create_chunk_node("E"),
+    }
+
+    # Create "child" relationships from document to chunks
+    child_relationships = [
+        Relationship(
+            source=nodes["A"],
+            target=nodes["B"],
+            type="child",
+            bidirectional=False,
+            properties={},
+        ),
+        Relationship(
+            source=nodes["A"],
+            target=nodes["C"],
+            type="child",
+            bidirectional=False,
+            properties={},
+        ),
+        Relationship(
+            source=nodes["A"],
+            target=nodes["D"],
+            type="child",
+            bidirectional=False,
+            properties={},
+        ),
+        Relationship(
+            source=nodes["A"],
+            target=nodes["E"],
+            type="child",
+            bidirectional=False,
+            properties={},
+        ),
+    ]
+
+    # Create "next" relationships between chunks
+    next_relationships = [
+        Relationship(
+            source=nodes["B"],
+            target=nodes["C"],
+            type="next",
+            bidirectional=False,
+            properties={},
+        ),
+        Relationship(
+            source=nodes["C"],
+            target=nodes["D"],
+            type="next",
+            bidirectional=False,
+            properties={},
+        ),
+        Relationship(
+            source=nodes["D"],
+            target=nodes["E"],
+            type="next",
+            bidirectional=False,
+            properties={},
+        ),
+    ]
+
+    # Combine all relationships
+    relationships = child_relationships + next_relationships
+
+    return nodes, relationships
+
+
+def build_knowledge_graph(nodes, relationships):
+    """
+    Build a knowledge graph from nodes and relationships.
+
+    Parameters
+    ----------
+    nodes : list or dict
+        Nodes to add to the graph
+    relationships : list
+        Relationships to add to the graph
+
+    Returns
+    -------
+    KnowledgeGraph
+        The constructed knowledge graph
+    """
+    kg = KnowledgeGraph()
+
+    # Add nodes to the graph
+    if isinstance(nodes, dict):
+        for node in nodes.values():
+            kg.add(node)
+    else:
+        for node in nodes:
+            kg.add(node)
+
+    # Add relationships to the graph
+    for rel in relationships:
+        kg.add(rel)
+
+    return kg
+
+
+def test_find_indirect_clusters_with_document_and_children():
+    """Test find_indirect_clusters with a document and its child nodes."""
+    # Create nodes and relationships
+    nodes, relationships = create_document_and_child_nodes()
+
+    # Build knowledge graph
+    kg = build_knowledge_graph(nodes, relationships)
+
+    # Find clusters
+    clusters = kg.find_indirect_clusters(depth_limit=10)
+
+    # Define expected clusters based on the graph structure and the find_indirect_clusters algorithm
+    # The algorithm creates clusters for each path through the graph
+    expected_clusters = [
+        {nodes["A"], nodes["B"]},  # A->B
+        {nodes["A"], nodes["C"]},  # A->C
+        {nodes["A"], nodes["D"]},  # A->D
+        {nodes["A"], nodes["E"]},  # A->E
+        {nodes["B"], nodes["C"]},  # B->C
+        {nodes["C"], nodes["D"]},  # C->D
+        {nodes["D"], nodes["E"]},  # D->E
+        {nodes["A"], nodes["B"], nodes["C"]},  # A->B->C
+        {nodes["A"], nodes["C"], nodes["D"]},  # A->C->D
+        {nodes["A"], nodes["D"], nodes["E"]},  # A->D->E
+        {nodes["B"], nodes["C"], nodes["D"]},  # B->C->D
+        {nodes["C"], nodes["D"], nodes["E"]},  # C->D->E
+        {nodes["A"], nodes["B"], nodes["C"], nodes["D"]},  # A->B->C->D
+        {nodes["A"], nodes["C"], nodes["D"], nodes["E"]},  # A->C->D->E
+        {nodes["B"], nodes["C"], nodes["D"], nodes["E"]},  # B->C->D->E
+        {nodes["A"], nodes["B"], nodes["C"], nodes["D"], nodes["E"]},  # A->B->C->D->E
+    ]
+
+    # Convert both lists to sets of frozensets for comparison
+    # This handles the case where the order of clusters doesn't matter
+    actual_clusters_set = {frozenset(cluster) for cluster in clusters}
+    expected_clusters_set = {frozenset(cluster) for cluster in expected_clusters}
+
+    # Assert that the actual clusters match the expected clusters
+    assert (
+        actual_clusters_set == expected_clusters_set
+    ), f"Expected clusters: {expected_clusters_set}\nActual clusters: {actual_clusters_set}"
+
+
+def test_find_indirect_clusters_with_similarity_relationships():
+    """Test find_indirect_clusters with cosine similarity relationships between document nodes."""
+    # Create nodes and relationships
+    nodes, relationships = create_chain_of_similarities(
+        create_document_node("Start"), node_count=4
+    )
+
+    # Build knowledge graph
+    kg = build_knowledge_graph(nodes, relationships)
+
+    # Find clusters
+    clusters = kg.find_indirect_clusters(depth_limit=10)
+
+    # Define expected clusters based on the graph structure and the find_indirect_clusters algorithm
+    # With bidirectional relationships, we expect clusters for each possible path
+    expected_clusters = [
+        {nodes[0], nodes[1]},  # Start->1
+        {nodes[1], nodes[2]},  # 1->2
+        {nodes[2], nodes[3]},  # 2->3
+        {nodes[0], nodes[1], nodes[2]},  # Start->1->2
+        {nodes[1], nodes[2], nodes[3]},  # 1->2->3
+        {nodes[0], nodes[1], nodes[2], nodes[3]},  # Start->1->2->3
+    ]
+
+    # Convert both lists to sets of frozensets for comparison
+    actual_clusters_set = {frozenset(cluster) for cluster in clusters}
+    expected_clusters_set = {frozenset(cluster) for cluster in expected_clusters}
+
+    # Assert that the actual clusters match the expected clusters
+    assert (
+        actual_clusters_set == expected_clusters_set
+    ), f"Expected clusters: {expected_clusters_set}\nActual clusters: {actual_clusters_set}"
+
+
+def test_find_indirect_clusters_with_overlap_relationships():
+    """Test find_indirect_clusters with entity overlap relationships."""
+    # Create nodes and relationships
+    nodes, relationships = create_chain_of_overlap_nodes(
+        create_document_node("Start"), node_count=4
+    )
+
+    # Build knowledge graph
+    kg = build_knowledge_graph(nodes, relationships)
+
+    # Find clusters
+    clusters = kg.find_indirect_clusters(depth_limit=10)
+
+    # Define expected clusters based on the graph structure and the find_indirect_clusters algorithm
+    # With unidirectional relationships, we expect clusters for each path
+    expected_clusters = [
+        {nodes[0], nodes[1]},  # Start->1
+        {nodes[1], nodes[2]},  # 1->2
+        {nodes[2], nodes[3]},  # 2->3
+        {nodes[0], nodes[1], nodes[2]},  # Start->1->2
+        {nodes[1], nodes[2], nodes[3]},  # 1->2->3
+        {nodes[0], nodes[1], nodes[2], nodes[3]},  # Start->1->2->3
+    ]
+
+    # Convert both lists to sets of frozensets for comparison
+    actual_clusters_set = {frozenset(cluster) for cluster in clusters}
+    expected_clusters_set = {frozenset(cluster) for cluster in expected_clusters}
+
+    # Assert that the actual clusters match the expected clusters
+    assert (
+        actual_clusters_set == expected_clusters_set
+    ), f"Expected clusters: {expected_clusters_set}\nActual clusters: {actual_clusters_set}"
+
+
+def test_find_indirect_clusters_with_condition():
+    """Test find_indirect_clusters with a relationship condition."""
+    # Create nodes and relationships
+    nodes, relationships = create_document_and_child_nodes()
+
+    # Build knowledge graph
+    kg = build_knowledge_graph(nodes, relationships)
+
+    # Find clusters with condition: only consider "next" relationships
+    def condition(rel):
+        return rel.type == "next"
+
+    clusters = kg.find_indirect_clusters(relationship_condition=condition)
+
+    # Define expected clusters based on the graph structure and the condition
+    # Only "next" relationships are considered, so we should only have paths between B, C, D, and E
+    expected_clusters = [
+        {nodes["B"], nodes["C"]},  # B->C
+        {nodes["C"], nodes["D"]},  # C->D
+        {nodes["D"], nodes["E"]},  # D->E
+        {nodes["B"], nodes["C"], nodes["D"]},  # B->C->D
+        {nodes["C"], nodes["D"], nodes["E"]},  # C->D->E
+    ]
+
+    # Convert both lists to sets of frozensets for comparison
+    actual_clusters_set = {frozenset(cluster) for cluster in clusters}
+    expected_clusters_set = {frozenset(cluster) for cluster in expected_clusters}
+
+    # Assert that the actual clusters match the expected clusters
+    assert (
+        actual_clusters_set == expected_clusters_set
+    ), f"Expected clusters: {expected_clusters_set}\nActual clusters: {actual_clusters_set}"
+
+
+def test_find_indirect_clusters_with_bidirectional():
+    """Test find_indirect_clusters with bidirectional relationships."""
+    # Create document nodes with similarity relationships (which are bidirectional)
+    nodes, relationships = create_chain_of_similarities(
+        create_document_node("Start"), node_count=3
+    )
+
+    # Build knowledge graph
+    kg = build_knowledge_graph(nodes, relationships)
+
+    # Find clusters
+    clusters = kg.find_indirect_clusters(depth_limit=10)
+
+    # Define expected clusters based on the graph structure
+    # With bidirectional relationships, we expect clusters for each possible path
+    expected_clusters = [
+        {nodes[0], nodes[1]},  # Start->1
+        {nodes[1], nodes[2]},  # 1->2
+        {nodes[0], nodes[1], nodes[2]},  # Start->1->2
+    ]
+
+    # Convert both lists to sets of frozensets for comparison
+    actual_clusters_set = {frozenset(cluster) for cluster in clusters}
+    expected_clusters_set = {frozenset(cluster) for cluster in expected_clusters}
+
+    # Assert that the actual clusters match the expected clusters
+    assert (
+        actual_clusters_set == expected_clusters_set
+    ), f"Expected clusters: {expected_clusters_set}\nActual clusters: {actual_clusters_set}"
+
+
+def test_find_indirect_clusters_depth_limit():
+    """Test find_indirect_clusters with a depth limit."""
+    # Create nodes and relationships
+    nodes, relationships = create_document_and_child_nodes()
+
+    # Build knowledge graph
+    kg = build_knowledge_graph(nodes, relationships)
+
+    # Find clusters with depth limit 1
+    clusters_depth_1 = kg.find_indirect_clusters(depth_limit=1)
+
+    # Define expected clusters for depth limit 1
+    # With depth limit 1, we should only have direct connections (pairs of nodes)
+    expected_clusters_depth_1 = (
+        []
+    )  # The actual implementation returns an empty set for depth_limit=1
+
+    # Convert both lists to sets of frozensets for comparison
+    actual_clusters_depth_1_set = {frozenset(cluster) for cluster in clusters_depth_1}
+    expected_clusters_depth_1_set = {
+        frozenset(cluster) for cluster in expected_clusters_depth_1
+    }
+
+    # Assert that the actual clusters match the expected clusters for depth limit 1
+    assert (
+        actual_clusters_depth_1_set == expected_clusters_depth_1_set
+    ), f"Expected clusters (depth 1): {expected_clusters_depth_1_set}\nActual clusters: {actual_clusters_depth_1_set}"
+
+    # Find clusters with depth limit 3 (default)
+    clusters_depth_3 = kg.find_indirect_clusters()
+
+    # Define expected clusters for depth limit 3
+    # With depth limit 3, we should have paths up to length 4 (including the start node)
+    expected_clusters_depth_3 = [
+        {nodes["A"], nodes["B"]},  # A->B
+        {nodes["A"], nodes["C"]},  # A->C
+        {nodes["A"], nodes["D"]},  # A->D
+        {nodes["A"], nodes["E"]},  # A->E
+        {nodes["B"], nodes["C"]},  # B->C
+        {nodes["C"], nodes["D"]},  # C->D
+        {nodes["D"], nodes["E"]},  # D->E
+        {nodes["A"], nodes["B"], nodes["C"]},  # A->B->C
+        {nodes["A"], nodes["C"], nodes["D"]},  # A->C->D
+        {nodes["A"], nodes["D"], nodes["E"]},  # A->D->E
+        {nodes["B"], nodes["C"], nodes["D"]},  # B->C->D
+        {nodes["C"], nodes["D"], nodes["E"]},  # C->D->E
+    ]
+
+    # Convert both lists to sets of frozensets for comparison
+    actual_clusters_depth_3_set = {frozenset(cluster) for cluster in clusters_depth_3}
+    expected_clusters_depth_3_set = {
+        frozenset(cluster) for cluster in expected_clusters_depth_3
+    }
+
+    # Assert that the actual clusters match the expected clusters for depth limit 3
+    assert (
+        actual_clusters_depth_3_set == expected_clusters_depth_3_set
+    ), f"Expected clusters (depth 3): {expected_clusters_depth_3_set}\nActual clusters: {actual_clusters_depth_3_set}"
+
+
+def test_find_two_nodes_single_rel_with_similarity():
+    """Test find_two_nodes_single_rel with cosine similarity relationships."""
+    # Create nodes and relationships
+    nodes, relationships = create_chain_of_similarities(
+        create_document_node("Start"), node_count=3
+    )
+
+    # Build knowledge graph
+    kg = build_knowledge_graph(nodes, relationships)
+
+    # Find two-node relationships
+    triplets = kg.find_two_nodes_single_rel()
+
+    # Verify triplets
+    assert len(triplets) == 2
+
+    # Check if all triplets have the correct relationship type
+    for triplet in triplets:
+        assert triplet[1].type == "cosine_similarity"
+        assert "summary_similarity" in triplet[1].properties
+
+
+def test_find_two_nodes_single_rel_with_overlap():
+    """Test find_two_nodes_single_rel with entity overlap relationships."""
+    # Create nodes and relationships
+    nodes, relationships = create_chain_of_overlap_nodes(
+        create_document_node("Start"), node_count=3
+    )
+
+    # Build knowledge graph
+    kg = build_knowledge_graph(nodes, relationships)
+
+    # Find two-node relationships
+    triplets = kg.find_two_nodes_single_rel()
+
+    # Verify triplets
+    assert len(triplets) == 2
+
+    # Check if all triplets have the correct relationship type
+    for triplet in triplets:
+        assert triplet[1].type == "entities_overlap"
+        assert "entities_overlap_score" in triplet[1].properties
+        assert "overlapped_items" in triplet[1].properties
+
+
+def test_find_two_nodes_single_rel_with_condition():
+    """Test find_two_nodes_single_rel with a relationship condition."""
+    # Create nodes and relationships
+    nodes, relationships = create_document_and_child_nodes()
+
+    # Build knowledge graph
+    kg = build_knowledge_graph(nodes, relationships)
+
+    # Find two-node relationships with condition: only consider "child" relationships
+    def condition(rel):
+        return rel.type == "child"
+
+    triplets = kg.find_two_nodes_single_rel(relationship_condition=condition)
+
+    # Verify triplets
+    assert len(triplets) == 4  # Should have 4 child relationships
+
+    # Check if all triplets have the correct relationship type
+    for triplet in triplets:
+        assert triplet[1].type == "child"
+
+        # Verify that one of the nodes is the document node (A)
+        # and the other is one of the chunk nodes (B, C, D, or E)
+        assert nodes["A"] in [triplet[0], triplet[2]]
+        assert triplet[0] == nodes["A"] or triplet[2] == nodes["A"]
+
+        # The other node should be one of the chunk nodes
+        other_node = triplet[0] if triplet[2] == nodes["A"] else triplet[2]
+        assert other_node in [nodes["B"], nodes["C"], nodes["D"], nodes["E"]]
+
+
+def test_find_two_nodes_single_rel_normalized_order():
+    """Test that find_two_nodes_single_rel normalizes the order of nodes based on ID."""
+    # Create nodes with specific UUIDs to ensure consistent ordering
+    node_a = Node(
+        id=DebugUUID("A"),
+        type=NodeType.CHUNK,
+        properties={
+            "page_content": "A content",
+            "summary": "A summary",
+            "summary_embedding": [0.001, 0.002, 0.003],
+            "themes": [],
+            "entities": [],
+        },
+    )
+
+    node_b = Node(
+        id=DebugUUID("B"),
+        type=NodeType.CHUNK,
+        properties={
+            "page_content": "B content",
+            "summary": "B summary",
+            "summary_embedding": [0.001, 0.002, 0.003],
+            "themes": [],
+            "entities": [],
+        },
+    )
+
+    # Create relationship from B to A (reverse of ID order)
+    rel_ba = Relationship(
+        source=node_b, target=node_a, type="next", bidirectional=False, properties={}
+    )
+
+    # Build knowledge graph
+    kg = build_knowledge_graph([node_a, node_b], [rel_ba])
+
+    # Find two-node relationships
+    triplets = kg.find_two_nodes_single_rel()
+
+    # Verify triplets - should have the relationship in the correct order
+    assert len(triplets) == 1
+    triplet = triplets[0]
+
+    # Check the relationship is correct
+    assert triplet[1].type == "next"
+
+    # Check source and target - the actual order depends on how the KnowledgeGraph.find_two_nodes_single_rel
+    # implementation sorts nodes, which may be by string representation or internal UUID value
+    # So we just verify that the relationship is between the two nodes we created
+    assert {triplet[0], triplet[2]} == {node_a, node_b}
+    assert (triplet[0] == node_a and triplet[2] == node_b) or (
+        triplet[0] == node_b and triplet[2] == node_a
+    )
+
+
+def test_find_two_nodes_single_rel_with_self_loops():
+    """Test find_two_nodes_single_rel with self-loops (should be excluded)."""
+    # Create nodes
+    node_a = create_chunk_node("A")
+    node_b = create_chunk_node("B")
+
+    # Create relationships including a self-loop
+    rel_ab = Relationship(
+        source=node_a, target=node_b, type="next", bidirectional=False, properties={}
+    )
+    rel_aa = Relationship(
+        source=node_a,
+        target=node_a,
+        type="self_loop",
+        bidirectional=True,
+        properties={},
+    )
+
+    # Build knowledge graph
+    kg = build_knowledge_graph([node_a, node_b], [rel_ab, rel_aa])
+
+    # Find two-node relationships
+    triplets = kg.find_two_nodes_single_rel()
+
+    # Verify triplets - self-loops should be excluded
+    assert len(triplets) == 1
+
+    # Check if we have only the A-B relationship
+    # The actual implementation returns nodes in a different order than expected
+    assert (triplets[0][0] == node_a and triplets[0][2] == node_b) or (
+        triplets[0][0] == node_b and triplets[0][2] == node_a
+    )
+    assert triplets[0][1].type == "next"

--- a/tests/unit/test_knowledge_graph_clusters.py
+++ b/tests/unit/test_knowledge_graph_clusters.py
@@ -1,7 +1,7 @@
 import random
 import time
+import typing as t
 import uuid
-from typing import Tuple
 
 import pytest
 
@@ -60,7 +60,9 @@ def create_chunk_node(name: str) -> Node:
     )
 
 
-def create_chain_of_similarities(starting_node: Node, node_count: int = 5, cycle: bool = False) -> Tuple[list[Node], list[Relationship]]:
+def create_chain_of_similarities(
+    starting_node: Node, node_count: int = 5, cycle: bool = False
+) -> t.Tuple[list[Node], list[Relationship]]:
     """
     Create a chain of document nodes with cosine similarity relationships.
 
@@ -110,7 +112,9 @@ def create_chain_of_similarities(starting_node: Node, node_count: int = 5, cycle
     return nodes, relationships
 
 
-def create_chain_of_overlaps(starting_node: Node, node_count: int = 3, cycle: bool = False) -> Tuple[list[Node], list[Relationship]]:
+def create_chain_of_overlaps(
+    starting_node: Node, node_count: int = 3, cycle: bool = False
+) -> t.Tuple[list[Node], list[Relationship]]:
     """
     Create a chain of nodes with entity overlap relationships.
 
@@ -134,7 +138,10 @@ def create_chain_of_overlaps(starting_node: Node, node_count: int = 3, cycle: bo
 
     # Use starting_node as the first node and set its entity
     first_entity = f"E_{starting_node.id}_1"
-    starting_node.properties["entities"] = [first_entity, *starting_node.properties["entities"]]
+    starting_node.properties["entities"] = [
+        first_entity,
+        *starting_node.properties["entities"],
+    ]
     nodes.append(starting_node)
 
     # Create relationships and remaining node
@@ -182,7 +189,9 @@ def create_chain_of_overlaps(starting_node: Node, node_count: int = 3, cycle: bo
     return nodes, relationships
 
 
-def create_web_of_similarities(node_count=4, similarity_score=0.9) -> Tuple[list[Node], list[Relationship]]:
+def create_web_of_similarities(
+    node_count=4, similarity_score=0.9
+) -> t.Tuple[list[Node], list[Relationship]]:
     """
     Create a web of document nodes with cosine similarity relationships between them.
     This represents the worst case scenario knowledge graph for the node_count in terms
@@ -222,7 +231,7 @@ def create_web_of_similarities(node_count=4, similarity_score=0.9) -> Tuple[list
     return nodes, relationships
 
 
-def create_document_and_child_nodes() -> Tuple[list[Node], list[Relationship]]:
+def create_document_and_child_nodes() -> t.Tuple[list[Node], list[Relationship]]:
     """
     Create a document node and its child chunk nodes with the same structure as create_branched_graph.
 
@@ -303,7 +312,9 @@ def create_document_and_child_nodes() -> Tuple[list[Node], list[Relationship]]:
     return nodes, relationships
 
 
-def build_knowledge_graph(nodes: list[Node], relationships: list[Relationship]) -> KnowledgeGraph:
+def build_knowledge_graph(
+    nodes: list[Node], relationships: list[Relationship]
+) -> KnowledgeGraph:
     """
     Build a knowledge graph from nodes and relationships.
 
@@ -320,7 +331,10 @@ def build_knowledge_graph(nodes: list[Node], relationships: list[Relationship]) 
         The constructed knowledge graph
     """
     kg: KnowledgeGraph = KnowledgeGraph()
-    isolated_nodes: list[Node] = [create_document_node("Iso_A"), create_document_node("Iso_B")]
+    isolated_nodes: list[Node] = [
+        create_document_node("Iso_A"),
+        create_document_node("Iso_B"),
+    ]
     nodes = nodes + isolated_nodes
 
     # Add nodes to the graph
@@ -338,7 +352,9 @@ def build_knowledge_graph(nodes: list[Node], relationships: list[Relationship]) 
     return kg
 
 
-def assert_clusters_equal(actual_clusters: list[set[Node]], expected_clusters: list[set[Node]]) -> None:
+def assert_clusters_equal(
+    actual_clusters: list[set[Node]], expected_clusters: list[set[Node]]
+) -> None:
     """
     Helper function to compare clusters with unordered comparison.
 
@@ -347,15 +363,21 @@ def assert_clusters_equal(actual_clusters: list[set[Node]], expected_clusters: l
         expected_clusters: List of sets representing the expected clusters
     """
     # Convert both lists to sets of frozensets for unordered comparison
-    actual_clusters_set: set[frozenset[Node]] = {frozenset(cluster) for cluster in actual_clusters}
-    expected_clusters_set: set[frozenset[Node]] = {frozenset(cluster) for cluster in expected_clusters}
+    actual_clusters_set: set[frozenset[Node]] = {
+        frozenset(cluster) for cluster in actual_clusters
+    }
+    expected_clusters_set: set[frozenset[Node]] = {
+        frozenset(cluster) for cluster in expected_clusters
+    }
 
     assert (
         actual_clusters_set == expected_clusters_set
     ), f"Expected clusters: {expected_clusters_set}\nActual clusters: {actual_clusters_set}"
 
 
-def assert_n_clusters_with_varying_params(kg: KnowledgeGraph, param_list: list[Tuple[int, int]]) -> None:
+def assert_n_clusters_with_varying_params(
+    kg: KnowledgeGraph, param_list: list[t.Tuple[int, int]]
+) -> None:
     """
     Helper function to test find_n_indirect_clusters with various combinations of n and depth_limit.
     Assert that the number of clusters returned is equal to n.
@@ -365,7 +387,9 @@ def assert_n_clusters_with_varying_params(kg: KnowledgeGraph, param_list: list[T
         param_list: List of tuples (n, depth_limit) to test
     """
     for n, depth_limit in param_list:
-        clusters: list[set[Node]] = kg.find_n_indirect_clusters(n=n, depth_limit=depth_limit)
+        clusters: list[set[Node]] = kg.find_n_indirect_clusters(
+            n=n, depth_limit=depth_limit
+        )
         if len(clusters) != n:
             # Convert clusters to sets of node IDs for more readable error messages
             cluster_ids = [{str(node.id) for node in cluster} for cluster in clusters]
@@ -603,7 +627,9 @@ def test_find_n_indirect_clusters_handles_worst_case_grouping():
         nodes_B, relationships_B = create_chain_of_similarities(
             create_document_node("B"), node_count=2
         )
-        kg: KnowledgeGraph = build_knowledge_graph(nodes_A + nodes_B, relationships_A + relationships_B)
+        kg: KnowledgeGraph = build_knowledge_graph(
+            nodes_A + nodes_B, relationships_A + relationships_B
+        )
         clusters: list[set[Node]] = kg.find_n_indirect_clusters(n=2, depth_limit=2)
 
         assert_clusters_equal(
@@ -626,7 +652,9 @@ def test_find_indirect_clusters_with_condition():
     def condition(rel):
         return rel.type == "next"
 
-    clusters: list[set[Node]] = kg.find_indirect_clusters(relationship_condition=condition)
+    clusters: list[set[Node]] = kg.find_indirect_clusters(
+        relationship_condition=condition
+    )
 
     # Only "next" relationships are considered, so we should only have paths between B, C, D, and E
     assert_clusters_equal(
@@ -649,7 +677,9 @@ def test_find_n_indirect_clusters_with_condition():
     def condition(rel):
         return rel.type == "next"
 
-    clusters: list[set[Node]] = kg.find_n_indirect_clusters(n=5, relationship_condition=condition)
+    clusters: list[set[Node]] = kg.find_n_indirect_clusters(
+        n=5, relationship_condition=condition
+    )
 
     # Only "next" relationships are considered, so we should only have paths between B, C, D, and E
     assert_clusters_equal(
@@ -865,7 +895,9 @@ def test_performance_find_n_indirect_clusters_large_web_constant_n(
     for kg, size in constant_n_knowledge_graphs:
         # Measure execution time
         start_time = time.time()
-        clusters: list[set[Node]] = kg.find_n_indirect_clusters(n=constant_n, depth_limit=3)
+        clusters: list[set[Node]] = kg.find_n_indirect_clusters(
+            n=constant_n, depth_limit=3
+        )
         end_time = time.time()
 
         execution_time = end_time - start_time
@@ -940,7 +972,9 @@ def test_performance_find_n_indirect_clusters_independent_chains():
 
         # Measure execution time
         start_time = time.time()
-        clusters: list[set[Node]] = kg.find_n_indirect_clusters(n=num_chains, depth_limit=3)
+        clusters: list[set[Node]] = kg.find_n_indirect_clusters(
+            n=num_chains, depth_limit=3
+        )
         end_time = time.time()
 
         execution_time = end_time - start_time

--- a/tests/unit/test_knowledge_graph_save.py
+++ b/tests/unit/test_knowledge_graph_save.py
@@ -13,14 +13,14 @@ def test_knowledge_graph_save_with_problematic_chars(tmp_path):
         "\u2192",  # arrow
         "\u2665",  # heart
         "\u2605",  # star
-        "\u221E",  # infinity
-        "\u00B5",  # micro
+        "\u221e",  # infinity
+        "\u00b5",  # micro
         "\u2264",  # less than or equal
         "\u2265",  # greater than or equal
         "\u0391",  # Greek letters
         "\u0392",
         "\u0393",
-        "\uFFFF",  # Special Unicode characters
+        "\uffff",  # Special Unicode characters
     ]
 
     # Create multiple nodes with combinations of problematic characters

--- a/tests/unit/test_multi_hop_abstract_query_synthesizer.py
+++ b/tests/unit/test_multi_hop_abstract_query_synthesizer.py
@@ -1,0 +1,128 @@
+import pytest
+import typing as t
+from tests.unit.test_knowledge_graph_clusters import (
+    create_document_and_child_nodes,
+    create_chain_of_similarities,
+    build_knowledge_graph,
+)
+from ragas.prompt import PydanticPrompt
+from ragas.testset.persona import Persona
+from ragas.testset.synthesizers.base import QueryLength, QueryStyle
+from ragas.testset.synthesizers.multi_hop.abstract import (
+    MultiHopAbstractQuerySynthesizer,
+)
+from ragas.testset.synthesizers.multi_hop.prompts import ConceptCombinations
+from ragas.testset.synthesizers.prompts import PersonaThemesMapping
+from ragas.testset.synthesizers.multi_hop.prompts import (
+    ConceptsList,
+)
+from ragas.testset.synthesizers.prompts import (
+    ThemesPersonasInput,
+)
+
+
+class MockConceptCombinationPrompt(PydanticPrompt):
+    async def generate(self, data: ConceptsList, llm, callbacks=None):
+        concepts: t.List[t.List[str]] = data.lists_of_concepts
+        max_combinations: int = data.max_combinations
+        return ConceptCombinations(combinations=concepts[:max_combinations])
+
+
+class MockThemePersonaMatchingPrompt(PydanticPrompt):
+    async def generate(self, data: ThemesPersonasInput, llm, callbacks=None):
+        themes: t.List[str] = data.themes
+        personas: t.List[Persona] = data.personas
+        return PersonaThemesMapping(
+            mapping={persona.name: themes for persona in personas}
+        )
+
+
+def _assert_scenario_properties(
+    scenarios: list[t.Any], personas: list[Persona]
+) -> None:
+    """Validate scenario properties."""
+    for scenario in scenarios:
+        assert hasattr(scenario, "nodes")
+        assert hasattr(scenario, "persona")
+        assert hasattr(scenario, "style")
+        assert hasattr(scenario, "length")
+        assert hasattr(scenario, "combinations")
+
+        # Check that the persona is from our list
+        assert scenario.persona in personas
+        assert scenario.style in QueryStyle
+        assert scenario.length in QueryLength
+        # Check that the document node was eliminated and replaced with its children
+        for node in scenario.nodes:
+            assert str(node.id) in [
+                "2",
+                "3",
+                "4",
+                "5",
+                "1_1",
+                "1_2",
+                "1_1_1",
+                "1_1_2",
+                "1_1_3",
+            ]
+        # Check that the combinations are from the themes we defined
+        for item in scenario.combinations:
+            assert item in [
+                "T_2",
+                "T_3",
+                "T_4",
+                "T_5",
+                "T_1_1",
+                "T_1_2",
+                "T_1_1_1",
+                "T_1_1_2",
+                "T_1_1_3",
+            ]
+
+
+@pytest.mark.asyncio
+async def test_generate_scenarios(fake_llm):
+    """Test the _generate_scenarios method of MultiHopAbstractQuerySynthesizer."""
+    nodes, relationships = create_document_and_child_nodes()
+    sim_nodes, sim_relationships = create_chain_of_similarities(nodes[0], node_count=3)
+    branch_nodes, branch_relationships = create_chain_of_similarities(
+        sim_nodes[1], node_count=4
+    )
+    nodes.extend(sim_nodes[1:])
+    nodes.extend(branch_nodes[1:])
+    relationships.extend(sim_relationships)
+    relationships.extend(branch_relationships)
+    kg = build_knowledge_graph(nodes, relationships)
+
+    personas = [
+        Persona(
+            name="Researcher",
+            role_description="Researcher interested in the latest advancements in AI.",
+        ),
+        Persona(
+            name="Engineer",
+            role_description="Engineer interested in the latest advancements in AI.",
+        ),
+    ]
+
+    synthesizer = MultiHopAbstractQuerySynthesizer(llm=fake_llm)
+
+    # Replace the prompts with mock versions
+    synthesizer.concept_combination_prompt = MockConceptCombinationPrompt()
+    synthesizer.theme_persona_matching_prompt = MockThemePersonaMatchingPrompt()
+
+    num_nodes = len(kg.nodes)
+    for n in range(1, num_nodes + 3):
+        scenarios = await synthesizer._generate_scenarios(
+            n=n,
+            knowledge_graph=kg,
+            persona_list=personas,
+            callbacks=None,
+        )
+
+        # Assert we got the expected number of scenarios
+        # Must be a range to compensate for num_sample_per_cluster rounding 
+        assert (
+            n <= len(scenarios) <= n + 2
+        ), f"Expected {n} or {n+1} scenarios, got {len(scenarios)}"
+        _assert_scenario_properties(scenarios, personas)

--- a/tests/unit/test_multi_hop_query_synthesizer.py
+++ b/tests/unit/test_multi_hop_query_synthesizer.py
@@ -40,7 +40,7 @@ class MockThemePersonaMatchingPrompt(PydanticPrompt):
 def _assert_scenario_properties(
     scenarios: list[t.Any], personas: list[Persona]
 ) -> None:
-    """Validate scenario properties."""
+    """Validate scenario has the expected properties."""
     for scenario in scenarios:
         assert hasattr(scenario, "nodes")
         assert hasattr(scenario, "persona")

--- a/tests/unit/test_multi_hop_query_synthesizer.py
+++ b/tests/unit/test_multi_hop_query_synthesizer.py
@@ -1,23 +1,22 @@
-import pytest
 import typing as t
-from tests.unit.test_knowledge_graph_clusters import (
-    create_document_and_child_nodes,
-    create_chain_of_similarities,
-    build_knowledge_graph,
-)
+
+import pytest
+
 from ragas.prompt import PydanticPrompt
 from ragas.testset.persona import Persona
 from ragas.testset.synthesizers.base import QueryLength, QueryStyle
 from ragas.testset.synthesizers.multi_hop.abstract import (
     MultiHopAbstractQuerySynthesizer,
 )
-from ragas.testset.synthesizers.multi_hop.prompts import ConceptCombinations
-from ragas.testset.synthesizers.prompts import PersonaThemesMapping
 from ragas.testset.synthesizers.multi_hop.prompts import (
+    ConceptCombinations,
     ConceptsList,
 )
-from ragas.testset.synthesizers.prompts import (
-    ThemesPersonasInput,
+from ragas.testset.synthesizers.prompts import PersonaThemesMapping, ThemesPersonasInput
+from tests.unit.test_knowledge_graph_clusters import (
+    build_knowledge_graph,
+    create_chain_of_similarities,
+    create_document_and_child_nodes,
 )
 
 
@@ -121,7 +120,7 @@ async def test_generate_scenarios(fake_llm):
         )
 
         # Assert we got the expected number of scenarios
-        # Must be a range to compensate for num_sample_per_cluster rounding 
+        # Must be a range to compensate for num_sample_per_cluster rounding
         assert (
             n <= len(scenarios) <= n + 2
         ), f"Expected {n} or {n+1} scenarios, got {len(scenarios)}"


### PR DESCRIPTION
Current implementation of find_indirect_clusters runs at exponential time because the depth-first search always explores every path in the graph. A  kg w/ ~3000 relationships takes over an hour on a 2024 M4 Macbook Pro. 
This brings it down to quad/cubic time relative to _testset size_ (instead of kg relationships). Generating a 100 sample testset of abstract multihop queries for a KG of 1 million relationships takes about 20 seconds.

- Added new find_n_indirect_clusters method and applied it to MultiHopAbstractQuerySynthesizer.
- No longer searches the entire graph, just enough to get a well-diversified randomized sample of clusters for the desired testset size.
- Added lots of tests. I can scale them back. They're mostly to demo the spec so you can easily compare the new behavior with the original find_indirect_clusters which I left in place.
- New behavior adds randomization and diversity to cluster sampling.
  - Will no longer return subsets along with their supersets, only the superset.
- Also fixed the other performance bottleneck in MultiHopAbstractQuerySynthesizer (collecting child nodes).
- Eliminates potentially expensive edge-case where LLM calls could be made for every possible cluster in the KG.
- In depth details can be found in the find_n_indirect_clusters docstring.