### PR TITLE
docs: remove broken reference to train_your_own_metric.md

### DIFF
--- a/docs/howtos/customizations/index.md
+++ b/docs/howtos/customizations/index.md
@@ -13,7 +13,6 @@ How to customize various aspects of Ragas to suit your needs.
 - [Write your own metrics](./metrics/_write_your_own_metric.md)
 - [Adapt metrics to target language](./metrics/_metrics_language_adaptation.md)
 - [Trace evaluations with Observability tools](metrics/tracing.md)
-- [Train and align metric](./metrics/train_your_own_metric.md)
 
 
 ## Testset Generation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,7 +98,6 @@ nav:
               - Adapt Metrics to Languages: howtos/customizations/metrics/_metrics_language_adaptation.md
               - Write your own Metrics: howtos/customizations/metrics/_write_your_own_metric.md
               - Write your own Metrics - (advanced): howtos/customizations/metrics/_write_your_own_metric_advanced.md
-              - Train and Align Metrics: howtos/customizations/metrics/train_your_own_metric.md
           - Testset Generation:
               - Non-English Testset Generation: howtos/customizations/testgenerator/_language_adaptation.md
               - Persona Generation: howtos/customizations/testgenerator/_persona_generator.md


### PR DESCRIPTION
## Issue Link / Problem Description

Fixes broken link in documentation navigation. The file `howtos/customizations/metrics/train_your_own_metric.md` was referenced in `mkdocs.yml` and the customizations index but never existed.

## Changes Made

- Removed broken reference from `mkdocs.yml` line 101
- Removed broken reference from `docs/howtos/customizations/index.md` line 16

## Notes

The topic (aligning LLM metrics with human judgment) is already covered by the existing guide `howtos/applications/align-llm-as-judge.md` which uses the modern `experiment()` and `llm_factory` patterns.

The legacy `metric.train()` / `GeneticOptimizer` approach is also documented in `howtos/applications/vertexai_alignment.md` for VertexAI users.

## Testing

- [ ] Manual testing: Verified documentation builds without broken link warnings