### PR TITLE
chore: remove old analtyics

### DIFF
--- a/docs/_static/js/rb2b.js
+++ b/docs/_static/js/rb2b.js
@@ -1,8 +1,0 @@
-!function(key) {
-  if (window.reb2b) return;
-  window.reb2b = {loaded: true};
-  var s = document.createElement("script");
-  s.async = true;
-  s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
-  document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
-}("0NW1GHLY45O4");

--- a/docs/_static/js/reo.js
+++ b/docs/_static/js/reo.js
@@ -1,1 +1,0 @@
-!function() { var e, t, n; e = "533ba943d66f565", t = function() { Reo.init({ clientID: "533ba943d66f565" }) }, (n = document.createElement("script")).src = "https://static.reo.dev/" + e + "/reo.js", n.defer = !0, n.onload = t, document.head.appendChild(n) }();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -284,6 +284,4 @@ extra_javascript:
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
   - _static/js/toggle.js
   - https://cdn.octolane.com/tag.js?pk=c7c9b2b863bf7eaf4e2a # octolane for analytics
-  - _static/js/reo.js # reo analytics
   - _static/js/commonroom.js # commonroom analytics
-  - _static/js/rb2b.js # rb2b analytics


### PR DESCRIPTION
  Summary

  Remove Reo and RB2B analytics tracking from documentation site.

  This PR removes third-party tracking scripts from the documentation:
  - Deleted docs/_static/js/reo.js - Reo analytics tracking script
  - Deleted docs/_static/js/rb2b.js - RB2B analytics tracking script
  - Removed references to both scripts from mkdocs.yml

  Changes

  - mkdocs.yml: Removed two entries from extra_javascript configuration
  - docs/_static/js/reo.js: Deleted file
  - docs/_static/js/rb2b.js: Deleted file

  Motivation

  Streamlining analytics vendors used in the documentation site. Octolane and CommonRoom analytics remain active.