### PR TITLE
fix: enum values instead of names in testset synthesizers

### DIFF
--- a/ragas/src/ragas/testset/synthesizers/multi_hop/base.py
+++ b/ragas/src/ragas/testset/synthesizers/multi_hop/base.py
@@ -167,8 +167,8 @@ class MultiHopQuerySynthesizer(BaseSynthesizer[Scenario]):
             persona=scenario.persona,
             themes=scenario.combinations,
             context=reference_context,
-            query_length=scenario.length.name,
-            query_style=scenario.style.name,
+            query_length=scenario.length.value,
+            query_style=scenario.style.value,
         )
         response = await self.generate_query_reference_prompt.generate(
             data=prompt_input, llm=self.llm, callbacks=callbacks

--- a/ragas/src/ragas/testset/synthesizers/single_hop/base.py
+++ b/ragas/src/ragas/testset/synthesizers/single_hop/base.py
@@ -128,8 +128,8 @@ class SingleHopQuerySynthesizer(BaseSynthesizer[Scenario]):
             persona=scenario.persona,
             term=scenario.term,
             context=reference_context,
-            query_length=scenario.length.name,
-            query_style=scenario.style.name,
+            query_length=scenario.length.value,
+            query_style=scenario.style.value,
         )
         response = await self.generate_query_reference_prompt.generate(
             data=prompt_input, llm=self.llm, callbacks=callbacks


### PR DESCRIPTION
**Change**
Using Enum.value instead of Enum.name

It seems that value (description) for QueryStyle is more logical than using names. The current name and value are almost identical, but this might change in the future