### PR TITLE
Update the logic of answer_relevance as per the definition

### DIFF
--- a/src/ragas/metrics/_answer_relevance.py
+++ b/src/ragas/metrics/_answer_relevance.py
@@ -139,15 +139,12 @@ class ResponseRelevancy(MetricWithLLM, MetricWithEmbeddings, SingleTurnMetric):
         assert self.llm is not None, "LLM is not set"
 
         prompt_input = ResponseRelevanceInput(response=row["response"])
-        tasks = [
-            self.question_generation.generate(
+        responses = await self.question_generation.generate_multiple(
+                n=self.strictness,
                 data=prompt_input,
                 llm=self.llm,
                 callbacks=callbacks,
-            )
-            for _ in range(self.strictness)
-        ]
-        responses = await asyncio.gather(*tasks)
+        )
 
         return self._calculate_score(responses, row)
 


### PR DESCRIPTION
Calling generate 3 times gives the questions with exact words every time. generate_multiple tends to give semantically matching questions.