### PR TITLE
aembed_text() replace embed_text() in AnswerRelevancy

### DIFF
--- a/src/ragas/metrics/collections/answer_relevancy/metric.py
+++ b/src/ragas/metrics/collections/answer_relevancy/metric.py
@@ -130,11 +130,13 @@ class AnswerRelevancy(BaseMetric):
         all_noncommittal = np.all(noncommittal_flags)
 
         # Embed the original question
-        question_vec = np.asarray(self.embeddings.embed_text(user_input)).reshape(1, -1)
+        question_vec = np.asarray(
+            await self.embeddings.aembed_text(user_input)
+        ).reshape(1, -1)
 
         # Embed the generated questions
         gen_question_vec = np.asarray(
-            self.embeddings.embed_texts(generated_questions)
+            await self.embeddings.aembed_texts(generated_questions)
         ).reshape(len(generated_questions), -1)
 
         # Calculate cosine similarity


### PR DESCRIPTION
## Issue Link / Problem Description
In the AnswerRelevancy.astore() method within src.ragas.metrics.collections.answer_relevancy, when embedding text, it currently calls the non-asynchronous embed_text() (although the underlying implementation might use run_event_loop). Therefore, it is recommended to call the asynchronous aembed_text() method instead.

## Changes Made
- invoke aembed_text() instead of embed_text()


