### PR TITLE
fix: allow unannotated parameters to accept any type

### DIFF
--- a/src/ragas/metrics/decorator.py
+++ b/src/ragas/metrics/decorator.py
@@ -164,13 +164,13 @@ def create_metric_decorator():
                     field_definitions = {}
 
                     for name, param in sig.parameters.items():
-                        # Get type hint, default to str if no hint available
+                        # Get type hint, default to Any if no hint available
                         type_hint = type_hints.get(name, param.annotation)
                         if type_hint == inspect.Parameter.empty:
                             if param.default != inspect.Parameter.empty:
                                 type_hint = type(param.default)
                             else:
-                                type_hint = str
+                                type_hint = t.Any
 
                         # Get default value
                         if param.default != inspect.Parameter.empty:


### PR DESCRIPTION
## Issue Link / Problem Description
- Fixes #2512 

## Changes Made

- Changed default type hint from `str` to `t.Any` for unannotated parameters in `_create_pydantic_model()` method (`src/ragas/metrics/decorator.py` line 173)

- Updated comment to reflect that unannotated parameters default to `Any` instead of `str` (line 167)

- This allows unannotated parameters to accept any type (DataFrames, dicts, lists, None, strings, etc.) without validation errors, which is appropriate since the Pydantic model already has `arbitrary_types_allowed=True` configured

## Testing
The changes are too simple for testing , although I have reproduced and tested this locally.

## Steps to Reproduce

1. Create a metric function with an unannotated parameter (no type annotation)

2. Decorate it with `@discrete_metric` decorator

3. Call the metric's `score()` method with a non-string value (e.g., pandas DataFrame) for the unannotated parameter

4. Observe the validation error indicating the parameter should be a string

