### PR TITLE
Detailed  error message for noise sensitivity metric

### DIFF
--- a/src/ragas/metrics/_noise_sensitivity.py
+++ b/src/ragas/metrics/_noise_sensitivity.py
@@ -126,6 +126,18 @@ class NoiseSensitivity(MetricWithLLM, SingleTurnMetric):
         """
         assert self.llm is not None, "LLM is not set"
 
+        if "reference" not in row or not row["reference"]:
+            raise ValueError("reference is missing in the test sample. Please add reference to the test sample.")
+
+        if "user_input" not in row or not row["user_input"]:
+            raise ValueError("user_input is missing in the test sample. Please add user_input to the test sample.")
+
+        if "response" not in row or not row["response"]:
+            raise ValueError("response is missing in the test sample. Please add response to the test sample.")
+
+        if "retrieved_contexts" not in row or not row["retrieved_contexts"]:
+            raise ValueError("retrieved_contexts is missing in the test sample. Please add retrieved_contexts to the test sample.")
+
         gt_statements = await self._decompose_answer_into_statements(
             row["reference"], row["user_input"], callbacks
         )


### PR DESCRIPTION
Absence of any of the required inputs **(user_input, response, reference or retrieved_contexts)** in the test sample results in **KeyError**. For example, the absence of **user_input** in the test sample results in the error message **"KeyError: user_input"**.  

The error message **"KeyError: user_input"** is too abstract.  I  included the following lines of code in the **_ascore()** function definition which will display a clear error message in the absence of any of the required inputs. 

```
if "reference" not in row or not row["reference"]:
      raise ValueError("reference is missing in the test sample. Please add reference to the test sample.")

 if "user_input" not in row or not row["user_input"]:
      raise ValueError("user_input is missing in the test sample. Please add user_input to the test sample.")

 if "response" not in row or not row["response"]:
       raise ValueError("response is missing in the test sample. Please add response to the test sample.")

 if "retrieved_contexts" not in row or not row["retrieved_contexts"]:
       raise ValueError("retrieved_contexts is missing in the test sample. Please add retrieved_contexts to the test sample.")
```