### PR TITLE
feat: Add utility to extract token usage from Azure AI-compatible LLM results

### DIFF
--- a/src/ragas/cost.py
+++ b/src/ragas/cost.py
@@ -127,6 +127,19 @@ def get_token_usage_for_bedrock(
     return TokenUsage(input_tokens=0, output_tokens=0)
 
 
+def get_token_usage_for_azure_ai(
+    llm_result: t.Union[LLMResult, ChatResult],
+) -> TokenUsage:
+    # AzureAI like interfaces
+    llm_output = llm_result.llm_output
+    if llm_output is None:
+        logger.info("No llm_output found in the LLMResult")
+        return TokenUsage(input_tokens=0, output_tokens=0)
+    output_tokens = get_from_dict(llm_output, "token_usage.input_tokens", 0)
+    input_tokens = get_from_dict(llm_output, "token_usage.output_tokens", 0)
+    return TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens)
+
+
 class CostCallbackHandler(BaseCallbackHandler):
     def __init__(self, token_usage_parser: TokenUsageParser):
         self.token_usage_parser = token_usage_parser

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -6,6 +6,7 @@ from ragas.cost import (
     CostCallbackHandler,
     TokenUsage,
     get_token_usage_for_anthropic,
+    get_token_usage_for_azure_ai,
     get_token_usage_for_bedrock,
     get_token_usage_for_openai,
 )
@@ -129,6 +130,18 @@ bedrock_claude_result = LLMResult(
     llm_output={},
 )
 
+azure_ai_result = LLMResult(
+    generations=[[ChatGeneration(message=AIMessage(content="Hello, world!"))]],
+    llm_output={
+        "token_usage": {
+            "input_tokens": 10,
+            "output_tokens": 10,
+            "total_tokens": 20,
+        },
+        "model_name": "mistral-small-2503",
+    },
+)
+
 
 def test_parse_llm_results():
     # openai
@@ -145,6 +158,10 @@ def test_parse_llm_results():
 
     # Bedrock Claude
     token_usage = get_token_usage_for_bedrock(bedrock_claude_result)
+    assert token_usage == TokenUsage(input_tokens=10, output_tokens=10)
+
+    # Azure AI
+    token_usage = get_token_usage_for_azure_ai(azure_ai_result)
     assert token_usage == TokenUsage(input_tokens=10, output_tokens=10)
 
 


### PR DESCRIPTION
**Description:**
This PR adds a helper function to extract token usage from LLMResult or ChatResult, using the `Azure AI` response format returned by `LangChain`.

**Key Changes:**
- Added `get_token_usage_for_azure_ai` utility, supporting Azure AI's token usage format as returned by LangChain.
- Implemented unit tests to validate behavior.