### PR TITLE
Fix 2440 Adjust LLM parameters in evals.py

### DIFF
--- a/examples/ragas_examples/improve_rag/evals.py
+++ b/examples/ragas_examples/improve_rag/evals.py
@@ -206,7 +206,7 @@ async def run_experiment(mode: str = "naive", model: str = "gpt-5-mini", name: O
         dataset, 
         name=name or f"{datetime.now().strftime('%Y%m%d-%H%M%S')}_{'agenticrag' if mode == 'agentic' else 'naiverag'}",
         rag=rag,
-        llm=llm_factory("gpt-5-mini", client=openai_client)
+        llm=llm_factory("gpt-5-mini", client=openai_client, temperature=1, top_p=None)
     )
     
     # Print basic results


### PR DESCRIPTION
## Issue Link / Problem Description
- Fixes #2440 

## Changes Made
Adjust llm_factory arguments as the default values do not work for GPT-5 mini
- `temperature=1`
- `top_p=None`

## Testing
### How to Test
- [ ] Automated tests added/updated
- [x] Manual testing steps:
  1. `python -m ragas_examples.improve_rag.evals` 

## References
- Documentation: https://docs.ragas.io/en/stable/howtos/applications/evaluate-and-improve-rag/#run-initial-rag-experiment

## Screenshots/Examples (if applicable)
N/A