### PR TITLE
chore: fix the dead space in the header for docsite

### DIFF
--- a/docs/extra/overrides/main.html
+++ b/docs/extra/overrides/main.html
@@ -3,7 +3,7 @@
 {% block extrahead %}
   {{ super() }}
   <!-- Scarf Analytics -->
-  <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f4040c26-97ff-4975-bcbb-8db47063d472" />
+  <img style="display: none;" referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f4040c26-97ff-4975-bcbb-8db47063d472" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">


### PR DESCRIPTION
remove the dead space in the docsite