### PR TITLE
Add python 3.13 target, refactor on pre-commit and benchmarking tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,9 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.12"
             test-type: "full"
+          - os: ubuntu-latest
+            python-version: "3.13"
+            test-type: "full"
           # Cross-platform validation (essential tests only)
           - os: macos-latest
             python-version: "3.11"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: monorepo-ci
         name: Run complete monorepo CI pipeline
-        entry: make run-ci
+        entry: make run-ci-format-check
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ benchmarks-docker: ## Run benchmarks in docker
 	docker buildx build --build-arg OPENAI_API_KEY=$(OPENAI_API_KEY) -t ragas-benchmark -f $(GIT_ROOT)/ragas/tests/benchmarks/Dockerfile .
 	docker inspect ragas-benchmark:latest | jq ".[0].Size" | numfmt --to=si
 
+benchmarks-test: ## Run benchmarks for ragas unit tests
+	@echo "Running ragas unit tests with timing benchmarks..."
+	$(Q)cd ragas && uv run pytest --nbmake tests/unit tests/experimental --durations=0 -v $(shell if [ -n "$(k)" ]; then echo "-k $(k)"; fi)
+
 # =============================================================================
 # CI/BUILD
 # =============================================================================


### PR DESCRIPTION
- add: make cmd to benchmark tests and get the slowest tests.
- refactor: change pre-commit from run-ci to only check format.
- add: python 3.13 to ci
