### PR TITLE
feat: move `experiment` from experimental to ragas main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Use UV with system installation for CI (simpler and more reliable)
-          uv pip install --system -e "./ragas" --group dev --cache-dir ~/.cache/uv
+          cd ragas && uv pip install --system -e "." --group dev --cache-dir ~/.cache/uv
 
       - name: Run unit tests
         run: |
@@ -173,7 +173,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Use UV with system installation for CI (simpler and more reliable)
-          uv pip install --system -e "./ragas" --group dev --cache-dir ~/.cache/uv
+          cd ragas && uv pip install --system -e "." --group dev --cache-dir ~/.cache/uv
 
       - name: Format check (dry run)
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Use UV with system installation for CI (simpler and more reliable)
-          cd ragas && uv pip install --system -e "." --group dev --cache-dir ~/.cache/uv
+          uv pip install --system -e "./ragas" --group dev --cache-dir ~/.cache/uv
 
       - name: Run unit tests
         run: |
@@ -120,7 +120,7 @@ jobs:
             # Use pytest-xdist to improve test run-time on Linux/macOS
             OPTS=(--dist loadfile -n auto)
           fi
-          
+
           # Run different test suites based on test type
           if [ "${{ matrix.test-type }}" = "full" ]; then
             # Full test suite with notebook tests
@@ -173,7 +173,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Use UV with system installation for CI (simpler and more reliable)
-          cd ragas && uv pip install --system -e "." --group dev --cache-dir ~/.cache/uv
+          uv pip install --system -e "./ragas" --group dev --cache-dir ~/.cache/uv
 
       - name: Format check (dry run)
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,6 @@ build:
     python: "3.12"
   commands:
     - pip install uv
-    - uv pip install -e "./ragas" --group docs
+    - cd ragas && uv pip install -e "." --group docs
     - if [ -n "$GH_TOKEN" ]; then pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git; fi
     - mkdocs build --site-dir $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,6 @@ build:
     python: "3.12"
   commands:
     - pip install uv
-    - cd ragas && uv pip install --system -e "." --group docs
+    - uv pip install -e "./ragas" --group docs
     - if [ -n "$GH_TOKEN" ]; then pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git; fi
     - mkdocs build --site-dir $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,6 @@ build:
     python: "3.12"
   commands:
     - pip install uv
-    - cd ragas && uv pip install -e "." --group docs
+    - cd ragas && uv pip install --system -e "." --group docs
     - if [ -n "$GH_TOKEN" ]; then pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git; fi
     - mkdocs build --site-dir $READTHEDOCS_OUTPUT/html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,8 @@ The experimental features are now integrated into the main ragas package:
 
 To use experimental features:
 ```python
-from ragas.experimental import Dataset, experiment
+from ragas.experimental import Dataset
+from ragas import experiment
 from ragas.backends import get_registry
 ```
 

--- a/docs/experimental/core_concepts/experimentation.md
+++ b/docs/experimental/core_concepts/experimentation.md
@@ -39,7 +39,7 @@ Running an experiment involves:
 The `@experiment` decorator in Ragas simplifies the orchestration, scaling, and storage of experiments. Here's an example:
 
 ```python
-from ragas_experimental import experiment
+from ragas import experiment
 
 # Define your metric and dataset
 my_metric = ...
@@ -115,7 +115,8 @@ Here's a complete example showing how to pass different LLM models to your exper
 
 ```python
 from pydantic import BaseModel
-from ragas.experimental import experiment, Dataset
+from ragas.experimental import Dataset
+from ragas import experiment
 
 class ExperimentResult(BaseModel):
     query: str

--- a/docs/experimental/index.md
+++ b/docs/experimental/index.md
@@ -39,7 +39,8 @@ pip install ragas-experimental && pip install "ragas-experimental[local]"
 
 ```python
 import numpy as np
-from ragas_experimental import experiment, Dataset
+from ragas_experimental import Dataset
+from ragas import experiment
 from ragas_experimental.metrics import MetricResult, discrete_metric  
 
 # Define a custom metric for accuracy

--- a/docs/experimental/tutorials/agent.md
+++ b/docs/experimental/tutorials/agent.md
@@ -56,7 +56,7 @@ def correctness_metric(prediction: float, actual: float):
 Next, we will write the experiment loop that will run our agent on the test dataset and evaluate it using the metric, and store the results in a CSV file.
 
 ```python
-from ragas_experimental import experiment
+from ragas import experiment
 
 @experiment()
 async def run_experiment(row):

--- a/docs/experimental/tutorials/prompt.md
+++ b/docs/experimental/tutorials/prompt.md
@@ -55,7 +55,7 @@ def my_metric(prediction: str, actual: str):
 Next, we will write the experiment loop that will run our prompt on the test dataset and evaluate it using the metric, and store the results in a csv file. 
 
 ```python
-from ragas_experimental import experiment
+from ragas import experiment
 
 @experiment()
 async def run_experiment(row):

--- a/docs/experimental/tutorials/workflow.md
+++ b/docs/experimental/tutorials/workflow.md
@@ -49,7 +49,7 @@ my_metric = DiscreteMetric(
 Next, we will write the evaluation experiment loop that will run our workflow on the test dataset and evaluate it using the metric, and store the results in a CSV file.
 
 ```python
-from ragas_experimental import experiment
+from ragas import experiment
 
 @experiment()
 async def run_experiment(row):

--- a/examples/agent_evals/evals.py
+++ b/examples/agent_evals/evals.py
@@ -1,4 +1,5 @@
-from ragas.experimental import Dataset, experiment
+from ragas.experimental import Dataset
+from ragas import experiment
 from ragas.experimental.metrics.numeric import numeric_metric
 from ragas.experimental.metrics.result import MetricResult
 from agent import get_default_agent

--- a/examples/prompt_evals/evals.py
+++ b/examples/prompt_evals/evals.py
@@ -1,4 +1,5 @@
-from ragas.experimental import Dataset, experiment
+from ragas.experimental import Dataset
+from ragas import experiment
 from ragas.experimental.metrics.result import MetricResult
 from ragas.experimental.metrics.discrete import discrete_metric
 

--- a/examples/rag_eval/evals.py
+++ b/examples/rag_eval/evals.py
@@ -1,4 +1,5 @@
-from ragas.experimental import Dataset, experiment
+from ragas.experimental import Dataset
+from ragas import experiment
 from ragas.experimental.metrics import DiscreteMetric
 from openai import OpenAI
 from ragas.experimental.llms import llm_factory

--- a/examples/workflow_eval/evals.py
+++ b/examples/workflow_eval/evals.py
@@ -1,6 +1,7 @@
 import os
 from openai import OpenAI
-from ragas.experimental import Dataset, experiment
+from ragas.experimental import Dataset
+from ragas import experiment
 from ragas.experimental.metrics import DiscreteMetric
 from ragas.experimental.llms import llm_factory
 from workflow import default_workflow_client

--- a/ragas/src/ragas/__init__.py
+++ b/ragas/src/ragas/__init__.py
@@ -1,6 +1,7 @@
 from ragas.cache import CacheInterface, DiskCacheBackend, cacher
 from ragas.dataset_schema import EvaluationDataset, MultiTurnSample, SingleTurnSample
 from ragas.evaluation import evaluate
+from ragas.experiment import Experiment, experiment, version_experiment
 from ragas.run_config import RunConfig
 
 # Backend imports
@@ -23,6 +24,9 @@ __all__ = [
     "CacheInterface",
     "DiskCacheBackend",
     "backends",
+    "Experiment",
+    "experiment",
+    "version_experiment",
 ]
 
 

--- a/ragas/src/ragas/__init__.py
+++ b/ragas/src/ragas/__init__.py
@@ -7,6 +7,8 @@ from ragas.run_config import RunConfig
 # Backend imports
 from ragas import backends
 
+# Backend imports
+
 try:
     from ._version import version as __version__
 except ImportError:

--- a/ragas/src/ragas/experiment.py
+++ b/ragas/src/ragas/experiment.py
@@ -13,8 +13,8 @@ from tqdm import tqdm
 from pydantic import BaseModel
 
 from ragas.backends.base import BaseBackend
-from .dataset import Dataset, DataTable
-from .utils import memorable_names, find_git_root
+from ragas.experimental.dataset import Dataset, DataTable
+from ragas.utils import memorable_names, find_git_root
 
 
 class Experiment(DataTable):

--- a/ragas/src/ragas/experimental/__init__.py
+++ b/ragas/src/ragas/experimental/__init__.py
@@ -12,8 +12,7 @@ except ImportError:
         __version__ = "unknown"
 
 from .dataset import Dataset
-from .experiment import experiment, Experiment
 from .llms import llm_factory
 from .embeddings import embedding_factory
 
-__all__ = ["Dataset", "experiment", "Experiment", "llm_factory", "embedding_factory"]
+__all__ = ["Dataset", "llm_factory", "embedding_factory"]

--- a/ragas/src/ragas/utils.py
+++ b/ragas/src/ragas/utils.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import itertools
 import logging
 import os
+import random
 import re
 import typing as t
 import warnings
 from datetime import datetime
 from functools import lru_cache
+from pathlib import Path
 
 import numpy as np
 import tiktoken
@@ -305,3 +307,242 @@ class _ContextualFormatter(logging.Formatter):
 
 
 base_logger = set_logging_level()
+
+
+class MemorableNames:
+    """Generator for memorable, unique names for experiments and datasets."""
+
+    def __init__(self):
+        # List of adjectives (similar to what Docker uses)
+        self.adjectives = [
+            "admiring",
+            "adoring",
+            "affectionate",
+            "agitated",
+            "amazing",
+            "angry",
+            "awesome",
+            "blissful",
+            "bold",
+            "boring",
+            "brave",
+            "busy",
+            "charming",
+            "clever",
+            "cool",
+            "compassionate",
+            "competent",
+            "condescending",
+            "confident",
+            "cranky",
+            "crazy",
+            "dazzling",
+            "determined",
+            "distracted",
+            "dreamy",
+            "eager",
+            "ecstatic",
+            "elastic",
+            "elated",
+            "elegant",
+            "eloquent",
+            "epic",
+            "fervent",
+            "festive",
+            "flamboyant",
+            "focused",
+            "friendly",
+            "frosty",
+            "gallant",
+            "gifted",
+            "goofy",
+            "gracious",
+            "happy",
+            "hardcore",
+            "heuristic",
+            "hopeful",
+            "hungry",
+            "infallible",
+            "inspiring",
+            "jolly",
+            "jovial",
+            "keen",
+            "kind",
+            "laughing",
+            "loving",
+            "lucid",
+            "magical",
+            "mystifying",
+            "modest",
+            "musing",
+            "naughty",
+            "nervous",
+            "nifty",
+            "nostalgic",
+            "objective",
+            "optimistic",
+            "peaceful",
+            "pedantic",
+            "pensive",
+            "practical",
+            "priceless",
+            "quirky",
+            "quizzical",
+            "relaxed",
+            "reverent",
+            "romantic",
+            "sad",
+            "serene",
+            "sharp",
+            "silly",
+            "sleepy",
+            "stoic",
+            "stupefied",
+            "suspicious",
+            "sweet",
+            "tender",
+            "thirsty",
+            "trusting",
+            "upbeat",
+            "vibrant",
+            "vigilant",
+            "vigorous",
+            "wizardly",
+            "wonderful",
+            "xenodochial",
+            "youthful",
+            "zealous",
+            "zen",
+        ]
+
+        # List of influential computer scientists and tech entrepreneurs
+        self.scientists = [
+            "turing",
+            "hopper",
+            "knuth",
+            "torvalds",
+            "ritchie",
+            "thompson",
+            "dijkstra",
+            "kay",
+            "wozniak",
+            "gates",
+            "jobs",
+            "musk",
+            "bezos",
+            "lovelace",
+            "berners_lee",
+            "cerf",
+            "gosling",
+            "kernighan",
+            "lamport",
+            "mccarthy",
+            "minsky",
+            "rossum",
+            "backus",
+            "engelbart",
+            "hamilton",
+            "chomsky",
+            "shannon",
+            "zuckerberg",
+            "page",
+            "brin",
+            "matsumoto",
+            "stallman",
+            "stroustrup",
+            "cook",
+            "neumann",
+            "babbage",
+            "tanenbaum",
+            "rivest",
+            "shamir",
+            "adleman",
+            "carmack",
+            "andreessen",
+            "ullman",
+            "postel",
+            "huffman",
+            "boole",
+            "curry",
+            "liskov",
+            "wing",
+            "goldwasser",
+            "hoare",
+            "milner",
+            "perlis",
+            "sutherland",
+            "tarjan",
+            "valiant",
+            "yao",
+            "hopcroft",
+            "naur",
+            "wilkes",
+            "codd",
+            "diffie",
+            "hellman",
+            "pearl",
+            "thiel",
+            "narayen",
+            "nadella",
+            "pichai",
+            "dorsey",
+        ]
+
+        self.used_names = set()
+
+    def generate_name(self):
+        """Generate a single memorable name."""
+        adjective = random.choice(self.adjectives)
+        scientist = random.choice(self.scientists)
+        return f"{adjective}_{scientist}"
+
+    def generate_unique_name(self):
+        """Generate a unique memorable name."""
+        attempts = 0
+        max_attempts = 100  # Prevent infinite loops
+
+        while attempts < max_attempts:
+            name = self.generate_name()
+            if name not in self.used_names:
+                self.used_names.add(name)
+                return name
+            attempts += 1
+
+        # If we exhaust our combinations, add a random suffix
+        base_name = self.generate_name()
+        unique_name = f"{base_name}_{random.randint(1000, 9999)}"
+        self.used_names.add(unique_name)
+        return unique_name
+
+    def generate_unique_names(self, count):
+        """Generate multiple unique memorable names."""
+        return [self.generate_unique_name() for _ in range(count)]
+
+
+# Global instance for easy access
+memorable_names = MemorableNames()
+
+
+def find_git_root(start_path: t.Union[str, Path, None] = None) -> Path:
+    """Find the root directory of a git repository by traversing up from the start path."""
+    # Start from the current directory if no path is provided
+    if start_path is None:
+        start_path = Path.cwd()
+    else:
+        start_path = Path(start_path).resolve()
+
+    # Check if the current directory is a git repository
+    current_path = start_path
+    while current_path != current_path.parent:  # Stop at filesystem root
+        if (current_path / ".git").exists() and (current_path / ".git").is_dir():
+            return current_path
+
+        # Move up to the parent directory
+        current_path = current_path.parent
+
+    # Final check for the root directory
+    if (current_path / ".git").exists() and (current_path / ".git").is_dir():
+        return current_path
+
+    # No git repository found
+    raise ValueError(f"No git repository found in or above {start_path}")

--- a/ragas/tests/experimental/unit/test_datatable.py
+++ b/ragas/tests/experimental/unit/test_datatable.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from ragas.backends.local_csv import LocalCSVBackend
 from ragas.experimental.dataset import DataTable, Dataset
-from ragas.experimental.experiment import Experiment
+from ragas import Experiment
 
 
 # Test BaseModel classes

--- a/ragas/tests/unit/test_experiment.py
+++ b/ragas/tests/unit/test_experiment.py
@@ -1,0 +1,421 @@
+"""Tests for the experiment module."""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from ragas.backends.inmemory import InMemoryBackend
+from ragas.experiment import Experiment, experiment, version_experiment
+from ragas.experimental.dataset import Dataset
+from ragas.utils import find_git_root, memorable_names
+
+
+# Test data models
+class SampleDataRow(BaseModel):
+    question: str
+    answer: str
+    score: float
+
+
+class ExperimentResultRow(BaseModel):
+    question: str
+    processed_answer: str
+    sentiment: str
+    processing_time: float
+
+
+# Test fixtures
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for testing."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yield Path(tmp_dir)
+
+
+@pytest.fixture
+def mock_git_repo(temp_dir):
+    """Create a mock git repository."""
+    git_dir = temp_dir / ".git"
+    git_dir.mkdir()
+
+    # Mock git.Repo
+    mock_repo = MagicMock()
+    mock_repo.is_dirty.return_value = False
+    mock_repo.head.commit.hexsha = "abc123def456"
+    mock_repo.git.add = MagicMock()
+    mock_repo.index.commit = MagicMock()
+    mock_repo.create_head = MagicMock()
+
+    with patch("ragas.experiment.git.Repo", return_value=mock_repo):
+        yield mock_repo, temp_dir
+
+
+@pytest.fixture
+def sample_dataset():
+    """Create a sample dataset for testing."""
+    backend = InMemoryBackend()
+    dataset = Dataset(
+        name="test_dataset",
+        data_model=SampleDataRow,
+        backend=backend,
+        data=[
+            SampleDataRow(
+                question="What is Python?", answer="A programming language", score=0.9
+            ),
+            SampleDataRow(
+                question="What is AI?", answer="Artificial Intelligence", score=0.8
+            ),
+            SampleDataRow(
+                question="What is ML?", answer="Machine Learning", score=0.85
+            ),
+        ],
+    )
+    return dataset
+
+
+@pytest.fixture
+def experiment_backend():
+    """Create a backend for experiments."""
+    return InMemoryBackend()
+
+
+# Test classes
+class TestExperiment:
+    """Test the Experiment class."""
+
+    def test_experiment_inheritance(self):
+        """Test that Experiment properly inherits from DataTable."""
+        assert hasattr(Experiment, "DATATABLE_TYPE")
+        assert Experiment.DATATABLE_TYPE == "Experiment"
+
+    def test_experiment_creation(self, experiment_backend):
+        """Test creating an Experiment instance."""
+        experiment = Experiment(
+            name="test_experiment",
+            data_model=ExperimentResultRow,
+            backend=experiment_backend,
+        )
+
+        assert experiment.name == "test_experiment"
+        assert experiment.backend == experiment_backend
+        assert len(experiment) == 0
+
+
+class TestVersionExperiment:
+    """Test the version_experiment function."""
+
+    def test_version_experiment_no_changes(self, mock_git_repo):
+        """Test version_experiment when there are no changes."""
+        mock_repo, temp_dir = mock_git_repo
+
+        # Mock that repo is clean
+        mock_repo.is_dirty.return_value = False
+
+        with patch("ragas.experiment.find_git_root", return_value=temp_dir):
+            commit_hash = version_experiment("test_experiment")
+
+        assert commit_hash == "abc123def456"
+        mock_repo.is_dirty.assert_called()
+        mock_repo.create_head.assert_called_with(
+            "ragas/test_experiment", "abc123def456"
+        )
+
+    def test_version_experiment_with_changes(self, mock_git_repo):
+        """Test version_experiment when there are changes to commit."""
+        mock_repo, temp_dir = mock_git_repo
+
+        # Mock that repo is dirty
+        mock_repo.is_dirty.return_value = True
+
+        # Mock commit object
+        mock_commit = MagicMock()
+        mock_commit.hexsha = "new123commit456"
+        mock_repo.index.commit.return_value = mock_commit
+
+        with patch("ragas.experiment.find_git_root", return_value=temp_dir):
+            commit_hash = version_experiment("test_experiment")
+
+        assert commit_hash == "new123commit456"
+        mock_repo.git.add.assert_called_with("-u")
+        mock_repo.index.commit.assert_called_once()
+
+    def test_version_experiment_with_custom_message(self, mock_git_repo):
+        """Test version_experiment with custom commit message."""
+        mock_repo, temp_dir = mock_git_repo
+        mock_repo.is_dirty.return_value = True
+
+        mock_commit = MagicMock()
+        mock_commit.hexsha = "custom123commit456"
+        mock_repo.index.commit.return_value = mock_commit
+
+        with patch("ragas.experiment.find_git_root", return_value=temp_dir):
+            version_experiment(
+                "test_experiment", commit_message="Custom experiment message"
+            )
+
+        mock_repo.index.commit.assert_called_with("Custom experiment message")
+
+    def test_version_experiment_stage_all(self, mock_git_repo):
+        """Test version_experiment with stage_all=True."""
+        mock_repo, temp_dir = mock_git_repo
+        mock_repo.is_dirty.return_value = True
+
+        mock_commit = MagicMock()
+        mock_commit.hexsha = "staged123commit456"
+        mock_repo.index.commit.return_value = mock_commit
+
+        with patch("ragas.experiment.find_git_root", return_value=temp_dir):
+            version_experiment("test_experiment", stage_all=True)
+
+        mock_repo.git.add.assert_called_with(".")
+
+    def test_version_experiment_no_branch_creation(self, mock_git_repo):
+        """Test version_experiment with create_branch=False."""
+        mock_repo, temp_dir = mock_git_repo
+
+        with patch("ragas.experiment.find_git_root", return_value=temp_dir):
+            version_experiment("test_experiment", create_branch=False)
+
+        mock_repo.create_head.assert_not_called()
+
+    def test_find_git_root_error_handling(self, temp_dir):
+        """Test that find_git_root raises ValueError when no git repo found."""
+        with pytest.raises(ValueError, match="No git repository found"):
+            find_git_root(temp_dir)
+
+
+class TestExperimentDecorator:
+    """Test the experiment decorator."""
+
+    @pytest.mark.asyncio
+    async def test_simple_async_experiment(self, sample_dataset, experiment_backend):
+        """Test a simple async experiment function."""
+
+        @experiment(experiment_model=ExperimentResultRow, backend=experiment_backend)
+        async def simple_experiment(row: SampleDataRow) -> ExperimentResultRow:
+            return ExperimentResultRow(
+                question=row.question,
+                processed_answer=row.answer.upper(),
+                sentiment="positive",
+                processing_time=0.1,
+            )
+
+        # Test that decorator creates proper wrapper
+        assert hasattr(simple_experiment, "arun")
+        assert hasattr(simple_experiment, "__call__")
+
+        # Test calling the wrapped function directly
+        test_row = SampleDataRow(question="Test?", answer="test answer", score=0.5)
+        result = await simple_experiment(test_row)
+
+        assert isinstance(result, ExperimentResultRow)
+        assert result.processed_answer == "TEST ANSWER"
+        assert result.sentiment == "positive"
+
+    @pytest.mark.asyncio
+    async def test_experiment_arun(self, sample_dataset, experiment_backend):
+        """Test running experiment against a dataset."""
+
+        @experiment(experiment_model=ExperimentResultRow, backend=experiment_backend)
+        async def test_experiment(row: SampleDataRow) -> ExperimentResultRow:
+            return ExperimentResultRow(
+                question=row.question,
+                processed_answer=row.answer.lower(),
+                sentiment="neutral",
+                processing_time=0.05,
+            )
+
+        # Mock memorable_names to return predictable name
+        with patch(
+            "ragas.experiment.memorable_names.generate_unique_name",
+            return_value="test_experiment_name",
+        ):
+            experiment_result = await test_experiment.arun(sample_dataset)
+
+        assert isinstance(experiment_result, Experiment)
+        assert experiment_result.name == "test_experiment_name"
+        assert len(experiment_result) == 3  # Should have processed all 3 items
+
+    @pytest.mark.asyncio
+    async def test_experiment_with_name_prefix(
+        self, sample_dataset, experiment_backend
+    ):
+        """Test experiment decorator with name prefix."""
+
+        @experiment(
+            experiment_model=ExperimentResultRow,
+            backend=experiment_backend,
+            name_prefix="prefix",
+        )
+        async def prefixed_experiment(row: SampleDataRow) -> ExperimentResultRow:
+            return ExperimentResultRow(
+                question=row.question,
+                processed_answer=row.answer,
+                sentiment="neutral",
+                processing_time=0.01,
+            )
+
+        with patch(
+            "ragas.experiment.memorable_names.generate_unique_name",
+            return_value="random_name",
+        ):
+            experiment_result = await prefixed_experiment.arun(sample_dataset)
+
+        assert experiment_result.name == "prefix-random_name"
+
+    @pytest.mark.asyncio
+    async def test_experiment_with_custom_name(
+        self, sample_dataset, experiment_backend
+    ):
+        """Test experiment with custom name."""
+
+        @experiment(experiment_model=ExperimentResultRow, backend=experiment_backend)
+        async def custom_named_experiment(row: SampleDataRow) -> ExperimentResultRow:
+            return ExperimentResultRow(
+                question=row.question,
+                processed_answer=row.answer,
+                sentiment="positive",
+                processing_time=0.02,
+            )
+
+        experiment_result = await custom_named_experiment.arun(
+            sample_dataset, name="my_custom_experiment"
+        )
+
+        assert experiment_result.name == "my_custom_experiment"
+
+    def test_sync_experiment_function(self, experiment_backend):
+        """Test that sync functions work with the experiment decorator."""
+
+        @experiment(experiment_model=ExperimentResultRow, backend=experiment_backend)
+        def sync_experiment(row: SampleDataRow) -> ExperimentResultRow:
+            return ExperimentResultRow(
+                question=row.question,
+                processed_answer=row.answer.upper(),
+                sentiment="positive",
+                processing_time=0.0,
+            )
+
+        # Test that we can call it synchronously within async context
+        test_row = SampleDataRow(question="Sync test?", answer="sync answer", score=0.7)
+
+        async def test_sync_call():
+            result = await sync_experiment(test_row)
+            return result
+
+        result = asyncio.run(test_sync_call())
+        assert isinstance(result, ExperimentResultRow)
+        assert result.processed_answer == "SYNC ANSWER"
+
+    @pytest.mark.asyncio
+    async def test_experiment_error_handling(self, sample_dataset, experiment_backend):
+        """Test that experiment handles individual task failures gracefully."""
+
+        @experiment(experiment_model=ExperimentResultRow, backend=experiment_backend)
+        async def failing_experiment(row: SampleDataRow) -> ExperimentResultRow:
+            if "AI" in row.question:  # Fail on the AI question
+                raise ValueError("Test error")
+            return ExperimentResultRow(
+                question=row.question,
+                processed_answer=row.answer,
+                sentiment="neutral",
+                processing_time=0.01,
+            )
+
+        # Should continue processing other items even if some fail
+        with patch(
+            "ragas.experiment.memorable_names.generate_unique_name",
+            return_value="error_test",
+        ):
+            experiment_result = await failing_experiment.arun(sample_dataset)
+
+        # Should have 2 successful results (3 items - 1 failure)
+        assert len(experiment_result) == 2
+
+    @pytest.mark.asyncio
+    async def test_experiment_with_no_model(self, sample_dataset, experiment_backend):
+        """Test experiment without specifying a model."""
+
+        @experiment(backend=experiment_backend)
+        async def untyped_experiment(row: SampleDataRow) -> dict:
+            return {"question": row.question, "answer": row.answer, "processed": True}
+
+        with patch(
+            "ragas.experiment.memorable_names.generate_unique_name",
+            return_value="untyped_test",
+        ):
+            experiment_result = await untyped_experiment.arun(sample_dataset)
+
+        assert isinstance(experiment_result, Experiment)
+        assert len(experiment_result) == 3
+
+
+class TestMemorableNames:
+    """Test the memorable names functionality."""
+
+    def test_memorable_names_generation(self):
+        """Test that memorable names are generated correctly."""
+        name = memorable_names.generate_name()
+        assert "_" in name
+        parts = name.split("_", 1)  # Split on first underscore only
+        assert len(parts) == 2
+        assert parts[0] in memorable_names.adjectives
+        assert parts[1] in memorable_names.scientists
+
+    def test_unique_name_generation(self):
+        """Test that unique names are generated."""
+        # Create a fresh instance to avoid state from other tests
+        from ragas.utils import MemorableNames
+
+        generator = MemorableNames()
+
+        names = [generator.generate_unique_name() for _ in range(10)]
+        assert len(set(names)) == 10  # All names should be unique
+
+    def test_unique_names_batch_generation(self):
+        """Test batch generation of unique names."""
+        from ragas.utils import MemorableNames
+
+        generator = MemorableNames()
+
+        names = generator.generate_unique_names(5)
+        assert len(names) == 5
+        assert len(set(names)) == 5  # All should be unique
+
+
+class TestUtilityFunctions:
+    """Test utility functions added to ragas.utils."""
+
+    def test_find_git_root_with_git_repo(self, temp_dir):
+        """Test find_git_root finds git repository correctly."""
+        # Create a nested directory structure with .git at the top
+        git_dir = temp_dir / ".git"
+        git_dir.mkdir()
+
+        nested_dir = temp_dir / "nested" / "deeply" / "nested"
+        nested_dir.mkdir(parents=True)
+
+        # Should find git root from nested directory
+        found_root = find_git_root(nested_dir)
+        # Use resolve() to handle symlinks and get canonical path
+        assert found_root.resolve() == temp_dir.resolve()
+
+    def test_find_git_root_current_dir(self):
+        """Test find_git_root uses current directory when no path provided."""
+        # This should find the actual git root of the ragas project
+        try:
+            root = find_git_root()
+            assert isinstance(root, Path)
+            assert (root / ".git").exists()
+        except ValueError:
+            # If we're not in a git repo, that's expected
+            pass
+
+    def test_find_git_root_no_repo_error(self, temp_dir):
+        """Test find_git_root raises error when no git repo found."""
+        with pytest.raises(ValueError, match="No git repository found"):
+            find_git_root(temp_dir)

--- a/ragas/tests/unit/test_experiment.py
+++ b/ragas/tests/unit/test_experiment.py
@@ -50,7 +50,7 @@ def mock_git_repo(temp_dir):
     mock_repo.index.commit = MagicMock()
     mock_repo.create_head = MagicMock()
 
-    with patch("ragas.experiment.git.Repo", return_value=mock_repo):
+    with patch("git.Repo", return_value=mock_repo):
         yield mock_repo, temp_dir
 
 
@@ -115,7 +115,7 @@ class TestVersionExperiment:
         # Mock that repo is clean
         mock_repo.is_dirty.return_value = False
 
-        with patch("ragas.experiment.find_git_root", return_value=temp_dir):
+        with patch("ragas.utils.find_git_root", return_value=temp_dir):
             commit_hash = version_experiment("test_experiment")
 
         assert commit_hash == "abc123def456"
@@ -136,7 +136,7 @@ class TestVersionExperiment:
         mock_commit.hexsha = "new123commit456"
         mock_repo.index.commit.return_value = mock_commit
 
-        with patch("ragas.experiment.find_git_root", return_value=temp_dir):
+        with patch("ragas.utils.find_git_root", return_value=temp_dir):
             commit_hash = version_experiment("test_experiment")
 
         assert commit_hash == "new123commit456"
@@ -152,7 +152,7 @@ class TestVersionExperiment:
         mock_commit.hexsha = "custom123commit456"
         mock_repo.index.commit.return_value = mock_commit
 
-        with patch("ragas.experiment.find_git_root", return_value=temp_dir):
+        with patch("ragas.utils.find_git_root", return_value=temp_dir):
             version_experiment(
                 "test_experiment", commit_message="Custom experiment message"
             )
@@ -168,7 +168,7 @@ class TestVersionExperiment:
         mock_commit.hexsha = "staged123commit456"
         mock_repo.index.commit.return_value = mock_commit
 
-        with patch("ragas.experiment.find_git_root", return_value=temp_dir):
+        with patch("ragas.utils.find_git_root", return_value=temp_dir):
             version_experiment("test_experiment", stage_all=True)
 
         mock_repo.git.add.assert_called_with(".")
@@ -177,7 +177,7 @@ class TestVersionExperiment:
         """Test version_experiment with create_branch=False."""
         mock_repo, temp_dir = mock_git_repo
 
-        with patch("ragas.experiment.find_git_root", return_value=temp_dir):
+        with patch("ragas.utils.find_git_root", return_value=temp_dir):
             version_experiment("test_experiment", create_branch=False)
 
         mock_repo.create_head.assert_not_called()
@@ -231,7 +231,7 @@ class TestExperimentDecorator:
 
         # Mock memorable_names to return predictable name
         with patch(
-            "ragas.experiment.memorable_names.generate_unique_name",
+            "ragas.utils.memorable_names.generate_unique_name",
             return_value="test_experiment_name",
         ):
             experiment_result = await test_experiment.arun(sample_dataset)
@@ -260,7 +260,7 @@ class TestExperimentDecorator:
             )
 
         with patch(
-            "ragas.experiment.memorable_names.generate_unique_name",
+            "ragas.utils.memorable_names.generate_unique_name",
             return_value="random_name",
         ):
             experiment_result = await prefixed_experiment.arun(sample_dataset)
@@ -328,7 +328,7 @@ class TestExperimentDecorator:
 
         # Should continue processing other items even if some fail
         with patch(
-            "ragas.experiment.memorable_names.generate_unique_name",
+            "ragas.utils.memorable_names.generate_unique_name",
             return_value="error_test",
         ):
             experiment_result = await failing_experiment.arun(sample_dataset)
@@ -345,7 +345,7 @@ class TestExperimentDecorator:
             return {"question": row.question, "answer": row.answer, "processed": True}
 
         with patch(
-            "ragas.experiment.memorable_names.generate_unique_name",
+            "ragas.utils.memorable_names.generate_unique_name",
             return_value="untyped_test",
         ):
             experiment_result = await untyped_experiment.arun(sample_dataset)


### PR DESCRIPTION
Done
---
- [x] This is a cascading PR i.e. you're expected to review and merge https://github.com/explodinggradients/ragas/pull/2174 before looking at this. 

Changes
---
1. Moved and renamed the experiment files, relevant imports in examples and docs
2. Expanded ragas current utils.py implementation to support behaviour from experimental utils
3. Added some tests which I deemed useful