### PR TITLE
Fix repeating template bug in _nv_metrics.py

### DIFF
--- a/src/ragas/metrics/_nv_metrics.py
+++ b/src/ragas/metrics/_nv_metrics.py
@@ -269,7 +269,7 @@ class ContextRelevance(MetricWithLLM, SingleTurnMetric):
 
             for retry in range(self.retry):
                 formatted_prompt = StringPromptValue(
-                    text=self.template_relevance1.format(
+                    text=self.template_relevance2.format(
                         query=sample.user_input,
                         context="\n".join(sample.retrieved_contexts)[:7000],
                     )


### PR DESCRIPTION
ContextRelevance class uses the same template(template_relevance1) in both retry loop, instead of template_relevance2.

Replaced template_relevance1 in second retry loop with template_relevance2