### PR TITLE
hotfix: Include LICENSE and README.md in PyPI package

### DIFF
--- a/ragas/LICENSE
+++ b/ragas/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2023] [Exploding Gradients]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ragas/README.md
+++ b/ragas/README.md
@@ -1,0 +1,157 @@
+<h1 align="center">
+  <img style="vertical-align:middle" height="200"
+  src="./docs/_static/imgs/logo.png">
+</h1>
+<p align="center">
+  <i>Supercharge Your LLM Application Evaluations 🚀</i>
+</p>
+
+<p align="center">
+    <a href="https://github.com/explodinggradients/ragas/releases">
+        <img alt="GitHub release" src="https://img.shields.io/github/release/explodinggradients/ragas.svg">
+    </a>
+    <a href="https://www.python.org/">
+            <img alt="Build" src="https://img.shields.io/badge/Made%20with-Python-1f425f.svg?color=purple">
+    </a>
+    <a href="https://github.com/explodinggradients/ragas/blob/master/LICENSE">
+        <img alt="License" src="https://img.shields.io/github/license/explodinggradients/ragas.svg?color=green">
+    </a>
+    <a href="https://pypi.org/project/ragas/">
+        <img alt="Open In Colab" src="https://img.shields.io/pypi/dm/ragas">
+    </a>
+    <a href="https://discord.gg/5djav8GGNZ">
+        <img alt="discord-invite" src="https://img.shields.io/discord/1119637219561451644">
+    </a>
+    <a target="_blank" href="https://deepwiki.com/explodinggradients/ragas">
+    <img 
+      src="https://devin.ai/assets/deepwiki-badge.png" 
+      alt="Ask DeepWiki.com" 
+      height="20" 
+    />
+  </a>
+</p>
+
+<h4 align="center">
+    <p>
+        <a href="https://docs.ragas.io/">Documentation</a> |
+        <a href="#fire-quickstart">Quick start</a> |
+        <a href="https://discord.gg/5djav8GGNZ">Join Discord</a> |
+        <a href="https://blog.ragas.io/">Blog</a> |
+        <a href="https://newsletter.ragas.io/">NewsLetter</a> |
+        <a href="https://www.ragas.io/careers">Careers</a>
+    <p>
+</h4>
+
+Objective metrics, intelligent test generation, and data-driven insights for LLM apps
+
+Ragas is your ultimate toolkit for evaluating and optimizing Large Language Model (LLM) applications. Say goodbye to time-consuming, subjective assessments and hello to data-driven, efficient evaluation workflows.
+Don't have a test dataset ready? We also do production-aligned test set generation.
+
+> [!NOTE]
+> Need help setting up Evals for your AI application? We'd love to help! We are conducting Office Hours every week. You can sign up [here](https://cal.com/team/ragas/office-hours).
+
+## Key Features
+
+- 🎯 Objective Metrics: Evaluate your LLM applications with precision using both LLM-based and traditional metrics.
+- 🧪 Test Data Generation: Automatically create comprehensive test datasets covering a wide range of scenarios.
+- 🔗 Seamless Integrations: Works flawlessly with popular LLM frameworks like LangChain and major observability tools.
+- 📊 Build feedback loops: Leverage production data to continually improve your LLM applications.
+
+## :shield: Installation
+
+Pypi: 
+
+```bash
+pip install ragas
+```
+
+Alternatively, from source:
+
+```bash
+pip install git+https://github.com/explodinggradients/ragas
+```
+
+## :fire: Quickstart
+
+### Evaluate your LLM App
+
+This is 5 main lines:
+
+```python
+from ragas import SingleTurnSample
+from ragas.metrics import AspectCritic
+
+test_data = {
+    "user_input": "summarise given text\nThe company reported an 8% rise in Q3 2024, driven by strong performance in the Asian market. Sales in this region have significantly contributed to the overall growth. Analysts attribute this success to strategic marketing and product localization. The positive trend in the Asian market is expected to continue into the next quarter.",
+    "response": "The company experienced an 8% increase in Q3 2024, largely due to effective marketing strategies and product adaptation, with expectations of continued growth in the coming quarter.",
+}
+evaluator_llm = LangchainLLMWrapper(ChatOpenAI(model="gpt-4o"))
+metric = AspectCritic(name="summary_accuracy",llm=evaluator_llm, definition="Verify if the summary is accurate.")
+await metric.single_turn_ascore(SingleTurnSample(**test_data))
+```
+
+Find the complete [Quickstart Guide](https://docs.ragas.io/en/latest/getstarted/evals)
+
+## Want help in improving your AI application using evals?
+
+In the past 2 years, we have seen and helped improve many AI applications using evals. 
+
+We are compressing this knowledge into a product to replace vibe checks with eval loops so that you can focus on building great AI applications. 
+
+If you want help with improving and scaling up your AI application using evals.
+
+
+🔗 Book a [slot](https://bit.ly/3EBYq4J) or drop us a line: [founders@explodinggradients.com](mailto:founders@explodinggradients.com).
+
+
+![](/docs/_static/ragas_app.gif)
+
+
+
+## 🫂 Community
+
+If you want to get more involved with Ragas, check out our [discord server](https://discord.gg/5qGUJ6mh7C). It's a fun community where we geek out about LLM, Retrieval, Production issues, and more.
+
+## Contributors
+
+```yml
++----------------------------------------------------------------------------+
+|     +----------------------------------------------------------------+     |
+|     | Developers: Those who built with `ragas`.                      |     |
+|     | (You have `import ragas` somewhere in your project)            |     |
+|     |     +----------------------------------------------------+     |     |
+|     |     | Contributors: Those who make `ragas` better.       |     |     |
+|     |     | (You make PR to this repo)                         |     |     |
+|     |     +----------------------------------------------------+     |     |
+|     +----------------------------------------------------------------+     |
++----------------------------------------------------------------------------+
+```
+
+We welcome contributions from the community! Whether it's bug fixes, feature additions, or documentation improvements, your input is valuable.
+
+1. Fork the repository
+2. Create your feature branch (git checkout -b feature/AmazingFeature)
+3. Commit your changes (git commit -m 'Add some AmazingFeature')
+4. Push to the branch (git push origin feature/AmazingFeature)
+5. Open a Pull Request
+
+## 🔍 Open Analytics
+At Ragas, we believe in transparency. We collect minimal, anonymized usage data to improve our product and guide our development efforts.
+
+✅ No personal or company-identifying information
+
+✅ Open-source data collection [code](./ragas/src/ragas/_analytics.py)
+
+✅ Publicly available aggregated [data](https://github.com/explodinggradients/ragas/issues/49)
+
+To opt-out, set the `RAGAS_DO_NOT_TRACK` environment variable to `true`.
+
+### Cite Us
+```
+@misc{ragas2024,
+  author       = {ExplodingGradients},
+  title        = {Ragas: Supercharge Your LLM Application Evaluations},
+  year         = {2024},
+  howpublished = {\url{https://github.com/explodinggradients/ragas}},
+}
+```

--- a/ragas/pyproject.toml
+++ b/ragas/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "ragas"
 requires-python = ">=3.9"
+license = {file = "LICENSE"}
 dependencies = [
     # Core dependencies
     "numpy",
@@ -108,8 +109,8 @@ dev = [
     "arize-phoenix>=6.1.0",
     "openinference-instrumentation-langchain>=0.1.29",
     "ragas[all,tracing,gdrive,ai-frameworks]",
+    "build>=1.3.0",
 ]
-
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material",


### PR DESCRIPTION
## Summary
- Fixes missing LICENSE and README.md files in PyPI package distribution
- Duplicates LICENSE and README.md files from repository root to ragas/ directory
- Updates pyproject.toml to properly reference these files in the package build

## Context  
This is a hotfix for #2124. The issue occurred because setuptools cannot access files outside the package directory (e.g., `../LICENSE` and `../README.md` paths don't work). While it would be cleaner to use a MANIFEST.in file or other approaches, duplicating the files directly into the ragas/ directory is the most reliable solution that ensures these critical files are always included in the PyPI distribution.

## Changes
- Copied LICENSE and README.md from repository root to ragas/LICENSE and ragas/README.md
- Updated ragas/pyproject.toml to reference local copies: `license = {file = "LICENSE"}` and `readme = {file = ["README.md"], content-type = "text/markdown"}`
- Verified both files are properly included in the built distribution package

## Test Plan
- [x] Built source distribution successfully with `uv run python -m build --sdist`
- [x] Verified LICENSE and README.md are included in the distribution tarball
- [x] Confirmed setuptools recognizes and processes both files correctly

This ensures PyPI users will have access to the license information and project documentation as expected.