### PR TITLE
fix ThemesPersonasInput model error when generate multi-hop query

### DIFF
--- a/src/ragas/testset/transforms/relationship_builders/traditional.py
+++ b/src/ragas/testset/transforms/relationship_builders/traditional.py
@@ -159,7 +159,7 @@ class OverlapScoreBuilder(RelationshipBuilder):
                                 verdict = similarity >= self.distance_threshold
                                 overlaps.append(verdict)
                                 if verdict:
-                                    overlapped_items.append((x, y))
+                                    overlapped_items.append(x)
 
                 similarity = self._overlap_score(overlaps)
                 if similarity >= self.threshold:


### PR DESCRIPTION
contd... https://github.com/explodinggradients/ragas/pull/2275

## Issue Link / Problem Description
**ragas version:  0.3.3**

I meet a problem when i try to generate multi-hop query based on some documents.

console log show that the ThemesPersonasInput model validation error:
pydantic_core._pydantic_core.ValidationError: 2 validation errors for ThemesPersonasInput
themes.0
Input should be a valid string [type=string_type, input_value=('车险代理', '车险'), input_type=tuple]
For further information visit https://errors.pydantic.dev/2.11/v/string_type
themes.1
Input should be a valid string [type=string_type, input_value=('交强险', '交强保险'), input_type=tuple]

I also found that has someone already report this issue: https://github.com/explodinggradients/ragas/issues/2274


## Changes Made
I found that ThemesPersonasInput model define the "themes" field as List[str], but actually themes value  is List[tuple[str, str]], so this error occurred.

**So I replace the assignment of overlapped_items in traditional.py from tuples to strings, to fix the error about ThemesPersonasInput model  "themes" field validation.**

## Testing
Manual testing steps:
  1. change code as described above
  2. try to generate multi-hop query again
  3. the result show success

<img width="2432" height="290" alt="image" src="https://github.com/user-attachments/assets/d86ea82d-98f2-4c86-a70f-cbb19654e40d" />




Test code:
```
from ragas.llms import LangchainLLMWrapper
from ragas.embeddings import LangchainEmbeddingsWrapper
from ragas.testset import TestsetGenerator
from langchain_community.document_loaders import JSONLoader
from langchain_google_genai import GoogleGenerativeAIEmbeddings, ChatGoogleGenerativeAI
from ragas.testset.synthesizers.multi_hop.specific import (
    MultiHopSpecificQuerySynthesizer,
)

import os
os.environ["GOOGLE_API_KEY"] = "xxxx-O5-xxxxx"

loader = JSONLoader(
    file_path="data/documents.json",
    jq_schema=".[].content",
)
documents = loader.load()

generator_llm = LangchainLLMWrapper(ChatGoogleGenerativeAI(model="gemini-2.5-flash"))
generator_embeddings = LangchainEmbeddingsWrapper(GoogleGenerativeAIEmbeddings(
    model="models/gemini-embedding-001",
))

distribution = [
    (MultiHopSpecificQuerySynthesizer(llm=generator_llm), 1),
]
generator = TestsetGenerator(llm=generator_llm, embedding_model=generator_embeddings)

async def generate():
    # generate testset
    testset = generator.generate_with_langchain_docs(
        documents,
        testset_size=4, 
        query_distribution=distribution,
    )

    testset.to_evaluation_dataset().to_jsonl("testset.jsonl")

import asyncio
asyncio.run(generate())
```


## References
- Related issues: https://github.com/explodinggradients/ragas/issues/2274

