### PR TITLE
feat: add bypass_n option to LangchainLLMWrapper for n-completion control

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -159,7 +159,7 @@ class LangchainLLMWrapper(BaseRagasLLM):
         self.is_finished_parser = is_finished_parser
         # Certain LLMs (e.g., OpenAI o1 series) do not support temperature
         self.bypass_temperature = bypass_temperature
-        # Certain Reason LLMs do not support n
+        # Certain reasoning LLMs (e.g., OpenAI o1 series) do not support n parameter for
         self.bypass_n = bypass_n
 
     def is_finished(self, response: LLMResult) -> bool:

--- a/tests/unit/llms/test_llm.py
+++ b/tests/unit/llms/test_llm.py
@@ -9,9 +9,6 @@ from langchain_core.prompt_values import PromptValue
 
 from ragas.llms.base import BaseRagasLLM, LangchainLLMWrapper
 
-if t.TYPE_CHECKING:
-    from langchain_core.prompt_values import PromptValue
-
 
 class FakeTestLLM(BaseRagasLLM):
     def llm(self):


### PR DESCRIPTION
When using some openai-compatible thinking models at that time, it was found that centain errors would occur.

2025-10-10 11:22:45,625 - ragas.executor - ERROR - Exception raised in Job[3]: BadRequestError(Error code: 400 - {'error': {'code': 'InvalidParameter', 'message': 'Reasoning model does not support n > 1, logit_bias, logprobs, top_logprobs Request id: xxx', 'param': '', 'type': 'BadRequest'}})

