### PR TITLE
Fix issue with cache hits

### DIFF
--- a/src/ragas/cache.py
+++ b/src/ragas/cache.py
@@ -148,9 +148,6 @@ EXCLUDE_KEYS = ["callbacks"]
 
 
 def _generate_cache_key(func, args, kwargs):
-    if inspect.ismethod(func):
-        args = args[1:]
-
     filtered_kwargs = {k: v for k, v in kwargs.items() if k not in EXCLUDE_KEYS}
 
     key_data = {

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -41,7 +41,7 @@ def test_generate_cache_key():
 
 
 def test_generate_cache_key_bound_method():
-    """Test that cache keys change when arguments or kwargs differ with a bound method."""
+    """Test that cache keys stay the same, when caching bound methods of different objects."""
 
     class Clazz():
         def __init__(self, irrelevant):

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -40,6 +40,24 @@ def test_generate_cache_key():
     assert key1 != key3, "Cache keys should differ if kwargs differ"
 
 
+def test_generate_cache_key_bound_method():
+    """Test that cache keys change when arguments or kwargs differ with a bound method."""
+
+    class Clazz():
+        def __init__(self, irrelevant):
+            self.irrelevant = irrelevant
+            
+        def sample_func(self, a, b):
+            return a + b
+
+    object = Clazz(irrelevant=1)
+    object2 = Clazz(irrelevant=2)
+
+    key1 = _generate_cache_key(object.sample_func, (1, 2), {})
+    key2 = _generate_cache_key(object2.sample_func, (1, 2), {})
+    assert key1 == key2, "Cache keys should match even if the originating objects the methods are bound to are not the same, as long as the arguments match"
+
+
 def test_no_cache_backend():
     """Test that if no cache backend is provided, results are not cached."""
     call_count = {"count": 0}


### PR DESCRIPTION
As per #1915

Args will not contain the `self` argument, it is bound to func in `__self__` so there is no need to try and strip it.