### PR TITLE
Refactor/update gemini to genai sdk

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -647,8 +647,8 @@ def instructor_llm_factory(
         # Cohere
         llm = instructor_llm_factory("cohere", "command-r-plus", client=cohere_client)
 
-        # Gemini
-        llm = instructor_llm_factory("gemini", "gemini-pro", client=gemini_client)
+        # Google
+        llm = instructor_llm_factory(provider="google", model="gemini-2.0-flash", client=google_client)
 
         # LiteLLM (supports 100+ models)
         llm = instructor_llm_factory("litellm", "gpt-4", client=litellm_client)
@@ -681,14 +681,14 @@ def instructor_llm_factory(
             return instructor.from_anthropic(client)
         elif provider_lower == "cohere":
             return instructor.from_cohere(client)
-        elif provider_lower == "gemini":
-            return instructor.from_gemini(client)
+        elif provider_lower == "google":
+            return instructor.from_genai(client)
         elif provider_lower == "litellm":
             return instructor.from_litellm(client)
         else:
             raise ValueError(
                 f"Unsupported provider: {provider}. "
-                f"Supported providers: openai, anthropic, cohere, gemini, litellm"
+                f"Supported providers: openai, anthropic, cohere, google, litellm"
             )
 
     instructor_patched_client = _initialize_client(provider=provider, client=client)

--- a/tests/unit/llms/test_instructor_factory.py
+++ b/tests/unit/llms/test_instructor_factory.py
@@ -172,7 +172,7 @@ def test_sync_client_agenerate_error(mock_sync_client, monkeypatch):
 
 def test_provider_support():
     """Test that all expected providers are supported."""
-    supported_providers = ["openai", "anthropic", "cohere", "gemini", "litellm"]
+    supported_providers = ["openai", "anthropic", "cohere", "google", "litellm"]
 
     for provider in supported_providers:
         mock_client = Mock()

--- a/tests/unit/llms/test_instructor_factory.py
+++ b/tests/unit/llms/test_instructor_factory.py
@@ -172,16 +172,22 @@ def test_sync_client_agenerate_error(mock_sync_client, monkeypatch):
 
 def test_provider_support():
     """Test that all expected providers are supported."""
-    supported_providers = ["openai", "anthropic", "cohere", "google", "litellm"]
+    supported_providers = {
+        "openai": "from_openai",
+        "anthropic": "from_anthropic",
+        "cohere": "from_cohere",
+        "google": "from_genai",
+        "litellm": "from_litellm",
+    }
 
-    for provider in supported_providers:
+    for provider, func_name in supported_providers.items():
         mock_client = Mock()
 
         # Mock the appropriate instructor function
         import instructor
 
         mock_instructor_func = Mock(return_value=MockInstructor(mock_client))
-        setattr(instructor, f"from_{provider}", mock_instructor_func)
+        setattr(instructor, func_name, mock_instructor_func)
 
         # This should not raise an error
         try:


### PR DESCRIPTION
## Problem Description

This PR updates the InstructorLLM wrapper and instructor_llm_factory to migrate from the legacy Gemini provider (instructor.from_gemini) to the new Google GenAI SDK (google-genai).

The Google GenAI SDK is now the official, production-ready library for working with Gemini models and has reached General Availability (GA) as of May 2025. It provides access to the latest Gemini features (such as Live API and Veo), offers better performance, and is actively maintained.

According to the [official Gemini documentation](https://ai.google.dev/gemini-api/docs/libraries):

> If you’re using one of our legacy libraries, we strongly recommend you migrate to the Google GenAI SDK. The legacy libraries are on a deprecation path and will stop receiving updates on November 30th, 2025.

## Changes Made
- Replaced references of gemini with google to align with the updated Google GenAI SDK naming and integration.
- Updated the provider handling inside _initialize_client:
```py
elif provider_lower == "google":
    return instructor.from_google(client)
```
instead of:
```py
elif provider_lower == "gemini":
    return instructor.from_gemini(client)
```

### How to Test
Use this code snippet to see it in action
```py
import instructor
from google import genai
from ragas.llms import instructor_llm_factory

client = genai.Client(api_key="...")
llm = instructor_llm_factory(provider="google", model="gemini-2.0-flash", client=client)
```

## References
- [Google GenAI SDK documentation](https://ai.google.dev/gemini-api/docs/libraries)




