### PR TITLE
redundant init and consistency of loop exit

### DIFF
--- a/ragas/src/ragas/testset/synthesizers/multi_hop/specific.py
+++ b/ragas/src/ragas/testset/synthesizers/multi_hop/specific.py
@@ -84,31 +84,31 @@ class MultiHopSpecificQuerySynthesizer(MultiHopQuerySynthesizer):
         scenarios = []
 
         for triplet in triplets:
-            if len(scenarios) < n:
-                node_a, node_b = triplet[0], triplet[-1]
-                overlapped_items = []
-                overlapped_items = triplet[1].properties["overlapped_items"]
-                if overlapped_items:
-                    themes = list(dict(overlapped_items).keys())
-                    prompt_input = ThemesPersonasInput(
-                        themes=themes, personas=persona_list
+            if len(scenarios) >= n:
+                break
+            node_a, node_b = triplet[0], triplet[-1]
+            overlapped_items = triplet[1].properties["overlapped_items"]
+            if overlapped_items:
+                themes = list(dict(overlapped_items).keys())
+                prompt_input = ThemesPersonasInput(
+                    themes=themes, personas=persona_list
+                )
+                persona_concepts = (
+                    await self.theme_persona_matching_prompt.generate(
+                        data=prompt_input, llm=self.llm, callbacks=callbacks
                     )
-                    persona_concepts = (
-                        await self.theme_persona_matching_prompt.generate(
-                            data=prompt_input, llm=self.llm, callbacks=callbacks
-                        )
-                    )
-                    overlapped_items = [list(item) for item in overlapped_items]
-                    base_scenarios = self.prepare_combinations(
-                        [node_a, node_b],
-                        overlapped_items,
-                        personas=persona_list,
-                        persona_item_mapping=persona_concepts.mapping,
-                        property_name=self.property_name,
-                    )
-                    base_scenarios = self.sample_diverse_combinations(
-                        base_scenarios, num_sample_per_cluster
-                    )
-                    scenarios.extend(base_scenarios)
+                )
+                overlapped_items = [list(item) for item in overlapped_items]
+                base_scenarios = self.prepare_combinations(
+                    [node_a, node_b],
+                    overlapped_items,
+                    personas=persona_list,
+                    persona_item_mapping=persona_concepts.mapping,
+                    property_name=self.property_name,
+                )
+                base_scenarios = self.sample_diverse_combinations(
+                    base_scenarios, num_sample_per_cluster
+                )
+                scenarios.extend(base_scenarios)
 
         return scenarios


### PR DESCRIPTION
**Change**

1. Deleted redundant init

`overlapped_items = []
overlapped_items = triplet[1].properties["overlapped_items"]`


2. consistency of loop exit
in `ragas/src/ragas/testset/synthesizers/multi_hop/specific.py`
exit condition was like `if len(scenarios) < n:`, 
but in other files 
(`ragas/src/ragas/testset/synthesizers/single_hop/specific.py`m line 103) and (`ragas/src/ragas/testset/synthesizers/multi_hop/abstract.py`, line 85) 
it was 
`if len(scenarios) >= n:
    break`


