### PR TITLE
docs: fix recall formula label in SQL metrics

### DIFF
--- a/docs/concepts/metrics/available_metrics/sql.md
+++ b/docs/concepts/metrics/available_metrics/sql.md
@@ -17,7 +17,7 @@ $$
 $$
 
 $$
-\text{Precision } = {|\text{Number of matching rows in response and reference}| \over |\text{Total number of rows in reference}|}
+\text{Recall } = {|\text{Number of matching rows in response and reference}| \over |\text{Total number of rows in reference}|}
 $$
 
 By default, the mode is set to `row`, and metric is F1 score which is the harmonic mean of precision and recall.


### PR DESCRIPTION
## Summary

Fixes #2404 

The formula for recall was incorrectly labeled as "Precision" in the SQL metrics documentation.

## Changes

- Fixed line 20 in 
- Changed label from "Precision" to "Recall" for the formula using reference rows as denominator

## Explanation

The two formulas represent different metrics:

**Precision** (line 16):
- Numerator: Number of matching rows
- **Denominator: Total rows in response**
- Measures: "Of all rows we returned, how many were correct?"

**Recall** (line 20):
- Numerator: Number of matching rows  
- **Denominator: Total rows in reference**
- Measures: "Of all correct rows, how many did we return?"

The formula on line 20 was mislabeled as Precision but is actually the Recall formula.

## Testing

- Verified formula definitions match standard precision/recall definitions
- Confirmed the fix aligns with the explanation in line 23 about F1 score being the harmonic mean of precision and recall