### PR TITLE
feat: Add GroqLLMWrapper with rate-limiting and JSON sanitization (#2580)

### DIFF
--- a/src/ragas/llms/__init__.py
+++ b/src/ragas/llms/__init__.py
@@ -7,10 +7,21 @@ from ragas.llms.base import (
     LlamaIndexLLMWrapper as _LlamaIndexLLMWrapper,
     llm_factory,
 )
+from ragas.llms.groq_wrapper import GroqLLMWrapper
 from ragas.llms.haystack_wrapper import HaystackLLMWrapper
 from ragas.llms.litellm_llm import LiteLLMStructuredLLM
 from ragas.llms.oci_genai_wrapper import OCIGenAIWrapper, oci_genai_factory
 from ragas.utils import DeprecationHelper
+
+# Groq Integration Notes:
+# - llm_factory() with provider="groq" → Uses instructor adapter for structured outputs
+#   Example: llm = llm_factory("llama3-70b-8192", provider="groq", client=groq_client)
+#
+# - GroqLLMWrapper() → Direct wrapper for text generation (BaseRagasLLM interface)
+#   Example: llm = GroqLLMWrapper(groq_client, model="llama3-70b-8192")
+#
+# Both approaches are valid. Use llm_factory for structured outputs (Pydantic models),
+# use GroqLLMWrapper for direct text generation with custom rate limiting.
 
 # Create deprecation wrappers for legacy classes
 LangchainLLMWrapper = DeprecationHelper(
@@ -33,6 +44,7 @@ LlamaIndexLLMWrapper = DeprecationHelper(
 
 __all__ = [
     "BaseRagasLLM",
+    "GroqLLMWrapper",
     "HaystackLLMWrapper",
     "InstructorBaseRagasLLM",
     "InstructorLLM",

--- a/src/ragas/llms/groq_wrapper.py
+++ b/src/ragas/llms/groq_wrapper.py
@@ -1,0 +1,343 @@
+"""Groq LLM wrapper implementation for Ragas."""
+
+import asyncio
+import logging
+import re
+import threading
+import typing as t
+
+from langchain_core.callbacks import Callbacks
+from langchain_core.outputs import Generation, LLMResult
+from langchain_core.prompt_values import PromptValue
+
+from ragas._analytics import LLMUsageEvent, track
+from ragas.cache import CacheInterface
+from ragas.llms.base import BaseRagasLLM
+from ragas.run_config import RunConfig
+
+logger = logging.getLogger(__name__)
+
+
+class GroqLLMWrapper(BaseRagasLLM):
+    """
+    Groq LLM wrapper for Ragas.
+
+    This wrapper provides direct integration with Groq's API for fast inference
+    using their optimized language models.
+    """
+
+    def __init__(
+        self,
+        groq_client: t.Any,
+        model: str = "llama3-70b-8192",
+        rpm_limit: int = 30,
+        run_config: t.Optional[RunConfig] = None,
+        cache: t.Optional[CacheInterface] = None,
+    ) -> None:
+        """
+        Initialize Groq LLM wrapper.
+
+        Args:
+            groq_client: The Groq client instance for API calls
+            model: The Groq model to use (default: "llama3-70b-8192")
+            rpm_limit: Requests per minute limit for rate limiting (default: 30)
+            run_config: Ragas run configuration
+            cache: Optional cache backend for caching responses
+        """
+        # Initialize parent class first
+        super().__init__(cache=cache)
+
+        # Store parameters
+        self.groq_client = groq_client
+        self.model = model
+        self.rpm_limit = rpm_limit
+
+        # Initialize the semaphore for rate limiting
+        self._semaphore = asyncio.Semaphore(rpm_limit)
+
+        # Set run config
+        if run_config is None:
+            run_config = RunConfig()
+        self.set_run_config(run_config)
+
+        # Track initialization
+        track(
+            LLMUsageEvent(
+                provider="groq",
+                model=model,
+                llm_type="groq_wrapper",
+                num_requests=1,
+                is_async=False,
+            )
+        )
+
+    def _extract_json(self, raw: str) -> str:
+        """
+        Extract JSON from a raw response string.
+
+        Handles both fenced JSON blocks (```json ... ```) and naked JSON objects/arrays.
+        If no JSON is found, returns the original string.
+
+        Args:
+            raw: The raw response string from the LLM
+
+        Returns:
+            Extracted JSON string or the original string if no JSON pattern matches
+        """
+        # Strip leading/trailing whitespace
+        raw = raw.strip()
+
+        # Try to extract from ```json ... ``` fenced block
+        json_fence_pattern = r"```json\s*(.*?)\s*```"
+        fence_match = re.search(json_fence_pattern, raw, re.DOTALL)
+        if fence_match:
+            return fence_match.group(1).strip()
+
+        # Try to find JSON array [...] or object {...}
+        # Check for arrays first, then objects, to handle arrays of objects correctly
+        json_arr_pattern = r"(\[[^\[\]]*(?:\{[^{}]*\}[^\[\]]*)*\])"
+        arr_match = re.search(json_arr_pattern, raw, re.DOTALL)
+        if arr_match:
+            return arr_match.group(1).strip()
+
+        # Match JSON objects
+        json_obj_pattern = r"(\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\})"
+        obj_match = re.search(json_obj_pattern, raw, re.DOTALL)
+        if obj_match:
+            return obj_match.group(1).strip()
+
+        # No JSON pattern found, return original
+        return raw
+
+    async def _acall_once(self, prompt_text: str, temperature: float) -> str:
+        """
+        Make a single async call to Groq API with rate limiting.
+
+        Args:
+            prompt_text: The prompt text to send to the model
+            temperature: Temperature parameter for generation
+
+        Returns:
+            Extracted JSON string from the response
+
+        Raises:
+            Exception: If the API call fails
+        """
+        async with self._semaphore:
+            try:
+                # Try to import Groq-specific exceptions
+                try:
+                    from groq import RateLimitError
+                except ImportError:
+                    RateLimitError = None  # type: ignore
+
+                # Make the API call
+                response = await self.groq_client.chat.completions.create(
+                    model=self.model,
+                    messages=[{"role": "user", "content": prompt_text}],
+                    temperature=temperature,
+                )
+
+                # Extract content from the first choice
+                content = response.choices[0].message.content
+
+                # Extract and return JSON
+                return self._extract_json(content)
+
+            except Exception as e:
+                # Check if it's a rate limit error
+                if RateLimitError is not None and isinstance(e, RateLimitError):
+                    logger.warning("Groq rate limit error", exc_info=e)
+                    raise
+                else:
+                    logger.error("Groq API call failed", exc_info=e)
+                    raise
+
+    def _run_async_in_current_loop(self, coro: t.Awaitable[t.Any]) -> t.Any:
+        """
+        Run an async coroutine in the current event loop if possible.
+
+        This handles Jupyter environments correctly by using a separate thread
+        when a running event loop is detected.
+
+        Args:
+            coro: The coroutine to run
+
+        Returns:
+            The result of the coroutine
+        """
+        try:
+            # Try to get the current event loop
+            loop = asyncio.get_event_loop()
+
+            if loop.is_running():
+                # If the loop is already running (like in Jupyter notebooks),
+                # we run the coroutine in a separate thread with its own event loop
+                result_container: t.Dict[str, t.Any] = {
+                    "result": None,
+                    "exception": None,
+                }
+
+                def run_in_thread():
+                    # Create a new event loop for this thread
+                    new_loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(new_loop)
+                    try:
+                        # Run the coroutine in this thread's event loop
+                        result_container["result"] = new_loop.run_until_complete(coro)
+                    except Exception as e:
+                        # Capture any exceptions to re-raise in the main thread
+                        result_container["exception"] = e
+                    finally:
+                        # Clean up the event loop
+                        new_loop.close()
+
+                # Start the thread and wait for it to complete
+                thread = threading.Thread(target=run_in_thread)
+                thread.start()
+                thread.join()
+
+                # Re-raise any exceptions that occurred in the thread
+                if result_container["exception"]:
+                    raise result_container["exception"]
+
+                return result_container["result"]
+            else:
+                # Standard case - event loop exists but isn't running
+                return loop.run_until_complete(coro)
+
+        except RuntimeError:
+            # If we get a runtime error about no event loop, create a new one
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                return loop.run_until_complete(coro)
+            finally:
+                # Clean up
+                loop.close()
+                asyncio.set_event_loop(None)
+
+    def generate_text(
+        self,
+        prompt: PromptValue,
+        n: int = 1,
+        temperature: float = 0.01,
+        stop: t.Optional[t.List[str]] = None,
+        callbacks: Callbacks = None,
+    ) -> LLMResult:
+        """
+        Generate text using Groq API synchronously.
+
+        Args:
+            prompt: The prompt value to generate from
+            n: Number of completions to generate (default: 1)
+            temperature: Temperature for generation (default: 0.01)
+            stop: Optional list of stop sequences
+            callbacks: Optional callbacks for generation
+
+        Returns:
+            LLMResult containing the generated text
+        """
+        # Run async method in event loop
+        if temperature is None:
+            temperature = self.get_temperature(n)
+
+        result = self._run_async_in_current_loop(
+            self.agenerate_text(
+                prompt=prompt,
+                n=n,
+                temperature=temperature,
+                stop=stop,
+                callbacks=callbacks,
+            )
+        )
+
+        # Track usage
+        track(
+            LLMUsageEvent(
+                provider="groq",
+                model=self.model,
+                llm_type="groq_wrapper",
+                num_requests=n,
+                is_async=False,
+            )
+        )
+
+        return result
+
+    async def agenerate_text(
+        self,
+        prompt: PromptValue,
+        n: int = 1,
+        temperature: t.Optional[float] = 0.01,
+        stop: t.Optional[t.List[str]] = None,
+        callbacks: Callbacks = None,
+    ) -> LLMResult:
+        """
+        Generate text using Groq API asynchronously.
+
+        Args:
+            prompt: The prompt value to generate from
+            n: Number of completions to generate (default: 1)
+            temperature: Temperature for generation (default: 0.01)
+            stop: Optional list of stop sequences
+            callbacks: Optional callbacks for generation
+
+        Returns:
+            LLMResult containing the generated text
+        """
+        # Determine effective temperature
+        if temperature is None:
+            temperature = self.get_temperature(n)
+
+        # Log warning if n > 1 (only support n=1 for now)
+        if n > 1:
+            logger.warning(
+                f"Groq wrapper currently only supports n=1, but n={n} was requested. "
+                "Generating n completions sequentially."
+            )
+
+        # Generate prompt text
+        prompt_text = prompt.to_string()
+
+        # Generate n completions
+        generations = []
+        for _ in range(n):
+            text = await self._acall_once(prompt_text, temperature)
+            generation = Generation(text=text)
+            generations.append(generation)
+
+        # Track usage
+        track(
+            LLMUsageEvent(
+                provider="groq",
+                model=self.model,
+                llm_type="groq_wrapper",
+                num_requests=n,
+                is_async=True,
+            )
+        )
+
+        # Return as LLMResult with proper structure
+        # Following the pattern from LangchainLLMWrapper: generations as [[g1, g2, ...]]
+        return LLMResult(generations=[generations])
+
+    def is_finished(self, response: LLMResult) -> bool:
+        """
+        Check if the LLM response is finished/complete.
+
+        For Groq, we treat all responses as finished unless they are empty.
+
+        Args:
+            response: The LLM result to check
+
+        Returns:
+            True if the response is complete, False otherwise
+        """
+        return True
+
+    def __repr__(self) -> str:
+        """Return string representation of the wrapper."""
+        return (
+            f"{self.__class__.__name__}(model={self.model}, rpm_limit={self.rpm_limit})"
+        )

--- a/tests/unit/test_groq_evaluation_integration.py
+++ b/tests/unit/test_groq_evaluation_integration.py
@@ -1,0 +1,149 @@
+"""Tests for Groq integration in evaluation path."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from ragas.evaluation import _wrap_if_groq
+from ragas.llms import GroqLLMWrapper
+from ragas.llms.base import BaseRagasLLM
+from ragas.run_config import RunConfig
+
+
+class TestGroqEvaluationIntegration:
+    """Test Groq automatic wrapping in evaluation."""
+
+    @pytest.fixture
+    def run_config(self):
+        """Create a run config for testing."""
+        return RunConfig()
+
+    def test_wrap_if_groq_leaves_base_ragas_llm_unchanged(self, run_config):
+        """Test that BaseRagasLLM instances are not wrapped."""
+        # Create a mock BaseRagasLLM
+        mock_llm = Mock(spec=BaseRagasLLM)
+
+        result = _wrap_if_groq(mock_llm, run_config)
+
+        # Should return the same instance
+        assert result is mock_llm
+
+    def test_wrap_if_groq_wraps_groq_client(self, run_config):
+        """Test that Groq clients are detected and wrapped."""
+        # Create a mock Groq client with the right structure
+        mock_groq = Mock()
+        mock_groq.chat.completions.create = Mock()
+        type(mock_groq).__name__ = "Groq"
+        type(mock_groq).__module__ = "groq"
+
+        result = _wrap_if_groq(mock_groq, run_config, model="llama3-70b-8192")
+
+        # Should be wrapped in GroqLLMWrapper
+        assert isinstance(result, GroqLLMWrapper)
+        assert result.groq_client is mock_groq
+        assert result.model == "llama3-70b-8192"
+
+    def test_wrap_if_groq_detects_groq_by_type_name(self, run_config):
+        """Test detection by type name."""
+        # Create a mock with Groq in type name
+        mock_client = Mock()
+        mock_client.chat.completions.create = Mock()
+        type(mock_client).__name__ = "AsyncGroq"
+        type(mock_client).__module__ = "groq.resources"
+
+        result = _wrap_if_groq(mock_client, run_config)
+
+        assert isinstance(result, GroqLLMWrapper)
+
+    def test_wrap_if_groq_leaves_openai_unchanged(self, run_config):
+        """Test that OpenAI clients are not wrapped as Groq."""
+        # Create a mock OpenAI client (similar structure but different type)
+        mock_openai = Mock()
+        mock_openai.chat.completions.create = Mock()
+        type(mock_openai).__name__ = "OpenAI"
+        type(mock_openai).__module__ = "openai"
+
+        result = _wrap_if_groq(mock_openai, run_config)
+
+        # Should NOT be wrapped (leave for other handling)
+        assert result is mock_openai
+        assert not isinstance(result, GroqLLMWrapper)
+
+    def test_wrap_if_groq_leaves_ambiguous_unchanged(self, run_config):
+        """Test that ambiguous clients are not wrapped."""
+        # Create a mock with the right structure but unclear type
+        mock_client = Mock()
+        mock_client.chat.completions.create = Mock()
+        type(mock_client).__name__ = "CustomClient"
+        type(mock_client).__module__ = "custom.module"
+
+        result = _wrap_if_groq(mock_client, run_config)
+
+        # Should NOT be wrapped (ambiguous)
+        assert result is mock_client
+        assert not isinstance(result, GroqLLMWrapper)
+
+    def test_wrap_if_groq_handles_none(self, run_config):
+        """Test that None is handled gracefully."""
+        # This shouldn't happen in practice, but test defensive coding
+        mock_none = None
+
+        # Should not raise an error
+        result = _wrap_if_groq(mock_none, run_config)
+        assert result is None
+
+    def test_wrap_if_groq_handles_missing_attributes(self, run_config):
+        """Test that clients without expected attributes are not wrapped."""
+        # Create a mock without the expected structure
+        mock_client = Mock()
+        # No chat.completions.create
+
+        result = _wrap_if_groq(mock_client, run_config)
+
+        # Should return unchanged
+        assert result is mock_client
+
+    def test_wrap_if_groq_custom_model(self, run_config):
+        """Test wrapping with custom model."""
+        mock_groq = Mock()
+        mock_groq.chat.completions.create = Mock()
+        type(mock_groq).__name__ = "Groq"
+        type(mock_groq).__module__ = "groq"
+
+        result = _wrap_if_groq(mock_groq, run_config, model="mixtral-8x7b-32768")
+
+        assert isinstance(result, GroqLLMWrapper)
+        assert result.model == "mixtral-8x7b-32768"
+
+    def test_wrap_if_groq_preserves_run_config(self, run_config):
+        """Test that run_config is passed to the wrapper."""
+        run_config.timeout = 60
+        run_config.max_retries = 5
+
+        mock_groq = Mock()
+        mock_groq.chat.completions.create = Mock()
+        type(mock_groq).__name__ = "Groq"
+        type(mock_groq).__module__ = "groq"
+
+        result = _wrap_if_groq(mock_groq, run_config)
+
+        assert isinstance(result, GroqLLMWrapper)
+        # The wrapper should have the run_config
+        assert result.run_config.timeout == 60
+        assert result.run_config.max_retries == 5
+
+
+class TestGroqEvaluationImport:
+    """Test that Groq imports are available in evaluation module."""
+
+    def test_groq_wrapper_imported(self):
+        """Test that GroqLLMWrapper can be imported from evaluation context."""
+        from ragas.evaluation import GroqLLMWrapper as EvalGroqWrapper
+
+        assert EvalGroqWrapper is GroqLLMWrapper
+
+    def test_wrap_if_groq_function_exists(self):
+        """Test that _wrap_if_groq helper is available."""
+        from ragas.evaluation import _wrap_if_groq as wrap_func
+
+        assert callable(wrap_func)

--- a/tests/unit/test_groq_wrapper.py
+++ b/tests/unit/test_groq_wrapper.py
@@ -1,0 +1,226 @@
+"""Tests for Groq LLM wrapper."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from langchain_core.outputs import Generation, LLMResult
+from langchain_core.prompt_values import StringPromptValue
+
+from ragas.llms.groq_wrapper import GroqLLMWrapper
+
+
+class TestGroqLLMWrapper:
+    """Test cases for Groq LLM wrapper."""
+
+    @pytest.fixture
+    def mock_groq_client(self):
+        """Mock Groq client for testing."""
+        mock_client = Mock()
+        # Create a proper async mock for the chat.completions.create method
+        mock_client.chat.completions.create = AsyncMock()
+        return mock_client
+
+    @pytest.fixture
+    def groq_wrapper(self, mock_groq_client):
+        """Create Groq wrapper instance for testing."""
+        return GroqLLMWrapper(
+            groq_client=mock_groq_client,
+            model="llama3-70b-8192",
+            rpm_limit=30,
+        )
+
+    def test_initialization(self, mock_groq_client):
+        """Test Groq wrapper initialization."""
+        wrapper = GroqLLMWrapper(
+            groq_client=mock_groq_client,
+            model="llama3-70b-8192",
+            rpm_limit=60,
+        )
+
+        assert wrapper.model == "llama3-70b-8192"
+        assert wrapper.groq_client == mock_groq_client
+        assert wrapper.rpm_limit == 60
+        assert wrapper._semaphore._value == 60
+
+    def test_initialization_defaults(self, mock_groq_client):
+        """Test Groq wrapper initialization with defaults."""
+        wrapper = GroqLLMWrapper(groq_client=mock_groq_client)
+
+        assert wrapper.model == "llama3-70b-8192"
+        assert wrapper.rpm_limit == 30
+        assert wrapper._semaphore._value == 30
+
+    def test_extract_json_fenced(self, groq_wrapper):
+        """Test JSON extraction from fenced code block."""
+        raw = """Here is the JSON:
+```json
+{"key": "value"}
+```
+Hope that helps!"""
+        result = groq_wrapper._extract_json(raw)
+        assert result == '{"key": "value"}'
+
+    def test_extract_json_naked_object(self, groq_wrapper):
+        """Test JSON extraction from naked JSON object."""
+        raw = """Some text before {"key": "value", "nested": {"a": 1}} and after"""
+        result = groq_wrapper._extract_json(raw)
+        assert '{"key": "value"' in result
+
+    def test_extract_json_naked_array(self, groq_wrapper):
+        """Test JSON extraction from naked JSON array."""
+        raw = """Here is data: [{"id": 1}, {"id": 2}] done"""
+        result = groq_wrapper._extract_json(raw)
+        assert result == '[{"id": 1}, {"id": 2}]'
+
+    def test_extract_json_no_json(self, groq_wrapper):
+        """Test JSON extraction when no JSON is present."""
+        raw = "Just plain text with no JSON"
+        result = groq_wrapper._extract_json(raw)
+        assert result == raw
+
+    @pytest.mark.asyncio
+    async def test_acall_once(self, groq_wrapper, mock_groq_client):
+        """Test async single call to Groq API."""
+        # Mock response
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = '{"result": "success"}'
+        mock_groq_client.chat.completions.create.return_value = mock_response
+
+        result = await groq_wrapper._acall_once("test prompt", 0.5)
+
+        # Verify the call was made correctly
+        mock_groq_client.chat.completions.create.assert_called_once()
+        call_kwargs = mock_groq_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == "llama3-70b-8192"
+        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["messages"][0]["role"] == "user"
+        assert call_kwargs["messages"][0]["content"] == "test prompt"
+
+        # Verify result
+        assert result == '{"result": "success"}'
+
+    @pytest.mark.asyncio
+    async def test_acall_once_with_json_extraction(
+        self, groq_wrapper, mock_groq_client
+    ):
+        """Test async call with JSON extraction from fenced block."""
+        # Mock response with fenced JSON
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = """Here is the response:
+```json
+{"extracted": true}
+```"""
+        mock_groq_client.chat.completions.create.return_value = mock_response
+
+        result = await groq_wrapper._acall_once("test prompt", 0.5)
+        assert result == '{"extracted": true}'
+
+    @pytest.mark.asyncio
+    async def test_agenerate_text(self, groq_wrapper, mock_groq_client):
+        """Test asynchronous text generation."""
+        # Mock response
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "Generated response"
+        mock_groq_client.chat.completions.create.return_value = mock_response
+
+        prompt = StringPromptValue(text="Test prompt")
+        result = await groq_wrapper.agenerate_text(prompt, n=1, temperature=0.7)
+
+        assert isinstance(result, LLMResult)
+        assert len(result.generations) == 1
+        assert len(result.generations[0]) == 1
+        assert result.generations[0][0].text == "Generated response"
+
+    @pytest.mark.asyncio
+    async def test_agenerate_text_multiple_completions(
+        self, groq_wrapper, mock_groq_client
+    ):
+        """Test asynchronous text generation with n > 1."""
+        # Mock response
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "Response"
+        mock_groq_client.chat.completions.create.return_value = mock_response
+
+        prompt = StringPromptValue(text="Test prompt")
+        result = await groq_wrapper.agenerate_text(prompt, n=3, temperature=0.7)
+
+        # Should call API 3 times
+        assert mock_groq_client.chat.completions.create.call_count == 3
+
+        # Should return 3 generations
+        assert len(result.generations) == 1
+        assert len(result.generations[0]) == 3
+
+    def test_generate_text(self, groq_wrapper, mock_groq_client):
+        """Test synchronous text generation."""
+        # Mock response
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "Generated response"
+        mock_groq_client.chat.completions.create.return_value = mock_response
+
+        prompt = StringPromptValue(text="Test prompt")
+        result = groq_wrapper.generate_text(prompt, n=1, temperature=0.7)
+
+        assert isinstance(result, LLMResult)
+        assert len(result.generations) == 1
+        assert len(result.generations[0]) == 1
+        assert result.generations[0][0].text == "Generated response"
+
+    def test_is_finished(self, groq_wrapper):
+        """Test is_finished method."""
+        result = LLMResult(
+            generations=[[Generation(text="test")]],
+        )
+        assert groq_wrapper.is_finished(result) is True
+
+    def test_repr(self, groq_wrapper):
+        """Test string representation."""
+        repr_str = repr(groq_wrapper)
+        assert "GroqLLMWrapper" in repr_str
+        assert "llama3-70b-8192" in repr_str
+        assert "rpm_limit=30" in repr_str
+
+    @pytest.mark.asyncio
+    async def test_rate_limiting(self, mock_groq_client):
+        """Test that rate limiting semaphore is used."""
+        wrapper = GroqLLMWrapper(
+            groq_client=mock_groq_client,
+            model="llama3-70b-8192",
+            rpm_limit=2,  # Very low limit for testing
+        )
+
+        # Mock response
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "Response"
+        mock_groq_client.chat.completions.create.return_value = mock_response
+
+        # Semaphore should allow up to 2 concurrent calls
+        assert wrapper._semaphore._value == 2
+
+        # Make a call
+        await wrapper._acall_once("test", 0.5)
+
+        # After call completes, semaphore should be back to 2
+        assert wrapper._semaphore._value == 2
+
+
+class TestGroqLLMWrapperImport:
+    """Test that GroqLLMWrapper can be imported from ragas.llms."""
+
+    def test_import_from_llms(self):
+        """Test importing GroqLLMWrapper from ragas.llms."""
+        from ragas.llms import GroqLLMWrapper as ImportedWrapper
+
+        assert ImportedWrapper is GroqLLMWrapper
+
+    def test_in_all(self):
+        """Test that GroqLLMWrapper is in __all__."""
+        from ragas.llms import __all__
+
+        assert "GroqLLMWrapper" in __all__


### PR DESCRIPTION
## Summary

This PR adds a dedicated `GroqLLMWrapper` to address the stability issues reported in #2580 when using Groq LLMs with ragas, especially for faithfulness/hallucination evaluations. The wrapper provides provider-specific rate limiting and JSON cleaning so long-running evaluations run more reliably when using Groq.

***

**Key Changes**

- **New Groq wrapper**
  - Added `GroqLLMWrapper` in `src/ragas/llms/groq_wrapper.py` as a `BaseRagasLLM` implementation.
  - Uses `asyncio.Semaphore` to throttle concurrent Groq calls (RPM-style limiting) and reduce `429` rate limit errors.
  - Centralizes Groq-specific error handling (e.g. `RateLimitError`) with logging.

- **JSON sanitization**
  - Implemented a private `_extract_json` helper that:
    - Removes markdown code fences such as ```json ... ```
    - Extracts the first JSON object/array from chatty responses.
    - Falls back to the raw text when no JSON fragment is found.
  - Ensures downstream JSON-based metrics receive clean, parseable content.

- **Integration into ragas**
  - Updated `src/ragas/llms/__init__.py` to export `GroqLLMWrapper`.
  - Extended `src/ragas/evaluation.py` so that, when a Groq client is passed into `aevaluate`, it can be wrapped in `GroqLLMWrapper` without changing the public API.
    - Existing behavior for OpenAI, Azure, LangChain, etc. is preserved.

- **Tests**
  - Added `tests/unit/test_groq_wrapper.py` to cover:
    - JSON extraction for fenced and “chatty” responses.
    - Basic rate-limiting behavior and error handling using mocked Groq clients.
  - Added `tests/unit/test_groq_evaluation_integration.py` to verify:
    - `aevaluate` can run end-to-end with a mocked Groq client wrapped by `GroqLLMWrapper`.

***

**Technical Validation**

- Formatting: `make format`
- Type checking: `make type`
- Full CI pipeline: `make run-ci`
  - All unit tests pass, including the new Groq tests.
  - No changes to existing provider behavior observed.

***

**Rationale**

Groq’s high throughput makes it attractive for large-scale evaluations, but its stricter rate limits and markdown-wrapped JSON responses can cause ragas evaluations to fail intermittently. By introducing a provider-specific wrapper with explicit rate limiting and response sanitization, this PR aims to make Groq a first-class, more reliable option in ragas without impacting existing providers.