### PR TITLE
fix: add disallowed_special  on tiktoken encode

### DIFF
--- a/ragas/src/ragas/testset/transforms/base.py
+++ b/ragas/src/ragas/testset/transforms/base.py
@@ -199,7 +199,7 @@ class LLMBasedExtractor(Extractor, PromptMixin):
     def split_text_by_token_limit(self, text, max_token_limit):
 
         # Tokenize the entire input string
-        tokens = self.tokenizer.encode(text)
+        tokens = self.tokenizer.encode(text, disallowed_special=())
 
         # Split tokens into chunks of max_token_limit or less
         chunks = []

--- a/ragas/src/ragas/utils.py
+++ b/ragas/src/ragas/utils.py
@@ -225,7 +225,7 @@ def camel_to_snake(name):
 def num_tokens_from_string(string: str, encoding_name: str = "cl100k_base") -> int:
     """Returns the number of tokens in a text string."""
     encoding = tiktoken.get_encoding(encoding_name)
-    num_tokens = len(encoding.encode(string))
+    num_tokens = len(encoding.encode(string, disallowed_special=()))
     return num_tokens
 
 


### PR DESCRIPTION
When generating testset, transformation using token count using tiktoken.
but if documents includes special tokens like '<endoftext>' tiktoken raises error.
To prevent it, added parameter "disallowed_special=()" on usages of tiktoken encode