### PR TITLE
v2 metrics refactor

### DIFF
--- a/src/ragas/metrics/v2/__init__.py
+++ b/src/ragas/metrics/v2/__init__.py
@@ -1,0 +1,35 @@
+"""
+V2 Metrics for Ragas.
+
+This module provides metrics with:
+    - Automatic validation and type safety
+    - Full serialization support
+    - Async-first design
+    - Both class-based and decorator interfaces
+
+Example:
+    >>> from ragas.metrics.v2 import AnswerRelevancy
+    >>> from ragas.llms import instructor_llm_factory
+    >>> from ragas.embeddings import embedding_factory
+    >>>
+    >>> llm = instructor_llm_factory("openai", model="gpt-4o-mini")
+    >>> embeddings = embedding_factory("openai", model="text-embedding-ada-002", interface="modern")
+    >>>
+    >>> metric = AnswerRelevancy(llm=llm, embeddings=embeddings, strictness=3)
+    >>> result = await metric.ascore(
+    ...     user_input="What is Python?",
+    ...     response="Python is a programming language"
+    ... )
+"""
+
+from ragas.metrics.v2._answer_relevancy import AnswerRelevancy
+from ragas.metrics.v2._rouge_score import RougeScore
+from ragas.metrics.v2.base import V2BaseMetric
+from ragas.metrics.v2.decorators import v2_metric
+
+__all__ = [
+    "V2BaseMetric",
+    "AnswerRelevancy",
+    "RougeScore",
+    "v2_metric",
+]

--- a/src/ragas/metrics/v2/_answer_relevancy.py
+++ b/src/ragas/metrics/v2/_answer_relevancy.py
@@ -1,0 +1,200 @@
+"""Answer Relevancy metric v2 with improved validation and bug fixes."""
+
+import typing as t
+
+import numpy as np
+from pydantic import BaseModel, Field, field_validator
+
+from ragas.metrics.result import MetricResult
+from ragas.metrics.v2.base import V2BaseMetric
+
+if t.TYPE_CHECKING:
+    from ragas.embeddings.base import BaseRagasEmbedding
+    from ragas.llms.base import InstructorBaseRagasLLM
+
+
+class AnswerRelevanceOutput(BaseModel):
+    """Structured output for answer relevance question generation."""
+
+    question: str = Field(..., description="Generated question from the answer")
+    noncommittal: int = Field(
+        ..., description="1 if answer is noncommittal, 0 if committal"
+    )
+
+
+class AnswerRelevancy(V2BaseMetric):
+    """
+    Evaluates answer relevancy by generating questions from the response.
+
+    This metric generates questions from the given answer and compares them with
+    the original question using embedding similarity.
+
+    Attributes:
+        name: The metric name
+        llm: Instructor LLM for question generation
+        embeddings: Embeddings model for similarity calculation
+        strictness: Number of questions to generate (1-10, recommended 3-5)
+        allowed_values: Score range (0.0 to 1.0)
+
+    Example:
+        >>> from ragas.metrics.v2 import AnswerRelevancy
+        >>> from ragas.llms import instructor_llm_factory
+        >>> from ragas.embeddings import embedding_factory
+        >>>
+        >>> llm = instructor_llm_factory("openai", model="gpt-4o-mini")
+        >>> embeddings = embedding_factory("openai", model="text-embedding-ada-002", interface="modern")
+        >>>
+        >>> metric = AnswerRelevancy(llm=llm, embeddings=embeddings, strictness=3)
+        >>> result = await metric.ascore(
+        ...     user_input="What is the capital of France?",
+        ...     response="Paris is the capital of France."
+        ... )
+    """
+
+    name: str = "answer_relevancy_v2"
+    llm: "InstructorBaseRagasLLM" = Field(
+        ..., description="Instructor LLM for question generation"
+    )
+    embeddings: "BaseRagasEmbedding" = Field(
+        ..., description="Embeddings model for similarity calculation"
+    )
+    strictness: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Number of questions to generate (1-10, recommended 3-5)",
+    )
+
+    @field_validator("llm")
+    @classmethod
+    def validate_llm(cls, v: t.Any) -> "InstructorBaseRagasLLM":
+        """Validate LLM compatibility."""
+        if not hasattr(v, "agenerate"):
+            raise ValueError(
+                "LLM must support structured output generation. "
+                "Use: instructor_llm_factory('openai', model='gpt-4o-mini')"
+            )
+
+        try:
+            from ragas.llms.base import InstructorBaseRagasLLM
+
+            if not isinstance(v, InstructorBaseRagasLLM):
+                raise ValueError(
+                    f"Incompatible LLM type: {type(v).__name__}. "
+                    "Use: instructor_llm_factory('openai', model='gpt-4o-mini')"
+                )
+        except ImportError:
+            pass
+
+        return v
+
+    @field_validator("embeddings")
+    @classmethod
+    def validate_embeddings(cls, v: t.Any) -> "BaseRagasEmbedding":
+        """Validate embeddings compatibility."""
+        if not hasattr(v, "embed_text") or not hasattr(v, "embed_texts"):
+            raise ValueError(
+                "Embeddings must support text embedding operations. "
+                "Use: embedding_factory('openai', model='text-embedding-ada-002', interface='modern')"
+            )
+
+        return v
+
+    async def _ascore_impl(self, user_input: str, response: str) -> MetricResult:
+        """
+        Calculate answer relevancy score asynchronously.
+
+        Args:
+            user_input: The original question
+            response: The response to evaluate
+
+        Returns:
+            MetricResult with relevancy score (0.0-1.0)
+        """
+        prompt = self._create_prompt(response)
+
+        generated_questions = []
+        noncommittal_flags = []
+
+        # Generate multiple questions for robustness
+        for _ in range(self.strictness):
+            try:
+                result = await self.llm.agenerate(prompt, AnswerRelevanceOutput)
+
+                if result and result.question:
+                    generated_questions.append(result.question)
+                    noncommittal_flags.append(result.noncommittal)
+            except Exception:
+                continue
+
+        if not generated_questions:
+            return MetricResult(
+                value=0.0, reason="Failed to generate any questions from the response"
+            )
+
+        all_noncommittal = all(noncommittal_flags)
+
+        # Compute embeddings
+        question_vec = np.asarray(self.embeddings.embed_text(user_input)).reshape(1, -1)
+        gen_question_vec = np.asarray(
+            self.embeddings.embed_texts(generated_questions)
+        ).reshape(len(generated_questions), -1)
+
+        # Calculate cosine similarity
+        norm = np.linalg.norm(gen_question_vec, axis=1) * np.linalg.norm(
+            question_vec, axis=1
+        )
+
+        epsilon = 1e-10
+        cosine_sim = np.dot(gen_question_vec, question_vec.T).reshape(
+            -1,
+        ) / (norm + epsilon)
+
+        score = float(cosine_sim.mean()) * int(not all_noncommittal)
+
+        return MetricResult(value=score)
+
+    def _create_prompt(self, response: str) -> str:
+        """
+        Generate the prompt for answer relevance evaluation.
+
+        Args:
+            response: The response text to evaluate
+
+        Returns:
+            Formatted prompt string for the LLM
+        """
+        import json
+
+        escaped_response = json.dumps(response)
+
+        return f"""Generate a question for the given answer and Identify if answer is noncommittal. Give noncommittal as 1 if the answer is noncommittal and 0 if the answer is committal. A noncommittal answer is one that is evasive, vague, or ambiguous. For example, "I don't know" or "I'm not sure" are noncommittal answers
+
+Please return the output in a JSON format that complies with the following schema as specified in JSON Schema:
+{{"properties": {{"question": {{"title": "Question", "type": "string"}}, "noncommittal": {{"title": "Noncommittal", "type": "integer"}}}}, "required": ["question", "noncommittal"], "title": "ResponseRelevanceOutput", "type": "object"}}
+
+--------EXAMPLES-----------
+Example 1
+Input: {{
+    "response": "Albert Einstein was born in Germany."
+}}
+Output: {{
+    "question": "Where was Albert Einstein born?",
+    "noncommittal": 0
+}}
+
+Example 2
+Input: {{
+    "response": "I don't know about the groundbreaking feature of the smartphone invented in 2023 as am unaware of information beyond 2022."
+}}
+Output: {{
+    "question": "What was the groundbreaking feature of the smartphone invented in 2023?",
+    "noncommittal": 1
+}}
+-----------------------------
+
+Now perform the same with the following input
+input: {{
+    "response": {escaped_response}
+}}
+Output: """

--- a/src/ragas/metrics/v2/_rouge_score.py
+++ b/src/ragas/metrics/v2/_rouge_score.py
@@ -1,0 +1,74 @@
+"""Rouge Score metric implementation."""
+
+import typing as t
+
+from pydantic import Field
+
+from ragas.metrics.result import MetricResult
+from ragas.metrics.v2.base import V2BaseMetric
+
+
+class RougeScore(V2BaseMetric):
+    """
+    Calculate ROUGE score between reference and response texts.
+
+    Attributes:
+        name: The metric name
+        rouge_type: Type of ROUGE metric ("rouge1" for unigrams, "rougeL" for LCS)
+        mode: Scoring mode ("fmeasure", "precision", or "recall")
+        allowed_values: Score range (0.0 to 1.0)
+
+    Example:
+        >>> from ragas.metrics.v2 import RougeScore
+        >>>
+        >>> metric = RougeScore(rouge_type="rougeL", mode="fmeasure")
+        >>> result = await metric.ascore(
+        ...     reference="The capital of France is Paris.",
+        ...     response="Paris is the capital of France."
+        ... )
+        >>> print(f"Score: {result.value}")
+    """
+
+    name: str = "rouge_score_v2"
+    rouge_type: t.Literal["rouge1", "rougeL"] = Field(
+        default="rougeL",
+        description="Type of ROUGE metric (rouge1 for unigrams, rougeL for LCS)",
+    )
+    mode: t.Literal["fmeasure", "precision", "recall"] = Field(
+        default="fmeasure",
+        description="Scoring mode (fmeasure, precision, or recall)",
+    )
+
+    async def _ascore_impl(
+        self,
+        reference: str,
+        response: str,
+    ) -> MetricResult:
+        """
+        Calculate ROUGE score asynchronously.
+
+        Args:
+            reference: The reference/ground truth text
+            response: The response text to evaluate
+
+        Returns:
+            MetricResult with ROUGE score (0.0-1.0)
+
+        Raises:
+            ImportError: If rouge_score package is not installed
+        """
+        # Import and check dependencies
+        try:
+            from rouge_score import rouge_scorer
+        except ImportError:
+            raise ImportError(
+                "rouge_score is required for ROUGE score calculation. "
+                "Please install it using `pip install rouge-score`"
+            )
+
+        # Calculate ROUGE score
+        scorer = rouge_scorer.RougeScorer([self.rouge_type], use_stemmer=True)
+        scores = scorer.score(reference, response)
+        score_value = getattr(scores[self.rouge_type], self.mode)
+
+        return MetricResult(value=float(score_value))

--- a/src/ragas/metrics/v2/base.py
+++ b/src/ragas/metrics/v2/base.py
@@ -1,0 +1,259 @@
+"""Base class for v2 metrics."""
+
+import asyncio
+import typing as t
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from ragas.metrics.result import MetricResult
+
+if t.TYPE_CHECKING:
+    pass
+
+
+class V2BaseMetric(BaseModel, ABC):
+    """
+    Base class for v2 metrics.
+
+    Attributes:
+        name: The metric name
+        allowed_values: Score range for numeric validation (tuple of min, max)
+
+    Example:
+        >>> class MyMetric(V2BaseMetric):
+        ...     name: str = "my_metric"
+        ...     llm: InstructorBaseRagasLLM
+        ...     threshold: float = 0.5
+        ...
+        ...     async def _ascore_impl(self, user_input: str, response: str):
+        ...         return MetricResult(value=0.95)
+        >>>
+        >>> metric = MyMetric(llm=my_llm, threshold=0.8)
+        >>> result = await metric.ascore(user_input="Q", response="A")
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        validate_assignment=True,
+        extra="forbid",
+    )
+
+    # Core fields
+    name: str = Field(..., description="The name of this metric")
+    allowed_values: t.Tuple[float, float] = Field(
+        default=(0.0, 1.0),
+        description="Valid range for metric scores as (min, max)",
+    )
+
+    @field_validator("allowed_values")
+    @classmethod
+    def validate_allowed_values(cls, v: t.Tuple[float, float]) -> t.Tuple[float, float]:
+        """Validate that allowed_values is a valid range tuple."""
+        if not isinstance(v, tuple) or len(v) != 2:
+            raise ValueError("allowed_values must be a tuple of (min, max)")
+
+        min_val, max_val = v
+        if not isinstance(min_val, (int, float)) or not isinstance(
+            max_val, (int, float)
+        ):
+            raise ValueError("allowed_values must contain numeric values")
+
+        if min_val >= max_val:
+            raise ValueError(
+                f"allowed_values min ({min_val}) must be less than max ({max_val})"
+            )
+
+        return v
+
+    async def ascore(self, **kwargs) -> MetricResult:
+        """
+        Calculate metric score asynchronously.
+
+        Args:
+            **kwargs: Metric-specific input parameters
+
+        Returns:
+            MetricResult with validated score
+        """
+        # Call the subclass implementation
+        result = await self._ascore_impl(**kwargs)
+
+        # Validate the result value
+        if result.value is not None:
+            validation_error = self._validate_result_value(result.value)
+            if validation_error:
+                return MetricResult(value=None, reason=validation_error)
+
+        return result
+
+    @abstractmethod
+    async def _ascore_impl(self, **kwargs) -> MetricResult:
+        """
+        Implement metric-specific scoring logic.
+
+        Args:
+            **kwargs: Metric-specific input parameters
+
+        Returns:
+            MetricResult with score and optional reasoning
+        """
+        ...
+
+    async def abatch_score(
+        self,
+        inputs: t.List[t.Dict[str, t.Any]],
+    ) -> t.List[MetricResult]:
+        """
+        Async batch scoring with concurrent execution.
+
+        Args:
+            inputs: List of input dictionaries for scoring
+
+        Returns:
+            List of MetricResult objects
+
+        Example:
+            >>> results = await metric.abatch_score([
+            ...     {"user_input": "Q1", "response": "A1"},
+            ...     {"user_input": "Q2", "response": "A2"},
+            ... ])
+            >>> for r in results:
+            ...     print(r.value)
+        """
+        # Create async tasks for concurrent execution
+        async_tasks = [self.ascore(**input_dict) for input_dict in inputs]
+
+        # Run all tasks concurrently
+        return await asyncio.gather(*async_tasks)
+
+    def score(self, **kwargs) -> MetricResult:
+        """
+        Synchronous scoring method.
+
+        Args:
+            **kwargs: Metric-specific input parameters
+
+        Returns:
+            MetricResult object
+
+        Raises:
+            RuntimeError: If called from within an async context
+
+        Example:
+            >>> result = metric.score(user_input="Q", response="A")
+        """
+        try:
+            # Check if we're already in an async context
+            asyncio.get_running_loop()
+            # If we get here, there's already a running loop
+            raise RuntimeError(
+                "Cannot call sync score() from an async context. "
+                "Use ascore() instead, or use ragas.async_utils.run() if needed."
+            )
+        except RuntimeError as e:
+            if "Use ascore() instead" in str(e):
+                raise  # Re-raise our custom error
+            # No running loop found, safe to use asyncio.run()
+            return asyncio.run(self.ascore(**kwargs))
+
+    def batch_score(
+        self,
+        inputs: t.List[t.Dict[str, t.Any]],
+    ) -> t.List[MetricResult]:
+        """
+        Synchronous batch scoring.
+
+        Args:
+            inputs: List of input dictionaries for scoring
+
+        Returns:
+            List of MetricResult objects
+
+        Raises:
+            RuntimeError: If called from within an async context
+        """
+        try:
+            # Check if we're already in an async context
+            asyncio.get_running_loop()
+            # If we get here, there's already a running loop
+            raise RuntimeError(
+                "Cannot call sync batch_score() from an async context. "
+                "Use abatch_score() instead, or use ragas.async_utils.run() if needed."
+            )
+        except RuntimeError as e:
+            if "Use abatch_score() instead" in str(e):
+                raise  # Re-raise our custom error
+            # No running loop found, safe to use asyncio.run()
+            return asyncio.run(self.abatch_score(inputs))
+
+    def _validate_result_value(self, result_value: t.Any) -> t.Optional[str]:
+        """
+        Validate that result value is within the numeric range.
+
+        Args:
+            result_value: The value to validate
+
+        Returns:
+            Error message if validation fails, None if valid
+        """
+        if not isinstance(result_value, (int, float)):
+            return (
+                f"Metric {self.name} returned '{result_value}' "
+                f"but expected a numeric value"
+            )
+
+        min_val, max_val = self.allowed_values
+        if not (min_val <= result_value <= max_val):
+            return (
+                f"Metric {self.name} returned {result_value} "
+                f"but expected value in range {self.allowed_values}"
+            )
+
+        return None
+
+    def save_config(self, exclude_components: bool = True) -> t.Dict[str, t.Any]:
+        """
+        Save metric configuration to a dictionary.
+
+        Args:
+            exclude_components: If True, excludes LLM/embeddings components
+
+        Returns:
+            Dictionary containing the metric configuration
+
+        Example:
+            >>> config = metric.save_config(exclude_components=True)
+            >>> new_metric = AnswerRelevancy(**config, llm=new_llm, embeddings=new_emb)
+        """
+        exclude_set = set()
+        if exclude_components:
+            for field_name in self.__class__.model_fields:
+                field_value = getattr(self, field_name, None)
+                if field_value is not None and hasattr(field_value, "agenerate"):
+                    exclude_set.add(field_name)
+                elif field_value is not None and hasattr(field_value, "embed_text"):
+                    exclude_set.add(field_name)
+
+        return self.model_dump(exclude=exclude_set)
+
+    def __repr__(self) -> str:
+        """Return a clean string representation of the metric."""
+        fields = []
+        # Use self.__class__.model_fields instead of self.model_fields
+        for field_name in self.__class__.model_fields.keys():
+            value = getattr(self, field_name, None)
+
+            # Special handling for different types
+            if field_name == "name":
+                fields.append(f"name='{value}'")
+            elif field_name == "allowed_values":
+                fields.append(f"allowed_values={value}")
+            elif hasattr(value, "__class__") and hasattr(value.__class__, "__name__"):
+                # For complex objects, just show the type
+                type_name = value.__class__.__name__
+                fields.append(f"{field_name}={type_name}(...)")
+            elif value is not None and not isinstance(value, type):
+                fields.append(f"{field_name}={value!r}")
+
+        return f"{self.__class__.__name__}({', '.join(fields)})"

--- a/src/ragas/metrics/v2/decorators.py
+++ b/src/ragas/metrics/v2/decorators.py
@@ -1,0 +1,127 @@
+"""Decorator factory for creating metrics from functions.
+
+This module provides a decorator that converts functions into metric class instances.
+"""
+
+import asyncio
+import inspect
+import typing as t
+
+from pydantic import Field, PrivateAttr
+
+from ragas.metrics.result import MetricResult
+from ragas.metrics.v2.base import V2BaseMetric
+
+
+def v2_metric(
+    *,
+    name: t.Optional[str] = None,
+    allowed_values: t.Tuple[float, float] = (float("-inf"), float("inf")),
+    **metric_params: t.Any,
+) -> t.Callable[[t.Callable], t.Any]:
+    """
+    Decorator for creating metrics from functions.
+
+    Args:
+        name: Optional name for the metric (defaults to function name)
+        allowed_values: Score range as (min, max) tuple (default: no limits)
+        **metric_params: Additional parameters to include as fields
+
+    Returns:
+        A decorator that transforms a function into a metric instance
+
+    Note:
+        Custom parameters passed via **metric_params are added dynamically at runtime.
+        Type checkers may not recognize these attributes. If needed, use type: ignore
+        or access them via getattr().
+
+    Example:
+        >>> from ragas.metrics.v2 import v2_metric
+        >>> from ragas.metrics.result import MetricResult
+        >>>
+        >>> @v2_metric(name="length_score", allowed_values=(0.0, 100.0))
+        >>> async def length_metric(response: str) -> MetricResult:
+        ...     score = len(response)
+        ...     return MetricResult(value=score, reason=f"Response length: {score}")
+        >>>
+        >>> result = await length_metric.ascore(response="Hello world")
+        >>> print(result.value)  # 11.0
+    """
+
+    def decorator(func: t.Callable) -> V2BaseMetric:
+        """Transform the function into a metric instance."""
+        metric_name = name or func.__name__
+        is_async = inspect.iscoroutinefunction(func)
+        _allowed_values = allowed_values
+
+        class DecoratorGeneratedMetric(V2BaseMetric):
+            """Metric generated from decorated function."""
+
+            name: str = Field(default=metric_name)
+            allowed_values: t.Tuple[float, float] = Field(default=_allowed_values)
+
+            _func: t.Callable = PrivateAttr()
+            _is_async: bool = PrivateAttr()
+
+            def model_post_init(self, __context):
+                """Initialize private attributes after model creation."""
+                super().model_post_init(__context)
+                self._func = func
+                self._is_async = is_async
+
+            async def _ascore_impl(self, **kwargs) -> MetricResult:
+                """Execute the wrapped function."""
+                if self._is_async:
+                    result = await self._func(**kwargs)
+                else:
+                    result = await asyncio.to_thread(self._func, **kwargs)
+
+                if not isinstance(result, MetricResult):
+                    result = MetricResult(value=result, reason=None)
+
+                return result
+
+            def __call__(self, *args, **kwargs):
+                """Make the metric callable like the original function."""
+                if self._is_async:
+                    return self.ascore(**kwargs)
+                else:
+                    return self.score(**kwargs)
+
+        # Add custom parameters as class-level defaults
+        for param_name, param_value in metric_params.items():
+            if not hasattr(DecoratorGeneratedMetric, "__annotations__"):
+                DecoratorGeneratedMetric.__annotations__ = {}
+            DecoratorGeneratedMetric.__annotations__[param_name] = t.Any
+            setattr(DecoratorGeneratedMetric, param_name, param_value)
+
+        # Recreate the model to register the new fields properly
+        DecoratorGeneratedMetric.model_rebuild()
+
+        metric_instance = DecoratorGeneratedMetric()
+        metric_instance.__doc__ = func.__doc__
+        metric_instance.__module__ = func.__module__
+
+        return metric_instance
+
+    return decorator
+
+
+create_v2_metric = v2_metric
+
+
+def v2_numeric_metric(
+    *,
+    name: t.Optional[str] = None,
+    allowed_values: t.Tuple[float, float] = (0.0, 1.0),
+    **metric_params: t.Any,
+):
+    """
+    Decorator for creating numeric metrics.
+
+    Example:
+        >>> @v2_numeric_metric(name="similarity", allowed_values=(0.0, 1.0))
+        >>> async def similarity_metric(text1: str, text2: str) -> float:
+        ...     return 0.85
+    """
+    return v2_metric(name=name, allowed_values=allowed_values, **metric_params)

--- a/tests/unit/metrics/v2/test_decorators.py
+++ b/tests/unit/metrics/v2/test_decorators.py
@@ -1,0 +1,202 @@
+"""Unit tests for v2 metric decorators."""
+
+import pytest
+
+from ragas.metrics.result import MetricResult
+from ragas.metrics.v2.base import V2BaseMetric
+from ragas.metrics.v2.decorators import v2_metric, v2_numeric_metric
+
+
+class TestV2MetricDecorator:
+    """Test suite for v2_metric decorator."""
+
+    def test_decorator_creates_class_instance(self):
+        """Test that decorator creates a V2BaseMetric instance."""
+
+        @v2_metric(name="test_metric")
+        async def my_metric(value: float) -> MetricResult:
+            return MetricResult(value=value)
+
+        # Should be an instance of V2BaseMetric
+        assert isinstance(my_metric, V2BaseMetric)
+        assert my_metric.name == "test_metric"
+
+    def test_decorator_default_name(self):
+        """Test that decorator uses function name as default."""
+
+        @v2_metric()
+        async def custom_metric_name(value: float) -> MetricResult:
+            return MetricResult(value=value)
+
+        assert custom_metric_name.name == "custom_metric_name"
+
+    def test_decorator_custom_allowed_values(self):
+        """Test decorator with custom allowed_values."""
+
+        @v2_metric(name="score", allowed_values=(0.0, 10.0))
+        async def my_metric(value: float) -> MetricResult:
+            return MetricResult(value=value)
+
+        assert my_metric.allowed_values == (0.0, 10.0)
+
+    @pytest.mark.asyncio
+    async def test_decorator_async_function(self):
+        """Test decorator with async function."""
+
+        @v2_metric(name="async_test")
+        async def async_metric(value: float) -> MetricResult:
+            return MetricResult(value=value * 2.0, reason="Doubled")
+
+        result = await async_metric.ascore(value=5.0)
+
+        assert result.value == 10.0
+        assert result.reason == "Doubled"
+
+    def test_decorator_sync_function(self):
+        """Test decorator with sync function."""
+
+        @v2_metric(name="sync_test")
+        def sync_metric(value: float) -> MetricResult:
+            return MetricResult(value=value * 3.0)
+
+        result = sync_metric.score(value=2.0)
+
+        assert result.value == 6.0
+
+    @pytest.mark.asyncio
+    async def test_decorator_auto_wraps_non_metricresult(self):
+        """Test that decorator wraps non-MetricResult returns."""
+
+        @v2_metric(name="auto_wrap")
+        async def simple_metric(value: float) -> float:
+            return value * 2.0
+
+        result = await simple_metric.ascore(value=3.0)
+
+        assert isinstance(result, MetricResult)
+        assert result.value == 6.0
+
+    @pytest.mark.asyncio
+    async def test_decorator_batch_scoring(self):
+        """Test batch scoring with decorated metric."""
+
+        @v2_metric(name="batch_test")
+        async def metric(value: float) -> float:
+            return value * 2.0
+
+        results = await metric.abatch_score(
+            [
+                {"value": 1.0},
+                {"value": 2.0},
+                {"value": 3.0},
+            ]
+        )
+
+        assert len(results) == 3
+        assert results[0].value == 2.0
+        assert results[1].value == 4.0
+        assert results[2].value == 6.0
+
+    def test_decorator_serialization(self):
+        """Test that decorated metrics can be serialized."""
+
+        @v2_metric(name="serializable", allowed_values=(0.0, 100.0))
+        async def metric(value: float) -> float:
+            return value
+
+        config = metric.save_config()
+
+        assert config["name"] == "serializable"
+        assert config["allowed_values"] == (0.0, 100.0)
+
+    def test_decorator_with_custom_parameters(self):
+        """Test decorator with custom metric parameters."""
+
+        @v2_metric(name="custom_params", threshold=5.0, description="Test metric")
+        async def metric(value: float, threshold: float = 5.0) -> float:
+            return min(value, threshold)
+
+        # Custom parameters should be accessible
+        assert hasattr(metric, "threshold")
+        assert metric.threshold == 5.0
+
+    def test_decorator_preserves_docstring(self):
+        """Test that decorator preserves function docstring."""
+
+        @v2_metric(name="documented")
+        async def metric(value: float) -> float:
+            """This is a test metric with documentation."""
+            return value
+
+        assert metric.__doc__ == "This is a test metric with documentation."
+
+    @pytest.mark.asyncio
+    async def test_decorator_validation(self):
+        """Test that decorated metrics validate results."""
+
+        @v2_metric(name="validated", allowed_values=(0.0, 1.0))
+        async def metric(value: float) -> float:
+            return value
+
+        # Valid result
+        result = await metric.ascore(value=0.5)
+        assert result.value == 0.5
+
+        # Invalid result (out of range)
+        result = await metric.ascore(value=2.0)
+        assert result.value is None
+        assert result.reason is not None
+        assert "expected value in range" in result.reason
+
+
+class TestV2NumericMetricDecorator:
+    """Test suite for v2_numeric_metric decorator."""
+
+    def test_numeric_metric_decorator(self):
+        """Test v2_numeric_metric decorator."""
+
+        @v2_numeric_metric(name="numeric", allowed_values=(0.0, 10.0))
+        async def metric(value: float) -> float:
+            return value
+
+        assert isinstance(metric, V2BaseMetric)
+        assert metric.name == "numeric"
+        assert metric.allowed_values == (0.0, 10.0)
+
+    @pytest.mark.asyncio
+    async def test_numeric_metric_scoring(self):
+        """Test numeric metric scoring."""
+
+        @v2_numeric_metric(name="score", allowed_values=(0.0, 100.0))
+        async def percentage_metric(correct: int, total: int) -> float:
+            return (correct / total) * 100 if total > 0 else 0.0
+
+        result = await percentage_metric.ascore(correct=85, total=100)
+
+        assert result.value == 85.0
+
+
+class TestDecoratorEdgeCases:
+    """Test edge cases for decorators."""
+
+    @pytest.mark.asyncio
+    async def test_decorator_with_exception(self):
+        """Test decorator when function raises exception."""
+
+        @v2_metric(name="error_metric")
+        async def failing_metric(value: float) -> float:
+            raise ValueError("Test error")
+
+        with pytest.raises(ValueError, match="Test error"):
+            await failing_metric.ascore(value=1.0)
+
+    def test_decorator_callable_backward_compat(self):
+        """Test that decorated metric can be called like a function."""
+
+        @v2_metric(name="callable_test")
+        def metric(value: float) -> float:
+            return value * 2.0
+
+        # Should be callable like the original function
+        # (This is for backward compatibility)
+        assert callable(metric)

--- a/tests/unit/metrics/v2/test_rouge_score.py
+++ b/tests/unit/metrics/v2/test_rouge_score.py
@@ -1,0 +1,175 @@
+"""Unit tests for RougeScore v2."""
+
+import pytest
+
+from ragas.metrics.v2 import RougeScore
+
+
+class TestRougeScore:
+    """Test suite for RougeScore v2 metric."""
+
+    def test_initialization_defaults(self):
+        """Test initialization with default parameters."""
+        metric = RougeScore()
+
+        assert metric.name == "rouge_score_v2"
+        assert metric.rouge_type == "rougeL"
+        assert metric.mode == "fmeasure"
+        assert metric.allowed_values == (0.0, 1.0)
+
+    def test_initialization_custom(self):
+        """Test initialization with custom parameters."""
+        metric = RougeScore(
+            rouge_type="rouge1",
+            mode="precision",
+        )
+
+        assert metric.rouge_type == "rouge1"
+        assert metric.mode == "precision"
+
+    @pytest.mark.asyncio
+    async def test_ascore_identical_texts(self):
+        """Test scoring with identical reference and response."""
+        metric = RougeScore()
+        result = await metric.ascore(
+            reference="The quick brown fox jumps over the lazy dog",
+            response="The quick brown fox jumps over the lazy dog",
+        )
+
+        # Identical texts should have perfect score
+        assert result.value == 1.0
+
+    @pytest.mark.asyncio
+    async def test_ascore_completely_different_texts(self):
+        """Test scoring with completely different texts."""
+        metric = RougeScore()
+        result = await metric.ascore(
+            reference="The quick brown fox",
+            response="Completely different words here",
+        )
+
+        # Completely different texts should have low score
+        assert result.value < 0.3
+
+    @pytest.mark.asyncio
+    async def test_ascore_partial_overlap(self):
+        """Test scoring with partial overlap."""
+        metric = RougeScore()
+        result = await metric.ascore(
+            reference="The capital of France is Paris",
+            response="Paris is the capital of France",
+        )
+
+        # Partial overlap should have medium score
+        assert 0.3 < result.value < 1.0
+
+    @pytest.mark.asyncio
+    async def test_ascore_rouge1_vs_rougeL(self):
+        """Test difference between rouge1 and rougeL."""
+        reference = "The quick brown fox"
+        response = "brown fox quick The"  # Same words, different order
+
+        rouge1_metric = RougeScore(rouge_type="rouge1")
+        rougeL_metric = RougeScore(rouge_type="rougeL")
+
+        rouge1_result = await rouge1_metric.ascore(
+            reference=reference, response=response
+        )
+        rougeL_result = await rougeL_metric.ascore(
+            reference=reference, response=response
+        )
+
+        # rouge1 should score higher (unigram match)
+        # rougeL should score lower (LCS cares about order)
+        assert rouge1_result.value == 1.0  # All unigrams match
+        assert rougeL_result.value < rouge1_result.value
+
+    @pytest.mark.asyncio
+    async def test_ascore_different_modes(self):
+        """Test different scoring modes."""
+        reference = "The quick brown fox jumps"
+        response = "The quick brown"  # Subset of reference
+
+        fmeasure_metric = RougeScore(mode="fmeasure")
+        precision_metric = RougeScore(mode="precision")
+        recall_metric = RougeScore(mode="recall")
+
+        fmeasure_result = await fmeasure_metric.ascore(
+            reference=reference, response=response
+        )
+        precision_result = await precision_metric.ascore(
+            reference=reference, response=response
+        )
+        recall_result = await recall_metric.ascore(
+            reference=reference, response=response
+        )
+
+        # Precision should be high (all response words in reference)
+        assert precision_result.value > 0.9
+
+        # Recall should be lower (not all reference words in response)
+        assert recall_result.value < precision_result.value
+
+        # F-measure should be between precision and recall
+        assert recall_result.value <= fmeasure_result.value <= precision_result.value
+
+    @pytest.mark.asyncio
+    async def test_abatch_score(self):
+        """Test batch scoring."""
+        metric = RougeScore()
+        inputs = [
+            {"reference": "Text A", "response": "Text A"},
+            {"reference": "Text B", "response": "Different"},
+            {"reference": "Text C", "response": "Text C"},
+        ]
+
+        results = await metric.abatch_score(inputs)
+
+        assert len(results) == 3
+        assert results[0].value == 1.0  # Perfect match
+        assert results[1].value < 0.5  # Low match
+        assert results[2].value == 1.0  # Perfect match
+
+    def test_score_sync(self):
+        """Test synchronous scoring."""
+        metric = RougeScore()
+        result = metric.score(
+            reference="Hello world",
+            response="Hello world",
+        )
+
+        assert result.value == 1.0
+
+    def test_serialization(self):
+        """Test Pydantic serialization."""
+        metric = RougeScore(rouge_type="rouge1", mode="precision")
+
+        # Test model_dump
+        data = metric.model_dump()
+        assert data["name"] == "rouge_score_v2"
+        assert data["rouge_type"] == "rouge1"
+        assert data["mode"] == "precision"
+
+        # Test model_dump_json
+        import json
+
+        json_str = metric.model_dump_json()
+        loaded_data = json.loads(json_str)
+        assert loaded_data["rouge_type"] == "rouge1"
+
+        # Test reconstruction
+        new_metric = RougeScore(**data)
+        assert new_metric.rouge_type == metric.rouge_type
+        assert new_metric.mode == metric.mode
+
+    def test_missing_dependency_error(self):
+        """Test error when rouge_score package is missing."""
+        import sys
+        from unittest.mock import patch
+
+        metric = RougeScore()
+
+        # Mock missing rouge_score package
+        with patch.dict(sys.modules, {"rouge_score": None}):
+            with pytest.raises(ImportError, match="rouge_score is required"):
+                metric.score(reference="test", response="test")

--- a/tests/unit/metrics/v2/test_v2_base.py
+++ b/tests/unit/metrics/v2/test_v2_base.py
@@ -1,0 +1,199 @@
+"""Unit tests for V2BaseMetric."""
+
+import pytest
+from pydantic import ValidationError
+
+from ragas.metrics.result import MetricResult
+from ragas.metrics.v2.base import V2BaseMetric
+
+
+class SimpleTestMetric(V2BaseMetric):
+    """Simple test metric for unit testing."""
+
+    name: str = "simple_test"
+    multiplier: float = 1.0
+
+    async def _ascore_impl(self, value: float) -> MetricResult:
+        """Multiply the input value."""
+        return MetricResult(value=value * self.multiplier)
+
+
+class TestV2BaseMetric:
+    """Test suite for V2BaseMetric."""
+
+    def test_initialization(self):
+        """Test basic metric initialization."""
+        metric = SimpleTestMetric()
+        assert metric.name == "simple_test"
+        assert metric.allowed_values == (0.0, 1.0)
+        assert metric.multiplier == 1.0
+
+    def test_custom_parameters(self):
+        """Test initialization with custom parameters."""
+        metric = SimpleTestMetric(multiplier=2.5, allowed_values=(0.0, 10.0))
+        assert metric.multiplier == 2.5
+        assert metric.allowed_values == (0.0, 10.0)
+
+    def test_pydantic_validation_on_init(self):
+        """Test that Pydantic validates on initialization."""
+        # Note: Pydantic coerces lists to tuples, so we test with invalid values instead
+
+        # Invalid allowed_values (min >= max)
+        with pytest.raises(ValidationError):
+            SimpleTestMetric(allowed_values=(1.0, 0.0))
+
+    def test_pydantic_extra_fields_forbidden(self):
+        """Test that extra fields are forbidden."""
+        with pytest.raises(ValidationError):
+            SimpleTestMetric(invalid_field="value")  # type: ignore
+
+    @pytest.mark.asyncio
+    async def test_ascore_basic(self):
+        """Test async scoring."""
+        metric = SimpleTestMetric(multiplier=2.0)
+        result = await metric.ascore(value=0.5)
+
+        assert result.value == 1.0
+        assert isinstance(result, MetricResult)
+
+    @pytest.mark.asyncio
+    async def test_ascore_validation(self):
+        """Test that results are validated against allowed_values."""
+        metric = SimpleTestMetric(multiplier=10.0, allowed_values=(0.0, 1.0))
+        result = await metric.ascore(value=0.5)
+
+        # Result is 5.0, which exceeds allowed_values (0.0, 1.0)
+        assert result.value is None
+        assert result.reason is not None
+        assert "expected value in range" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_abatch_score(self):
+        """Test batch scoring with concurrency."""
+        metric = SimpleTestMetric(multiplier=2.0)
+        inputs = [{"value": 0.1}, {"value": 0.2}, {"value": 0.3}]
+
+        results = await metric.abatch_score(inputs)
+
+        assert len(results) == 3
+        assert results[0].value == 0.2
+        assert results[1].value == 0.4
+        assert results[2].value == 0.6
+
+    def test_score_sync(self):
+        """Test synchronous scoring."""
+        metric = SimpleTestMetric(multiplier=3.0)
+        result = metric.score(value=0.25)
+
+        assert result.value == 0.75
+
+    def test_score_from_async_context_raises(self):
+        """Test that score() raises when called from async context."""
+        import asyncio
+
+        metric = SimpleTestMetric()
+
+        async def try_sync_in_async():
+            with pytest.raises(RuntimeError, match="Use ascore\\(\\) instead"):
+                metric.score(value=0.5)
+
+        asyncio.run(try_sync_in_async())
+
+    def test_batch_score_sync(self):
+        """Test synchronous batch scoring."""
+        metric = SimpleTestMetric(multiplier=2.0)
+        inputs = [{"value": 0.1}, {"value": 0.2}]
+
+        results = metric.batch_score(inputs)
+
+        assert len(results) == 2
+        assert results[0].value == 0.2
+        assert results[1].value == 0.4
+
+    def test_save_config(self):
+        """Test configuration serialization."""
+        metric = SimpleTestMetric(multiplier=2.5, allowed_values=(0.0, 10.0))
+        config = metric.save_config(exclude_components=False)
+
+        assert config["name"] == "simple_test"
+        assert config["multiplier"] == 2.5
+        assert config["allowed_values"] == (0.0, 10.0)
+
+    def test_model_dump(self):
+        """Test Pydantic model_dump."""
+        metric = SimpleTestMetric(multiplier=3.0)
+        data = metric.model_dump()
+
+        assert data["name"] == "simple_test"
+        assert data["multiplier"] == 3.0
+        assert data["allowed_values"] == (0.0, 1.0)
+
+    def test_repr(self):
+        """Test string representation."""
+        metric = SimpleTestMetric(multiplier=2.0)
+        repr_str = repr(metric)
+
+        assert "SimpleTestMetric" in repr_str
+        assert "name='simple_test'" in repr_str
+        # Check that multiplier is present in repr
+        assert "multiplier" in repr_str
+
+
+class TestV2BaseMetricValidation:
+    """Test validation logic."""
+
+    def test_validate_result_value_valid(self):
+        """Test validation of valid result values."""
+        metric = SimpleTestMetric()
+
+        assert metric._validate_result_value(0.0) is None
+        assert metric._validate_result_value(0.5) is None
+        assert metric._validate_result_value(1.0) is None
+
+    def test_validate_result_value_out_of_range(self):
+        """Test validation of out-of-range values."""
+        metric = SimpleTestMetric()
+
+        error = metric._validate_result_value(1.5)
+        assert error is not None
+        assert "expected value in range" in error
+
+        error = metric._validate_result_value(-0.1)
+        assert error is not None
+        assert "expected value in range" in error
+
+    def test_validate_result_value_non_numeric(self):
+        """Test validation of non-numeric values."""
+        metric = SimpleTestMetric()
+
+        error = metric._validate_result_value("invalid")
+        assert error is not None
+        assert "expected a numeric value" in error
+
+        error = metric._validate_result_value(None)
+        assert error is not None
+        assert "expected a numeric value" in error
+
+
+class TestV2BaseMetricFieldValidators:
+    """Test Pydantic field validators."""
+
+    def test_allowed_values_validator_invalid_type(self):
+        """Test allowed_values validator with invalid types."""
+        # Wrong tuple length should raise validation error
+        with pytest.raises(ValidationError):
+            SimpleTestMetric(allowed_values=(0.0,))  # type: ignore
+
+    def test_allowed_values_validator_non_numeric(self):
+        """Test allowed_values validator with non-numeric values."""
+        # Pydantic tries to coerce strings to numbers, so use truly invalid types
+        with pytest.raises(ValidationError):
+            SimpleTestMetric(allowed_values=("invalid", "values"))  # type: ignore
+
+    def test_allowed_values_validator_inverted_range(self):
+        """Test allowed_values validator with min >= max."""
+        with pytest.raises(ValidationError, match="must be less than max"):
+            SimpleTestMetric(allowed_values=(1.0, 1.0))
+
+        with pytest.raises(ValidationError, match="must be less than max"):
+            SimpleTestMetric(allowed_values=(2.0, 1.0))


### PR DESCRIPTION
V2 Metrics fixes the following, treating metrics as **configured objects** rather than stateless functions:
- **Manual validation**: Developers write repetitive validation code in `__post_init__`
- **Hard to serialize**: Saving/loading metric configs requires custom code
- **Components as kwargs**: Passing `llm=` and `embeddings=` every time is verbose
- **Type safety gaps**: Runtime errors from invalid configs that IDEs can't catch

### Current Approach
```python
from ragas.metrics import AnswerRelevancy

# Create metric (no validation)
metric = AnswerRelevancy()

# Pass LLM and embeddings every time
result = await metric.ascore(
    llm=my_llm,
    embeddings=my_embeddings,
    user_input="What is Python?",
    response="Python is a programming language."
)

# Manual serialization
config = {"name": metric.name}
```

### V2 Approach
```python
from ragas.metrics.v2 import AnswerRelevancy

# Configure once (validates automatically)
metric = AnswerRelevancy(
    llm=my_llm,
    embeddings=my_embeddings,
    strictness=3
)

# Use anywhere
result = await metric.ascore(
    user_input="What is Python?",
    response="Python is a programming language."
)

# Serialization built-in
config = metric.model_dump()
```

