### PR TITLE
Fix docs: correct inheritance class for Non-LLM metrics

### DIFF
--- a/docs/concepts/metrics/overview/index.md
+++ b/docs/concepts/metrics/overview/index.md
@@ -66,7 +66,7 @@ Each LLM based metrics also will have prompts associated with it written using [
 
 &nbsp;&nbsp;&nbsp;&nbsp; **Non-LLM-based metrics**: These metrics do not use LLM underneath to do the evaluation. These metrics are deterministic and can be used to evaluate the performance of the AI application without using LLM. These metrics rely on traditional methods to evaluate the performance of the AI application, such as string similarity, BLEU score, etc. Due to the same, these metrics are known to have a lower correlation with human evaluation.
 
-All LLM based metrics in ragas are inherited from `Metric` class. 
+All Non-LLM-based metrics in ragas are inherited from `Metric` class. 
 
 **Metrics can be broadly classified into two categories based on the type of data they evaluate**:
 


### PR DESCRIPTION
## Issue Link / Problem Description
- Fixes #2271
- The Metrics Overview docs currently say:  
  > "All LLM based metrics in ragas are inherited from Metric class."  
  This is incorrect.  
- Correct inheritance is:  
  - LLM-based metrics → `MetricWithLLM`  
  - Non-LLM-based metrics → `Metric`  

## Changes Made
- Updated `docs/concepts/metrics/overview/index.md`  
- Corrected wording to reflect that **Non-LLM-based metrics** inherit from `Metric`.  
- Ensures consistency between docs and actual implementation.  

## Testing
### How to Test
- [ ] Automated tests added/updated → *Not applicable (docs-only change)*  
- [ ] Manual testing steps:  


## References
- Related issue: #2271  
- Documentation page: [Metrics Overview](https://docs.ragas.io/en/latest/concepts/metrics/overview/#types-of-metrics-in-ragas)  

## Screenshots/Examples (if applicable)
**Before:**  
> All LLM based metrics in ragas are inherited from Metric class.  

**After:**  
> All Non-LLM-based metrics in ragas are inherited from Metric class.  
