### PR TITLE
Fixed a small typo in context_precision.md

### DIFF
--- a/docs/concepts/metrics/available_metrics/context_precision.md
+++ b/docs/concepts/metrics/available_metrics/context_precision.md
@@ -72,7 +72,7 @@ This metric uses traditional methods to determine whether a retrieved context is
 
 ### Context Precision with reference contexts
 
-The `NonLLMContextPrecisionWithReference` metric is designed for scenarios where both retrieved contexts and reference contexts are available for a `user_input`. To determine if a retrieved context is relevant, this method compares each retrieved context or chunk in `retrieved_context`s with every context in `reference_contexts` using a non-LLM-based similarity measure.
+The `NonLLMContextPrecisionWithReference` metric is designed for scenarios where both retrieved contexts and reference contexts are available for a `user_input`. To determine if a retrieved context is relevant, this method compares each retrieved context or chunk in `retrieved_contexts` with every context in `reference_contexts` using a non-LLM-based similarity measure.
 
 #### Example
     


### PR DESCRIPTION
Hi!

While reading [this page](https://docs.ragas.io/en/stable/concepts/metrics/available_metrics/context_precision/#example_2), I have found that the `s` in `retrieved_contexts` was not inside the backticks.

**Before**:
`retrieved_context`s

**After**:
`retrieved_contexts`