### PR TITLE
fix: correct double swap of parameters in AnswerAccuracy metric templ…

### DIFF
--- a/src/ragas/metrics/_nv_metrics.py
+++ b/src/ragas/metrics/_nv_metrics.py
@@ -134,8 +134,8 @@ class AnswerAccuracy(MetricWithLLM, SingleTurnMetric):
                         query=sample.user_input,
                         answer0="Reference Answer",
                         answer1="User Answer",
-                        sentence_inference=sample.reference,
-                        sentence_true=sample.response,
+                        sentence_inference=sample.response,
+                        sentence_true=sample.reference,
                     )
                 )
                 req1 = self.llm.agenerate_text(


### PR DESCRIPTION
## Overview

This PR addresses the double swap bug in the AnswerAccuracy metric implementation. In the original implementation, both the meta-labels (User Answer / Reference Answer) and their corresponding values (sample.response and sample.reference) were swapped, leading to an unintended behavior. According to the documentation, only the labels should be swapped while the values must remain in the original order.

## Changes Made

- Modified the second prompt generation for AnswerAccuracy to maintain the original order of values, while swapping only the meta-labels.
- Ensured consistency with the documentation by keeping `sentence_inference` as sample.response and `sentence_true` as sample.reference in both prompts.

## Issue Reference

This fixes [issue #2000](https://github.com/explodinggradients/ragas/issues/2000).

## Additional Notes

Please review the changes and let me know if further modifications are needed.
