### PR TITLE
fix: non default temperature check

### DIFF
--- a/ragas/src/ragas/llms/base.py
+++ b/ragas/src/ragas/llms/base.py
@@ -211,6 +211,9 @@ class LangchainLLMWrapper(BaseRagasLLM):
                 if self.langchain_llm.model_name not in MODELS_NOT_SUPPORT_TEMP:
                     self.langchain_llm.temperature = temperature  # type: ignore
                     old_temperature = temperature
+            else:
+                self.langchain_llm.temperature = temperature
+                old_temperature = temperature
 
         if is_multiple_completion_supported(self.langchain_llm):
             result = self.langchain_llm.generate_prompt(
@@ -253,6 +256,9 @@ class LangchainLLMWrapper(BaseRagasLLM):
                 if self.langchain_llm.model_name not in MODELS_NOT_SUPPORT_TEMP:
                     self.langchain_llm.temperature = temperature  # type: ignore
                     old_temperature = temperature
+            else:
+                self.langchain_llm.temperature = temperature
+                old_temperature = temperature
 
         # handle n
         if hasattr(self.langchain_llm, "n"):


### PR DESCRIPTION
**Change**
Added check for models o3-mini, o4-mini, o3

**Reason**
Models o3-mini, o4-mini, o3 has `temperature`, but they don't support setting it to non default value, so I encountered error:
```
BadRequestError: Error code: 400 - {
    'error’: {
        'message': "Unsupported value: 'temperature' does not support 1E-8 with this model. Only the default (1) value is supported.", 
        'type': 'invalid_request_error’, 
        'param': 'temperature’, 
        'code': 'unsupported_value’
    }
}
```
