### PR TITLE
fix: correct mkdocstrings path configuration for local development

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -254,7 +254,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: [src]
+          paths: [ragas/src]  # Fixed path to point to correct src directory
           options:
             docstring_style: numpy
             members_order: source


### PR DESCRIPTION
The mkdocstrings plugin was configured with 'paths: [src]' but the actual source code is located at 'ragas/src' relative to the mkdocs.yml file.

This was causing build failures with errors like:
- 'ragas.cache could not be found'
- 'ragas.embeddings could not be found'

The fix updates the path to 'ragas/src' which allows mkdocstrings to properly generate API documentation when running 'mkdocs serve' locally.

Resolves mkdocstrings module import errors during local documentation development.