### PR TITLE
Ensure old_temperature is set correctly. Fixes #1937 and #2110

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -216,7 +216,7 @@ class LangchainLLMWrapper(BaseRagasLLM):
         if temperature is None:
             temperature = self.get_temperature(n=n)
         if hasattr(self.langchain_llm, "temperature"):
-            old_temperature = self.langchain_llm.temperature
+            old_temperature = self.langchain_llm.temperature  # type: ignore
             self.langchain_llm.temperature = temperature  # type: ignore
 
         if is_multiple_completion_supported(self.langchain_llm):
@@ -268,7 +268,7 @@ class LangchainLLMWrapper(BaseRagasLLM):
         if temperature is None:
             temperature = self.get_temperature(n=n)
         if hasattr(self.langchain_llm, "temperature") and not self.bypass_temperature:
-            old_temperature = self.langchain_llm.temperature
+            old_temperature = self.langchain_llm.temperature # type: ignore
             self.langchain_llm.temperature = temperature  # type: ignore
 
         # handle n

--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -268,7 +268,7 @@ class LangchainLLMWrapper(BaseRagasLLM):
         if temperature is None:
             temperature = self.get_temperature(n=n)
         if hasattr(self.langchain_llm, "temperature") and not self.bypass_temperature:
-            old_temperature = self.langchain_llm.temperature # type: ignore
+            old_temperature = self.langchain_llm.temperature  # type: ignore
             self.langchain_llm.temperature = temperature  # type: ignore
 
         # handle n

--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -216,8 +216,8 @@ class LangchainLLMWrapper(BaseRagasLLM):
         if temperature is None:
             temperature = self.get_temperature(n=n)
         if hasattr(self.langchain_llm, "temperature"):
+            old_temperature = self.langchain_llm.temperature
             self.langchain_llm.temperature = temperature  # type: ignore
-            old_temperature = temperature
 
         if is_multiple_completion_supported(self.langchain_llm):
             result = self.langchain_llm.generate_prompt(
@@ -268,8 +268,8 @@ class LangchainLLMWrapper(BaseRagasLLM):
         if temperature is None:
             temperature = self.get_temperature(n=n)
         if hasattr(self.langchain_llm, "temperature") and not self.bypass_temperature:
+            old_temperature = self.langchain_llm.temperature
             self.langchain_llm.temperature = temperature  # type: ignore
-            old_temperature = temperature
 
         # handle n
         if hasattr(self.langchain_llm, "n"):

--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -259,7 +259,7 @@ class LangchainLLMWrapper(BaseRagasLLM):
         self,
         prompt: PromptValue,
         n: int = 1,
-        temperature: t.Optional[float] = None,
+        temperature: t.Optional[float] = 0.01,
         stop: t.Optional[t.List[str]] = None,
         callbacks: Callbacks = None,
     ) -> LLMResult:
@@ -400,7 +400,7 @@ class LlamaIndexLLMWrapper(BaseRagasLLM):
         self,
         prompt: PromptValue,
         n: int = 1,
-        temperature: t.Optional[float] = None,
+        temperature: t.Optional[float] = 0.01,
         stop: t.Optional[t.List[str]] = None,
         callbacks: Callbacks = None,
     ) -> LLMResult:


### PR DESCRIPTION
## Issue Link 
- Fixes #1937 and #2110 

## Changes Made
- Modified `src/ragas/llms/base.py` to properly define and use `old_temperature`  (see example below)

## Testing
N/A
 
## References
N/A

## Examples 

### Current (incorrect) behavior

```python
from langchain_openai import ChatOpenAI
from ragas.llms import LangchainLLMWrapper
from ragas import SingleTurnSample
from ragas.metrics import AspectCritic

llm=ChatOpenAI(model="gpt-4o",temperature=0.33)
evaluator_llm = LangchainLLMWrapper(llm)

print('Before call:')
print(f'llm.temperature: {llm.temperature}') # 0.33
print(f'evaluator_llm.langchain_llm.temperature: {evaluator_llm.langchain_llm.temperature}') # 0.33

test_data = {
    "user_input": "summarise given text\nThe company reported an 8% rise in Q3 2024, driven by strong performance in the Asian market. Sales in this region have significantly contributed to the overall growth. Analysts attribute this success to strategic marketing and product localization. The positive trend in the Asian market is expected to continue into the next quarter.",
    "response": "The company experienced an 8% increase in Q3 2024, largely due to effective marketing strategies and product adaptation, with expectations of continued growth in the coming quarter.",
}
metric = AspectCritic(name="summary_accuracy",llm=evaluator_llm,
                      definition="Verify if the summary is accurate.")
await metric.single_turn_ascore(SingleTurnSample(**test_data))

print('\nAfter call:')
print(f'llm.temperature: {llm.temperature}') # 0.01
print(f'evaluator_llm.langchain_llm.temperature: {evaluator_llm.langchain_llm.temperature}') # 0.01
```

```bash
Before call:
llm.temperature: 0.33
evaluator_llm.langchain_llm.temperature: 0.33

After call:
llm.temperature: 0.01
evaluator_llm.langchain_llm.temperature: 0.01
```

### With change (correct behavior):
```bash
Before call:
llm.temperature: 0.33
evaluator_llm.langchain_llm.temperature: 0.33

After call:
llm.temperature: 0.33
evaluator_llm.langchain_llm.temperature: 0.33
```
---
<!-- 
Thank you for contributing to Ragas! 
Please fill out the sections above as completely as possible.
The more information you provide, the faster your PR can be reviewed and merged.
-->
