### PR TITLE
docs: fix broken link in FAQ (metrics tracing)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Ragas is a library that provides tools to supercharge the evaluation of Large La
 
 <div class="toggle-list"><span class="arrow">→</span> How can I make evaluation results more explainable?</div>
 <div style="display: none;">
-    The best way is to trace and log your evaluation, then inspect the results using LLM traces. You can follow a detailed example of this process <a href="/howtos/customizations/metrics/tracing/">here</a>.
+    The best way is to trace and log your evaluation, then inspect the results using LLM traces. You can follow a detailed example of this process <a href="https://docs.ragas.io/en/stable/howtos/customizations/metrics/tracing/">here</a>.
 </div>
 
 <script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Ragas is a library that provides tools to supercharge the evaluation of Large La
 
 <div class="toggle-list"><span class="arrow">→</span> How can I make evaluation results more explainable?</div>
 <div style="display: none;">
-    The best way is to trace and log your evaluation, then inspect the results using LLM traces. You can follow a detailed example of this process <a href="https://docs.ragas.io/en/stable/howtos/customizations/metrics/tracing/">here</a>.
+    The best way is to trace and log your evaluation, then inspect the results using LLM traces. You can follow a detailed example of this process <a href="./howtos/customizations/metrics/tracing/">here</a>.
 </div>
 
 <script>


### PR DESCRIPTION
This PR fixes a broken link in the FAQ section of the documentation.

- Old link: /howtos/customizations/metrics/tracing/
- New link: https://docs.ragas.io/en/stable/howtos/customizations/metrics/tracing/

Closes #2140
