### PR TITLE
Closes Issue #2170: Address issue 2170 by specifying 'datasets' core dependency version to >=4.0.0

### DIFF
--- a/ragas/pyproject.toml
+++ b/ragas/pyproject.toml
@@ -6,7 +6,7 @@ license = {file = "LICENSE"}
 dependencies = [
     # Core dependencies
     "numpy",
-    "datasets",
+    "datasets>=4.0.0",
     "tiktoken",
     "pydantic>=2.0.0",
     "nest-asyncio",


### PR DESCRIPTION
The fix includes specifying the 'datasets' core dependency to use the latest datasets version >=4.0.0. 

This fixes an issue where pip accidentally resolves to a lower version due to a dependency-resolution chain that causes an unfavourable outcome which leads to ragas breaking at the import step.

Please test ragas comprehensively with this fix in place before merging.