### PR TITLE
docs: correct small typos in Testset Generation page and related md components

### DIFF
--- a/docs/extra/components/choose_generator_llm.md
+++ b/docs/extra/components/choose_generator_llm.md
@@ -43,7 +43,7 @@
     }
     ```
 
-    Define you LLMs and wrap them in `LangchainLLMWrapper` so that it can be used with ragas.
+    Define your LLMs and wrap them in `LangchainLLMWrapper` so that it can be used with ragas.
 
     ```python
     from langchain_aws import ChatBedrockConverse

--- a/docs/getstarted/rag_testset_generation.md
+++ b/docs/getstarted/rag_testset_generation.md
@@ -3,7 +3,7 @@
 This simple guide will help you generate a testset for evaluating your RAG pipeline using your own documents.
 
 ## Quickstart
-Let's walk through an quick example of generating a testset for a RAG pipeline. Following that we will explore the main components of the testset generation pipeline.
+Let's walk through a quick example of generating a testset for a RAG pipeline. Following that we will explore the main components of the testset generation pipeline.
 
 ### Load Sample Documents
 


### PR DESCRIPTION
I noticed a few small typos and inconsistent casing in the [Testset Generation page](https://docs.ragas.io/en/stable/getstarted/rag_testset_generation/) and a related markdown component.





