### PR TITLE
modified the documentation to be in sync with current output format

### DIFF
--- a/docs/concepts/test_data_generation/rag.md
+++ b/docs/concepts/test_data_generation/rag.md
@@ -121,14 +121,7 @@ output[0]
 Returns a tuple of the type of the extractor and the extracted information.
 
 ```bash
-('entities',
- {'ORG': [],
-  'LOC': [],
-  'PER': ['Einstein'],
-  'MISC': ['theory of relativity',
-   'space',
-   'time',
-   "observer's frame of reference"]})
+('entities', ['Einstein', 'theory of relativity', 'space', 'time', "observer's frame of reference"])
 ```
 
 Let's add the extracted information to the node.
@@ -140,14 +133,8 @@ sample_nodes[0].properties
 
 Output:
 ```bash
-{'page_content': "Einstein's theory of relativity revolutionized our understanding of space and time. It introduced the concept that time is not absolute but can change depending on the observer's frame of reference.",
- 'entities': {'ORG': [],
-  'LOC': [],
-  'PER': ['Einstein'],
-  'MISC': ['theory of relativity',
-   'space',
-   'time',
-   "observer's frame of reference"]}}
+{'page_content': "Einstein's theory of relativity revolutionized our understanding of space and time. It introduced the concept that time is not absolute but can change depending on the observer's frame of reference.", 
+'entities': ['Einstein', 'theory of relativity', 'space', 'time', 'observer']}
 ```
 
 ```mermaid


### PR DESCRIPTION
- Fixes #2276 
This solved to be document in sync with current output NERExtractor module is giving.

## Changes Made
Updated the document to current output given by NERExtractor

## Testing
<!-- Describe how this should be tested -->
### How to Test
- [ ] Manual testing steps:
  1. Go here https://docs.ragas.io/en/latest/concepts/test_data_generation/rag/#example_1
  2. Verify that document updated with latest output format from NERExtractor as per screen shot below.


## References
<!-- Link to related issues, discussions, forums, or external resources -->
- Related issues: 
- Documentation: https://docs.ragas.io/en/latest/concepts/test_data_generation/rag/#example_1
- External references: 

## Screenshots/Examples (if applicable)
<img width="1645" height="847" alt="image" src="https://github.com/user-attachments/assets/b3574842-d0f7-4440-8703-4da9d6fee1ff" />


---
<!-- 
Thank you for contributing to Ragas! 
Please fill out the sections above as completely as possible.
The more information you provide, the faster your PR can be reviewed and merged.
-->
