### PR TITLE
fix: lazy init DEFAULT_TOKENIZER to avoid network calls at import time.

### DIFF
--- a/tests/unit/test_tokenizers.py
+++ b/tests/unit/test_tokenizers.py
@@ -1,0 +1,53 @@
+"""Tests for ragas.tokenizers module."""
+
+from __future__ import annotations
+
+import socket
+
+
+def test_tokenizer_import_without_network(monkeypatch):
+    """Import should work without network (for offline environments)."""
+
+    def block_network(*args, **kwargs):
+        raise OSError("Network blocked for testing")
+
+    monkeypatch.setattr(socket, "getaddrinfo", block_network)
+
+    from ragas.tokenizers import DEFAULT_TOKENIZER, get_default_tokenizer
+
+    assert DEFAULT_TOKENIZER is not None
+    assert get_default_tokenizer is not None
+
+
+def test_default_tokenizer_encode_decode():
+    from ragas.tokenizers import DEFAULT_TOKENIZER
+
+    text = "Hello world"
+    tokens = DEFAULT_TOKENIZER.encode(text)
+    decoded = DEFAULT_TOKENIZER.decode(tokens)
+
+    assert len(tokens) > 0
+    assert decoded == text
+
+
+def test_get_default_tokenizer_singleton():
+    from ragas.tokenizers import get_default_tokenizer
+
+    t1 = get_default_tokenizer()
+    t2 = get_default_tokenizer()
+
+    assert t1 is t2
+
+
+def test_default_tokenizer_with_dataclass():
+    """Ensure backwards compat with existing default_factory usage."""
+    from dataclasses import dataclass, field
+
+    from ragas.tokenizers import DEFAULT_TOKENIZER, BaseTokenizer
+
+    @dataclass
+    class TestClass:
+        tokenizer: BaseTokenizer = field(default_factory=lambda: DEFAULT_TOKENIZER)
+
+    obj = TestClass()
+    assert len(obj.tokenizer.encode("test")) > 0


### PR DESCRIPTION
## Issue Link / Problem Description
- Fixes #2538 


## Changes Made
<!-- Describe what you changed and why -->
- Replace eager ```DEFAULT_TOKENIZER``` with  ``` _LazyTokenizer```  that defers creation.
- Add ```get_default_tokenizer()```  that lazily constructs a singleton ```TiktokenWrapper```.
- ```DEFAULT_TOKENIZER``` remains available (```BaseTokenizer```) for backward compatibility.
- Add tests: ```test_tokenizers.py``` to cover offline import, encode/decode, singleton, and dataclass default usage.

## Testing
### How to Test
- [x] Automated tests added/updated
- [x] Manual testing steps:
  1.  Verify importing ragas.tokenizers works when network/DNS is blocked (the test monkeypatches socket.getaddrinfo).
  2. Confirm DEFAULT_TOKENIZER.encode/decode and get_default_tokenizer() singleton behavior.


