### PR TITLE
Make `AnswerSimilarity` a dataclass

### DIFF
--- a/ragas/src/ragas/metrics/_answer_similarity.py
+++ b/ragas/src/ragas/metrics/_answer_similarity.py
@@ -98,6 +98,7 @@ class SemanticSimilarity(MetricWithEmbeddings, SingleTurnMetric):
         return float(score.item())
 
 
+@dataclass
 class AnswerSimilarity(SemanticSimilarity):
     name: str = "answer_similarity"
 


### PR DESCRIPTION
Before this change the name attribute (`name: str = "answer_similarity"`) was overwritten by the parent class (`semantic_similarity`) on instantiation, as can be seen in this example:

```sh
>>> from ragas.metrics._answer_similarity import AnswerSimilarity
>>> AnswerSimilarity.name
'answer_similarity'
>>> AnswerSimilarity()
AnswerSimilarity(..., name='semantic_similarity', ...)
```

By making AnswerSimilarity a dataclass like the parent class `SemanticSimilarity`, the name is correctly set to `answer_similarity` on instantation.