### PR TITLE
fix: update make commands to use uv for docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,9 +159,9 @@ test-e2e: ## Run all end-to-end tests
 build-docs: ## Build all documentation
 	@echo "Building all documentation..."
 	@echo "Converting ipynb notebooks to md files..."
-	$(Q)python $(GIT_ROOT)/docs/ipynb_to_md.py
+	$(Q)MKDOCS_CI=true uv run python $(GIT_ROOT)/docs/ipynb_to_md.py
 	@echo "Building ragas documentation..."
-	$(Q)mkdocs build
+	$(Q)uv run --group docs mkdocs build
 
 serve-docs: ## Build and serve documentation locally
-	$(Q)mkdocs serve --dirtyreload
+	$(Q)uv run --group docs mkdocs serve --dirtyreload


### PR DESCRIPTION
## Issue Link / Problem Description
<!-- Link to related issue or describe the problem this PR solves -->
- Docs build is failing

## Changes Made
<!-- Describe what you changed and why -->
- Fixes docs build and serve

## Testing
<!-- Describe how this should be tested -->
### How to Test
- [x] Automated tests added/updated
- [x] Manual testing steps:
  1. `make build-docs`
  2. `make serve-docs`
