### PR TITLE
fix: answer_relevancy scoring logic to prevent false zero

### DIFF
--- a/src/ragas/metrics/_answer_relevance.py
+++ b/src/ragas/metrics/_answer_relevance.py
@@ -116,7 +116,7 @@ class ResponseRelevancy(MetricWithLLM, MetricWithEmbeddings, SingleTurnMetric):
     ) -> float:
         question = row["user_input"]
         gen_questions = [answer.question for answer in answers]
-        committal = np.any([answer.noncommittal for answer in answers])
+        all_noncommittal = np.all([answer.noncommittal for answer in answers])
         if all(q == "" for q in gen_questions):
             logger.warning(
                 "Invalid JSON response. Expected dictionary with key 'question'"
@@ -124,7 +124,7 @@ class ResponseRelevancy(MetricWithLLM, MetricWithEmbeddings, SingleTurnMetric):
             score = np.nan
         else:
             cosine_sim = self.calculate_similarity(question, gen_questions)
-            score = cosine_sim.mean() * int(not committal)
+            score = cosine_sim.mean() * int(not all_noncommittal)
 
         return score
 


### PR DESCRIPTION
## Issue Link / Problem Description
<!-- Link to related issue or describe the problem this PR solves -->
- Fixes #2326 

## Changes Made
<!-- Describe what you changed and why -->
-  fixed answer_relevancy scoring logic to prevent false zero scores for valid answers