### PR TITLE
feat: dspy caching

### DIFF
--- a/tests/unit/test_dspy_optimizer.py
+++ b/tests/unit/test_dspy_optimizer.py
@@ -53,6 +53,112 @@ class TestDSPyOptimizer:
         assert optimizer.init_temperature == 0.5
 
     @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
+    def test_initialization_with_all_params(self):
+        """Test DSPyOptimizer initialization with all parameters."""
+        from ragas.optimizers.dspy_optimizer import DSPyOptimizer
+
+        optimizer = DSPyOptimizer(
+            num_candidates=15,
+            max_bootstrapped_demos=7,
+            max_labeled_demos=6,
+            init_temperature=0.8,
+            auto="heavy",
+            num_threads=4,
+            max_errors=5,
+            seed=42,
+            verbose=True,
+            track_stats=False,
+            log_dir="/tmp/dspy_logs",
+            metric_threshold=0.9,
+        )
+
+        assert optimizer.num_candidates == 15
+        assert optimizer.max_bootstrapped_demos == 7
+        assert optimizer.max_labeled_demos == 6
+        assert optimizer.init_temperature == 0.8
+        assert optimizer.auto == "heavy"
+        assert optimizer.num_threads == 4
+        assert optimizer.max_errors == 5
+        assert optimizer.seed == 42
+        assert optimizer.verbose is True
+        assert optimizer.track_stats is False
+        assert optimizer.log_dir == "/tmp/dspy_logs"
+        assert optimizer.metric_threshold == 0.9
+
+    @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
+    def test_validation_negative_num_candidates(self):
+        """Test validation for negative num_candidates."""
+        from ragas.optimizers.dspy_optimizer import DSPyOptimizer
+
+        with pytest.raises(ValueError, match="num_candidates must be positive"):
+            DSPyOptimizer(num_candidates=-1)
+
+    @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
+    def test_validation_negative_max_bootstrapped_demos(self):
+        """Test validation for negative max_bootstrapped_demos."""
+        from ragas.optimizers.dspy_optimizer import DSPyOptimizer
+
+        with pytest.raises(
+            ValueError, match="max_bootstrapped_demos must be non-negative"
+        ):
+            DSPyOptimizer(max_bootstrapped_demos=-1)
+
+    @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
+    def test_validation_negative_max_labeled_demos(self):
+        """Test validation for negative max_labeled_demos."""
+        from ragas.optimizers.dspy_optimizer import DSPyOptimizer
+
+        with pytest.raises(ValueError, match="max_labeled_demos must be non-negative"):
+            DSPyOptimizer(max_labeled_demos=-1)
+
+    @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
+    def test_validation_zero_init_temperature(self):
+        """Test validation for zero init_temperature."""
+        from ragas.optimizers.dspy_optimizer import DSPyOptimizer
+
+        with pytest.raises(ValueError, match="init_temperature must be positive"):
+            DSPyOptimizer(init_temperature=0)
+
+    @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
+    def test_validation_invalid_auto(self):
+        """Test validation for invalid auto parameter."""
+        from ragas.optimizers.dspy_optimizer import DSPyOptimizer
+
+        with pytest.raises(ValueError, match="auto must be"):
+            DSPyOptimizer(auto="invalid")
+
+    @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
+    def test_validation_negative_num_threads(self):
+        """Test validation for negative num_threads."""
+        from ragas.optimizers.dspy_optimizer import DSPyOptimizer
+
+        with pytest.raises(ValueError, match="num_threads must be positive"):
+            DSPyOptimizer(num_threads=-1)
+
+    @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
+    def test_validation_negative_max_errors(self):
+        """Test validation for negative max_errors."""
+        from ragas.optimizers.dspy_optimizer import DSPyOptimizer
+
+        with pytest.raises(ValueError, match="max_errors must be non-negative"):
+            DSPyOptimizer(max_errors=-1)
+
+    @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
+    def test_validation_invalid_metric_threshold(self):
+        """Test validation for metric_threshold out of range."""
+        from ragas.optimizers.dspy_optimizer import DSPyOptimizer
+
+        with pytest.raises(
+            ValueError, match="metric_threshold must be between 0 and 1"
+        ):
+            DSPyOptimizer(metric_threshold=1.5)
+
+        with pytest.raises(
+            ValueError, match="metric_threshold must be between 0 and 1"
+        ):
+            DSPyOptimizer(metric_threshold=-0.1)
+
+    @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
     def test_optimize_without_metric(self, fake_llm):
         """Test that optimize raises ValueError when no metric is set."""
         from ragas.optimizers.dspy_optimizer import DSPyOptimizer
@@ -148,12 +254,103 @@ class TestDSPyOptimizer:
             max_bootstrapped_demos=5,
             max_labeled_demos=5,
             init_temperature=1.0,
+            auto="light",
+            num_threads=None,
+            max_errors=None,
+            seed=9,
+            verbose=False,
+            track_stats=True,
+            log_dir=None,
+            metric_threshold=None,
         )
 
         mock_teleprompter.compile.assert_called_once_with(
             mock_module,
             trainset=mock_examples,
             metric=mock_metric_fn,
+        )
+
+    @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")
+    @patch("ragas.optimizers.dspy_adapter.setup_dspy_llm")
+    @patch("ragas.optimizers.dspy_adapter.pydantic_prompt_to_dspy_signature")
+    @patch("ragas.optimizers.dspy_adapter.ragas_dataset_to_dspy_examples")
+    @patch("ragas.optimizers.dspy_adapter.create_dspy_metric")
+    def test_optimize_with_custom_params(
+        self,
+        mock_create_metric,
+        mock_to_examples,
+        mock_to_signature,
+        mock_setup_llm,
+        fake_llm,
+    ):
+        """Test that custom parameters are passed to MIPROv2."""
+        from ragas.optimizers.dspy_optimizer import DSPyOptimizer
+
+        optimizer = DSPyOptimizer(
+            num_candidates=15,
+            max_bootstrapped_demos=7,
+            max_labeled_demos=6,
+            init_temperature=0.8,
+            auto="heavy",
+            num_threads=4,
+            max_errors=5,
+            seed=42,
+            verbose=True,
+            track_stats=False,
+            log_dir="/tmp/dspy",
+            metric_threshold=0.85,
+        )
+
+        mock_metric = Mock()
+        mock_metric.name = "test_metric"
+        mock_metric.get_prompts.return_value = {
+            "test_prompt": Mock(instruction="Test instruction")
+        }
+        optimizer.metric = mock_metric
+        optimizer.llm = fake_llm
+
+        mock_dspy = MagicMock()
+        mock_signature = Mock()
+        mock_to_signature.return_value = mock_signature
+
+        mock_module = Mock()
+        mock_dspy.Predict.return_value = mock_module
+
+        mock_examples = [Mock()]
+        mock_to_examples.return_value = mock_examples
+
+        mock_metric_fn = Mock()
+        mock_create_metric.return_value = mock_metric_fn
+
+        mock_teleprompter = Mock()
+        mock_optimized = Mock()
+        mock_optimized.signature.instructions = "Optimized instruction"
+        mock_teleprompter.compile.return_value = mock_optimized
+        mock_dspy.MIPROv2.return_value = mock_teleprompter
+
+        optimizer._dspy = mock_dspy
+
+        dataset = Mock(spec=SingleMetricAnnotation)
+        dataset.name = "test_metric"
+        loss = MSELoss()
+
+        result = optimizer.optimize(dataset, loss, {})
+
+        assert "test_prompt" in result
+
+        mock_dspy.MIPROv2.assert_called_once_with(
+            num_candidates=15,
+            max_bootstrapped_demos=7,
+            max_labeled_demos=6,
+            init_temperature=0.8,
+            auto="heavy",
+            num_threads=4,
+            max_errors=5,
+            seed=42,
+            verbose=True,
+            track_stats=False,
+            log_dir="/tmp/dspy",
+            metric_threshold=0.85,
         )
 
     @pytest.mark.skipif(not DSPY_AVAILABLE, reason="dspy-ai not installed")


### PR DESCRIPTION
Uses same `DiskCacheBackend()`

The DSPy optimizer uses manual cache checking instead of the decorator because:

- It needs custom cache key generation (based on dataset hash, loss, config, optimizer params)
- Caching entire optimization results is more valuable than caching individual LLM calls within DSPy
- DSPy's MIPROv2 makes many exploratory LLM calls - caching the final result is more efficient

Usage:

```py
from ragas.cache import DiskCacheBackend

# Single cache instance for everything
cache = DiskCacheBackend()

# LLM caching
llm = llm_factory("gpt-4o-mini", client=client, cache=cache)

# Embeddings caching
embeddings = embedding_factory("openai", client=client, cache=cache)

# DSPy optimizer caching
optimizer = DSPyOptimizer(cache=cache, llm=llm)
  ```