### PR TITLE
feat: add save/load methods to BasePrompt

### DIFF
--- a/docs/howtos/customizations/metrics/_modifying-prompts-metrics.md
+++ b/docs/howtos/customizations/metrics/_modifying-prompts-metrics.md
@@ -147,6 +147,183 @@ result = await scorer.ascore(
 
 This approach ensures that the LLM has examples that better reflect your domain and evaluation criteria.
 
+### Saving and loading custom prompts (BasePrompt)
+
+Modern metrics in Ragas use `BasePrompt` instances stored as attributes on the metric. You can save and load these prompts individually for reuse across evaluation runs. This is useful when you've customized prompts for your domain or adapted them to different languages.
+
+**Why save prompts?**
+- Avoid recreating customizations every time
+- Reuse adapted prompts without re-running expensive LLM calls
+- Share optimized prompts with your team
+- Version control prompt modifications
+
+#### Example: Saving and loading individual prompts
+
+```python
+import os
+from ragas.metrics.collections import Faithfulness
+from ragas.metrics.collections.faithfulness.util import StatementGeneratorPrompt
+from openai import AsyncOpenAI
+from ragas.llms import llm_factory
+
+# Setup
+client = AsyncOpenAI()
+llm = llm_factory("gpt-4o-mini", client=client)
+
+# Create metric instance
+scorer = Faithfulness(llm=llm)
+
+# Access the prompt you want to customize
+# The metric has two prompts stored as instance attributes:
+# - scorer.statement_generator_prompt
+# - scorer.nli_statement_prompt
+
+# Customize the statement generator prompt
+custom_prompt = StatementGeneratorPrompt()
+custom_prompt.instruction = "Custom instruction for your domain"
+
+# Replace the prompt in the metric
+scorer.statement_generator_prompt = custom_prompt
+
+# Save the customized prompt to a file
+os.makedirs("custom_prompts", exist_ok=True)
+custom_prompt.save("custom_prompts/statement_generator_english.json")
+
+# Later, in a different script or session, load the saved prompt
+loaded_prompt = StatementGeneratorPrompt.load("custom_prompts/statement_generator_english.json")
+
+# Use the loaded prompt in your metric
+scorer.statement_generator_prompt = loaded_prompt
+
+# Now evaluate with your custom prompt
+result = await scorer.ascore(
+    user_input="Where was Einstein born?",
+    response="Einstein was born in Germany.",
+    retrieved_contexts=["Albert Einstein was born in Germany..."]
+)
+```
+
+**What's happening here:**
+1. We access the specific prompt attribute on the metric (`scorer.statement_generator_prompt`)
+2. We customize the prompt by modifying its properties
+3. We call `prompt.save(file_path)` to save it to a JSON file (stores instruction, examples, language)
+4. Later, we call `PromptClass.load(file_path)` to recreate the prompt from the saved file
+5. We assign the loaded prompt back to the metric's attribute
+
+#### Example: Adapting and saving prompts for different languages
+
+```python
+from ragas.metrics.collections import Faithfulness
+from ragas.metrics.collections.faithfulness.util import StatementGeneratorPrompt
+from openai import AsyncOpenAI
+from ragas.llms import llm_factory
+import os
+
+# Setup with a good LLM for translation
+client = AsyncOpenAI()
+llm = llm_factory("gpt-4o-mini", client=client)
+
+scorer = Faithfulness(llm=llm)
+
+# Adapt the prompt to Spanish (this uses the LLM to translate examples)
+adapted_prompt = await scorer.statement_generator_prompt.adapt(
+    target_language="spanish",
+    llm=llm,
+    adapt_instruction=False  # Keep instruction in English, only translate examples
+)
+
+# Save the adapted prompt for reuse
+os.makedirs("adapted_prompts", exist_ok=True)
+adapted_prompt.save("adapted_prompts/statement_generator_spanish.json")
+
+# Replace the prompt in the metric with the adapted version
+scorer.statement_generator_prompt = adapted_prompt
+
+# Later, load the Spanish prompt without re-adapting
+scorer.statement_generator_prompt = StatementGeneratorPrompt.load(
+    "adapted_prompts/statement_generator_spanish.json"
+)
+
+# Now use the metric with Spanish prompts
+result = await scorer.ascore(
+    user_input="¿Dónde nació Einstein?",
+    response="Einstein nació en Alemania.",
+    retrieved_contexts=["Albert Einstein nació en Alemania..."]
+)
+```
+
+**What's happening here:**
+1. We call `prompt.adapt()` which uses the LLM to translate few-shot examples to the target language
+2. This returns a new prompt instance with translated examples
+3. We save this adapted prompt to avoid repeating the expensive adaptation step
+4. In future runs, we load the saved Spanish prompt directly
+5. The metric now evaluates using prompts with Spanish examples
+
+#### Example: Creating custom prompt subclasses
+
+```python
+from ragas.metrics.collections import Faithfulness
+from ragas.metrics.collections.faithfulness.util import (
+    StatementGeneratorPrompt,
+    StatementGeneratorInput,
+    StatementGeneratorOutput,
+)
+from openai import AsyncOpenAI
+from ragas.llms import llm_factory
+
+# Create a custom version of the prompt for your specific domain
+class MedicalStatementPrompt(StatementGeneratorPrompt):
+    instruction = """Break down medical diagnoses into atomic, verifiable statements.
+    Ensure each statement contains only one medical fact and uses precise medical terminology."""
+
+    examples = [
+        (
+            StatementGeneratorInput(
+                question="What is the patient's diagnosis?",
+                answer="The patient has Type 2 diabetes with poor glycemic control and early signs of diabetic neuropathy.",
+            ),
+            StatementGeneratorOutput(
+                statements=[
+                    "The patient has Type 2 diabetes.",
+                    "The patient has poor glycemic control.",
+                    "The patient shows early signs of diabetic neuropathy.",
+                ]
+            ),
+        ),
+    ]
+
+# Setup
+client = AsyncOpenAI()
+llm = llm_factory("gpt-4o-mini", client=client)
+scorer = Faithfulness(llm=llm)
+
+# Use your custom prompt
+custom_prompt = MedicalStatementPrompt()
+scorer.statement_generator_prompt = custom_prompt
+
+# Save for reuse
+custom_prompt.save("domain_prompts/medical_statement_generator.json")
+
+# Later, load your custom prompt
+loaded = MedicalStatementPrompt.load("domain_prompts/medical_statement_generator.json")
+scorer.statement_generator_prompt = loaded
+```
+
+**What's happening here:**
+1. We create a subclass of the original prompt with domain-specific instruction and examples
+2. We instantiate our custom prompt and assign it to the metric
+3. We save the custom prompt with all its modifications
+4. When loading, we use our custom class (`MedicalStatementPrompt.load()`) to ensure proper type
+5. The metric now uses domain-specific prompts tailored to medical text evaluation
+
+**Key points about BasePrompt save/load:**
+- Each prompt is saved/loaded individually (not all prompts at once)
+- You have full control over where and when to save prompts
+- The saved JSON file contains: instruction, examples, language, and version info
+- Use `prompt.save(file_path)` (instance method) to save
+- Use `PromptClass.load(file_path)` (class method) to load
+- Modern metrics may have multiple prompt attributes - save each one separately
+
 ### Full prompt customization example
 
 Here's a complete example showing how to verify your customizations:

--- a/tests/unit/prompt/test_base_prompt.py
+++ b/tests/unit/prompt/test_base_prompt.py
@@ -1,0 +1,149 @@
+import json
+
+import pytest
+
+from ragas.prompt.base import BasePrompt
+
+
+class DummyPrompt(BasePrompt):
+    async def generate(self, llm, data, temperature=None, stop=None, callbacks=[]):
+        return "dummy"
+
+    def generate_multiple(
+        self, llm, data, n=1, temperature=None, stop=None, callbacks=[]
+    ):
+        return ["dummy"] * n
+
+
+class TestBasePromptSaveLoad:
+    def test_save_basic(self, tmp_path):
+        prompt = DummyPrompt(name="test_prompt", language="english")
+        file_path = tmp_path / "test_prompt.json"
+
+        prompt.save(str(file_path))
+
+        assert file_path.exists()
+        with open(file_path, "r") as f:
+            data = json.load(f)
+
+        assert "ragas_version" in data
+        assert data["language"] == "english"
+        assert data["original_hash"] is None
+
+    def test_save_with_language(self, tmp_path):
+        prompt = DummyPrompt(name="test_prompt", language="french")
+        file_path = tmp_path / "test_french.json"
+
+        prompt.save(str(file_path))
+
+        with open(file_path, "r") as f:
+            data = json.load(f)
+
+        assert data["language"] == "french"
+
+    def test_save_with_hash(self, tmp_path):
+        prompt = DummyPrompt(
+            name="test_prompt", language="english", original_hash="test_hash"
+        )
+        file_path = tmp_path / "test_hash.json"
+
+        prompt.save(str(file_path))
+
+        with open(file_path, "r") as f:
+            data = json.load(f)
+
+        assert data["original_hash"] == "test_hash"
+
+    def test_save_file_already_exists(self, tmp_path):
+        prompt = DummyPrompt(name="test_prompt")
+        file_path = tmp_path / "existing.json"
+
+        file_path.write_text("{}")
+
+        with pytest.raises(FileExistsError, match="already exists"):
+            prompt.save(str(file_path))
+
+    def test_load_basic(self, tmp_path):
+        original = DummyPrompt(name="test_prompt", language="spanish")
+        file_path = tmp_path / "test_load.json"
+
+        original.save(str(file_path))
+        loaded = DummyPrompt.load(str(file_path))
+
+        assert loaded.language == "spanish"
+        assert loaded.original_hash is None
+
+    def test_load_with_hash(self, tmp_path):
+        original = DummyPrompt(
+            name="test_prompt", language="german", original_hash="hash123"
+        )
+        file_path = tmp_path / "test_hash_load.json"
+
+        original.save(str(file_path))
+        loaded = DummyPrompt.load(str(file_path))
+
+        assert loaded.language == "german"
+        assert loaded.original_hash == "hash123"
+
+    def test_load_nonexistent_file(self, tmp_path):
+        file_path = tmp_path / "nonexistent.json"
+
+        with pytest.raises(FileNotFoundError):
+            DummyPrompt.load(str(file_path))
+
+    def test_round_trip(self, tmp_path):
+        original = DummyPrompt(
+            name="test_prompt", language="japanese", original_hash="original_hash"
+        )
+        file_path = tmp_path / "round_trip.json"
+
+        original.save(str(file_path))
+        loaded = DummyPrompt.load(str(file_path))
+
+        assert loaded.language == original.language
+        assert loaded.original_hash == original.original_hash
+
+    def test_load_version_mismatch_warning(self, tmp_path, caplog):
+        file_path = tmp_path / "version_test.json"
+
+        data = {
+            "ragas_version": "0.0.1",
+            "language": "english",
+            "original_hash": None,
+        }
+
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        DummyPrompt.load(str(file_path))
+
+        assert any("incompatibilities" in record.message for record in caplog.records)
+
+    def test_save_unicode_language(self, tmp_path):
+        prompt = DummyPrompt(name="test_prompt", language="日本語")
+        file_path = tmp_path / "unicode.json"
+
+        prompt.save(str(file_path))
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        assert data["language"] == "日本語"
+
+        loaded = DummyPrompt.load(str(file_path))
+        assert loaded.language == "日本語"
+
+    def test_load_missing_fields(self, tmp_path):
+        file_path = tmp_path / "minimal.json"
+
+        data = {
+            "ragas_version": "0.3.0",
+        }
+
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        loaded = DummyPrompt.load(str(file_path))
+
+        assert loaded.language == "english"
+        assert loaded.original_hash is None


### PR DESCRIPTION
```python
# Adapt prompt to Spanish
adapted = await scorer.statement_generator_prompt.adapt("spanish", llm)

# Save it
adapted.save("prompts/spanish/statement_gen_spanish.json")

# Later, load without re-adapting
scorer.statement_generator_prompt = StatementGeneratorPrompt.load(
    "prompts/spanish/statement_gen_spanish.json"
)
```