### PR TITLE
feat: separate minimal and full dev installations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,47 @@ The repository contains:
 
 ## Development Environment Setup
 
-### Installation
+### Installation Options
+
+Choose the appropriate installation based on your development needs:
+
+#### Minimal Development Setup
+Recommended for:
+- Code formatting, linting, and type checking
+- Running unit tests
+- Basic development tasks
+- Contributing to core functionality
 
 ```bash
 # Create a virtual environment
 python -m venv venv
 source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
 
-# For ragas (includes experimental features)
+# Install minimal development dependencies
 pip install -U setuptools  # Required on newer Python versions
 pip install -e "./ragas[dev]"
+# Or use make command
+make install-minimal
+```
+
+#### Full Development Setup
+Required for:
+- Working with experimental features
+- ML model development and testing
+- Notebook development
+- Tracing and observability features
+- Complete testing including benchmarks
+
+```bash
+# Create a virtual environment
+python -m venv venv
+source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
+
+# Install full development dependencies
+pip install -U setuptools
+uv sync --group dev-full --package ragas
+# Or use make command
+make install
 ```
 
 ## Common Commands
@@ -32,7 +63,8 @@ pip install -e "./ragas[dev]"
 
 ```bash
 # Setup and installation
-make install        # Install dependencies for ragas
+make install         # Install full development dependencies (including ML stack)
+make install-minimal # Install minimal development dependencies
 
 # Code quality
 make format         # Format and lint all code

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,7 +13,9 @@ cd ragas
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # 3. Install dependencies and setup environment
-make install
+make install         # Full setup with ML stack
+# OR
+make install-minimal # Lightweight setup for basic development
 
 # 4. Verify everything works
 make check
@@ -29,7 +31,8 @@ AI agents working with this codebase should use these standardized commands:
 ```bash
 # Essential commands for AI development
 make help           # See all available targets
-make install        # Install dependencies and setup environment
+make install        # Full development setup (recommended for most tasks)
+make install-minimal# Minimal setup for basic code quality tasks
 make check          # Quick health check (format + type)
 make test           # Run all tests
 make run-ci         # Full CI pipeline locally
@@ -82,19 +85,28 @@ ragas/
 
 ### Setup Process
 
-#### Option 1: Using Make (Recommended)
+#### Option 1: Full Development Setup (Recommended)
+Includes all dependencies for ML stack, experimental features, and notebooks:
 ```bash
 make install
 ```
 
-#### Option 2: Manual Setup
+#### Option 2: Minimal Development Setup
+Lightweight setup for basic development tasks (code quality, testing):
+```bash
+make install-minimal
+```
+
+#### Option 3: Manual Setup
 ```bash
 # Install uv if not available
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Install both projects
+# Minimal setup
 uv pip install -e "./ragas[dev]"
-uv pip install -e "./experimental[dev]"
+
+# Full setup
+uv sync --group dev-full --package ragas
 ```
 
 ### Verification
@@ -108,7 +120,8 @@ make test   # Runs all tests
 Run `make help` to see all targets. Here are the essential commands:
 
 ### Setup & Installation
-- `make install` - Install dependencies for both projects
+- `make install` - Install full development dependencies (including ML stack)
+- `make install-minimal` - Install minimal development dependencies
 
 ### Code Quality
 - `make format` - Format and lint all code (includes unused import cleanup)
@@ -323,8 +336,23 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```bash
 # Clean install
 make clean
-make install
+make install        # Full setup
+# OR
+make install-minimal # Minimal setup if you don't need ML stack
 ```
+
+#### Choosing Installation Type
+**Use minimal installation when:**
+- Working on core code changes
+- Running format, lint, type checks
+- Basic unit testing
+- Limited disk space or slow internet
+
+**Use full installation when:**
+- Working with experimental features
+- ML model development or testing
+- Running benchmarks
+- Working with notebooks or tracing
 
 ### Getting Help
 - **Documentation**: Check `CLAUDE.md` for AI assistant guidance

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,21 @@ help: ## Show all Makefile targets
 # SETUP & INSTALLATION
 # =============================================================================
 
-install: ## Install dependencies for ragas
-	@echo "Installing dependencies..."
-	@echo "Installing ragas dependencies (including experimental)..."
+install: ## Install full development dependencies for ragas
+	@echo "Installing full development dependencies..."
+	@echo "Installing ragas with all development dependencies (including ML stack)..."
+	$(Q)uv sync --group dev-full --package ragas
+	@echo "Setting up pre-commit hooks..."
+	$(Q)pre-commit install
+	@echo "Full installation complete!"
+
+install-minimal: ## Install minimal development dependencies for ragas
+	@echo "Installing minimal development dependencies..."
+	@echo "Installing ragas with minimal dev dependencies..."
 	$(Q)uv pip install -e "./ragas[dev]"
 	@echo "Setting up pre-commit hooks..."
 	$(Q)pre-commit install
-	@echo "Installation complete!"
+	@echo "Minimal installation complete!"
 
 # =============================================================================
 # CODE QUALITY

--- a/ragas/pyproject.toml
+++ b/ragas/pyproject.toml
@@ -65,6 +65,17 @@ gdrive = [
 ]
 ai-frameworks = ["haystack-ai"]
 
+# Development dependencies
+dev = [  # Minimal dev requirements
+    "ruff",
+    "pyright>=1.1.403",
+    "pre-commit>=4.3.0",
+    "pytest",
+    "pytest-xdist[psutil]",
+    "pytest-asyncio",
+    "nbmake",
+]
+
 test = []
 [project.entry-points."ragas.backends"]
 "local/csv" = "ragas.backends.local_csv:LocalCSVBackend"
@@ -104,18 +115,11 @@ markers = [
 ]
 
 [dependency-groups]
-dev = [
-    "ruff",
-    "pyright>=1.1.403",
-    "pre-commit>=4.3.0",
-    "pytest",
-    "pytest-xdist[psutil]",
-    "pytest-asyncio",
-    "nbmake",
+dev-full = [  # Everything including ML stack
+    "ragas[dev,all,tracing,gdrive,ai-frameworks]",
     "notebook",
     "arize-phoenix>=6.1.0",
     "openinference-instrumentation-langchain>=0.1.29",
-    "ragas[all,tracing,gdrive,ai-frameworks]",
     "build>=1.3.0",
 ]
 docs = [


### PR DESCRIPTION
This is a thinking out loud PR about how I am thinking on some changes in `pyproject.toml`
 
## Summary
- Add minimal dev installation option with core development tools only (ruff, pytest, pyright)
- Keep full installation with complete ML stack and experimental features for advanced development
- Update documentation and build commands to support both installation types

Fixes https://github.com/explodinggradients/ragas/issues/2185