### PR TITLE
feat(docs): add llms.txt generation for LLM-friendly documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -263,9 +263,41 @@ extra:
     provider: google
     property: !ENV GOOGLE_ANALYTICS_KEY
 plugins:
+  - search
   - social:
       enabled: !ENV [MKDOCS_CI, true]
-  - search
+  - llmstxt:
+      markdown_description: |
+        Ragas is an open-source evaluation framework for LLM applications including RAG pipelines,
+        AI agents, and workflows. It provides objective metrics for evaluation, test data generation
+        capabilities, and integrations with popular LLM frameworks like LangChain and LlamaIndex.
+      full_output: llms-full.txt
+      sections:
+        Getting Started:
+          - getstarted/*.md
+        Tutorials:
+          - tutorials/*.md
+        Core Concepts:
+          - concepts/*.md
+          - concepts/components/*.md
+        Metrics:
+          - concepts/metrics/overview/*.md
+          - concepts/metrics/available_metrics/*.md
+        Test Data Generation:
+          - concepts/test_data_generation/*.md
+        Customization Guides:
+          - howtos/customizations/*.md
+          - howtos/customizations/metrics/*.md
+          - howtos/customizations/testgenerator/*.md
+          - howtos/customizations/optimizers/*.md
+        Application Guides:
+          - howtos/applications/*.md
+        CLI:
+          - howtos/cli/*.md
+        Integrations:
+          - howtos/integrations/*.md
+        API Reference:
+          - references/*.md
   - git-revision-date-localized:
       enabled: !ENV [MKDOCS_CI, false]
       enable_creation_date: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ docs = [
     "mkdocs-section-index",
     "mkdocs-git-committers-plugin-2",
     "mkdocs-git-revision-date-localized-plugin",
+    "mkdocs-llmstxt",  # Requires Python 3.10+, only used in docs CI
 ]
 
 docs-pdf = [


### PR DESCRIPTION
## Issue Link / Problem Description
- Adds support for the [llms.txt specification](https://llmstxt.org/) proposed by Jeremy Howard
- This enables LLMs to efficiently access and understand Ragas documentation during inference

## Changes Made
- Added `mkdocs-llmstxt` plugin to docs dependencies in `pyproject.toml`
- Configured the plugin in `mkdocs.yml` with comprehensive section coverage:
  - Getting Started, Tutorials, Core Concepts
  - All metrics (RAG, Comparison, Agent)
  - Test Data Generation
  - Customization & Application Guides
  - Integrations, CLI, API Reference
- Plugin generates:
  - `/llms.txt` - Index with links to markdown versions of all docs
  - `/llms-full.txt` - Full content of all pages concatenated
  - Individual `.md` files converted from HTML for each page

## Testing
### How to Test
- [ ] Manual testing steps:
  1. `uv pip install mkdocs-llmstxt`
  2. `uv run mkdocs build`
  3. Verify `site/llms.txt` and `site/llms-full.txt` exist
  4. Check `site/getstarted/quickstart/index.md` contains clean Markdown

## References
- llms.txt specification: https://llmstxt.org/
- mkdocs-llmstxt plugin: https://github.com/pawamoy/mkdocs-llmstxt