### PR TITLE
fix: minor typo in  context_precision.md

### DIFF
--- a/docs/concepts/metrics/available_metrics/context_precision.md
+++ b/docs/concepts/metrics/available_metrics/context_precision.md
@@ -17,7 +17,7 @@ The following metrics uses LLM to identify if a retrieved context is relevant or
 
 ### Context Precision without reference
 
-`LLMContextPrecisionWithoutReference` metric can be used when you have both retrieved contexts and also reference contexts associated with a `user_input`. To estimate if a retrieved contexts is relevant or not this method uses the LLM to compare each of the retrieved context or chunk present in `retrieved_contexts` with `response`.
+`LLMContextPrecisionWithoutReference` metric can be used when you have both retrieved contexts and also reference answer associated with a `user_input`. To estimate if a retrieved contexts is relevant or not this method uses the LLM to compare each of the retrieved context or chunk present in `retrieved_contexts` with `response`.
 
 #### Example
     
@@ -43,7 +43,7 @@ Output
 
 ### Context Precision with reference
 
-`LLMContextPrecisionWithReference` metric is can be used when you have both retrieved contexts and also reference answer associated with a `user_input`. To estimate if a retrieved contexts is relevant or not this method uses the LLM to compare each of the retrieved context or chunk present in `retrieved_contexts` with `reference`. 
+`LLMContextPrecisionWithReference` metric is can be used when you have both retrieved contexts and also reference context associated with a `user_input`. To estimate if a retrieved contexts is relevant or not this method uses the LLM to compare each of the retrieved context or chunk present in `retrieved_contexts` with `reference`. 
 
 #### Example
     


### PR DESCRIPTION
for `Context Precision without reference` definition, i.e LLMContextPrecisionWithoutReference metric can be used when you have both retrieved contexts and also reference contexts associated with a user_input.

Here, it should be reference `answer` instead of reference `contexts` as per my understanding

Similarly, 

for `Context Precision with reference definition` i.e LLMContextPrecisionWithReference metric is can be used when you have both retrieved contexts and also reference answer associated with a user_input. 

here, reference answer should be replaced with reference context