### PR TITLE
docs: change query execution to use asyncio.run

### DIFF
--- a/docs/howtos/applications/evaluate-and-improve-rag.md
+++ b/docs/howtos/applications/evaluate-and-improve-rag.md
@@ -46,7 +46,7 @@ rag = RAG(openai_client, retriever)
 
 # Query the system
 question = "What architecture is the `tokenizers-linux-x64-musl` binary designed for?"
-result = await rag.query(question)
+result = asyncio.run(rag.query(question))
 print(f"Answer: {result['answer']}")
 ```
 ??? note "Output"


### PR DESCRIPTION
Updated the query execution to run asynchronously using asyncio.

## Issue Link / Problem Description
<!-- Link to related issue or describe the problem this PR solves -->
The issue on line 49 of the file `docs/howtos/applications/evaluate-and-improve-rag.md` is that it uses the `await` keyword at the top level of the script.

### Description of the Issue:
In Python, the `await` keyword is only allowed within an asynchronous function (defined with `async def`). When the code snippet provided in the documentation is run as a standard Python script (e.g., `python script.py`), it will fail with the following error:
`SyntaxError: 'await' outside function`

### Context (Lines 33–51):
The code block imports `asyncio` (line 35) but fails to use it to execute the asynchronous `rag.query()` method.

## Changes Made
<!-- Describe what you changed and why -->
To make the script runnable, the asynchronous logic should be executed using asyncio.run():
```python
# Query the system
question = "What architecture is the `tokenizers-linux-x64-musl` binary designed for?"
result = asyncio.run(rag.query(question))
print(f"Answer: {result['answer']}")
```

## Testing
<!-- Describe how this should be tested -->
### How to Test
- [x] Manual testing


## References
<!-- Link to related issues, discussions, forums, or external resources -->
- Related issues: 
- Documentation: 
- External references: 

## Screenshots/Examples (if applicable)
<!-- Add screenshots or code examples showing the change -->

---
<!-- 
Thank you for contributing to Ragas! 
Please fill out the sections above as completely as possible.
The more information you provide, the faster your PR can be reviewed and merged.
-->
