### PR TITLE
Fix: apply_transforms(kg, transforms, run_config=run_config or RunCon…

### DIFF
--- a/src/ragas/testset/synthesizers/generate.py
+++ b/src/ragas/testset/synthesizers/generate.py
@@ -192,7 +192,7 @@ class TestsetGenerator:
         kg = KnowledgeGraph(nodes=nodes)
 
         # apply transforms and update the knowledge graph
-        apply_transforms(kg, transforms)
+        apply_transforms(kg, transforms, run_config=run_config or RunConfig())
         self.knowledge_graph = kg
 
         return self.generate(


### PR DESCRIPTION
…fig())

## Issue Link / Problem Description
<!-- Link to related issue or describe the problem this PR solves -->
- Fixes #[1]

## Changes Made
<!-- Describe what you changed and why -->
- in the [src/ragas/testset/synthesizers/generate.py
for generate_with_langchain_docs, 
added run_config=run_config or RunConfig() as an input parameter to the apply_transforms
so it mimics the apply_transforms for the generate_with_llamaindex_docs

## Testing
<!-- Describe how this should be tested -->
### How to Test
- [ ] Automated tests added/updated
- [ ] Manual testing steps:
  

## References
<!-- Link to related issues, discussions, forums, or external resources -->
- Related issues: 
- Documentation: 
- External references: 

## Screenshots/Examples (if applicable)
<!-- Add screenshots or code examples showing the change -->

---
<!-- 
Thank you for contributing to Ragas! 
Please fill out the sections above as completely as possible.
The more information you provide, the faster your PR can be reviewed and merged.
-->
