### PR TITLE
fix: adjust n if fewer results to avoid AnswerRelevancy IndexError

### DIFF
--- a/src/ragas/prompt/pydantic_prompt.py
+++ b/src/ragas/prompt/pydantic_prompt.py
@@ -236,6 +236,7 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
                 stop=stop,
                 callbacks=prompt_cb,
             )
+            n = min(n, len(resp.generations))  # adjust n if fewer results
         else:
             # This is a Ragas LLM - use generate()
             ragas_llm = t.cast(BaseRagasLLM, llm)
@@ -246,6 +247,7 @@ class PydanticPrompt(BasePrompt, t.Generic[InputModel, OutputModel]):
                 stop=stop,
                 callbacks=prompt_cb,
             )
+            n = min(n, len(resp.generations[0]))  # adjust n if fewer results
 
         output_models = []
         parser = RagasOutputParser(pydantic_object=self.output_model)


### PR DESCRIPTION
## Issue Link / Problem Description
<!-- Link to related issue or describe the problem this PR solves -->
- [Fixes #2324](https://github.com/explodinggradients/ragas/issues/2324)

## Changes Made
<!-- Describe what you changed and why -->
AnswerRelevancy tries to generate `n` questions from a generated answer. But I the answer was too short to generate `n` questions, it will fail and result `IndexError` at src/ragas/prompt/pydantic_prompt.py#255 or #258.

Code from In src/ragas/prompt/pydantic_prompt.py
```python
if is_langchain_llm(llm):
    # For LangChain LLMs, each generation is in a separate batch result
    output_string = resp.generations[i][0].text
else:
    # For Ragas LLMs, all generations are in the first batch
    output_string = resp.generations[0][i].text
```

To avoid this, I added 2 lines that adjust n if fewer results at src/ragas/prompt/pydantic_prompt.py#230 and #250.

before 
```python
       if is_langchain_llm(llm):
            # some code
            resp = await langchain_llm.agenerate_prompt(
                prompts,
                stop=stop,
                callbacks=prompt_cb,
            )
        else:
            # some code
            resp = await ragas_llm.generate(
                prompt_value,
                n=n,
                temperature=temperature,
                stop=stop,
                callbacks=prompt_cb,
            )
```

after 
```python
       if is_langchain_llm(llm):
            # some code
            resp = await langchain_llm.agenerate_prompt(
                prompts,
                stop=stop,
                callbacks=prompt_cb,
            )
            n = min(n, len(resp.generations))  # adjust n if fewer results
        else:
            # some code
            resp = await ragas_llm.generate(
                prompt_value,
                n=n,
                temperature=temperature,
                stop=stop,
                callbacks=prompt_cb,
            )
            n = min(n, len(resp.generations[0]))  # adjust n if fewer results
```

Since this is my first PR, please tell me what I can do to improve this PR.

<!-- 
Thank you for contributing to Ragas! 
Please fill out the sections above as completely as possible.
The more information you provide, the faster your PR can be reviewed and merged.
-->
