### PR TITLE
fix: handle missing headlines property in HeadlineSplitter

### DIFF
--- a/src/ragas/testset/transforms/splitters/headline.py
+++ b/src/ragas/testset/transforms/splitters/headline.py
@@ -62,7 +62,7 @@ class HeadlineSplitter(Splitter):
 
         headlines = node.get_property("headlines")
         if headlines is None:
-            raise ValueError("'headlines' property not found in this node")
+            headlines = []
 
         if num_tokens_from_string(text) < self.min_tokens:
             return [node], []

--- a/tests/unit/test_headline_splitter.py
+++ b/tests/unit/test_headline_splitter.py
@@ -1,0 +1,54 @@
+import pytest
+
+from ragas.testset.graph import Node, NodeType
+from ragas.testset.transforms.splitters import HeadlineSplitter
+
+
+@pytest.mark.asyncio
+async def test_headline_splitter_missing_property_small_doc():
+    # Case 1: Small document (< min_tokens) with missing headlines
+    node = Node(
+        type=NodeType.DOCUMENT,
+        properties={
+            "page_content": "This is a small document without headlines."
+        }
+    )
+    splitter = HeadlineSplitter(min_tokens=500)
+    nodes, relationships = await splitter.split(node)
+    
+    assert len(nodes) == 1
+    assert nodes[0] == node
+
+@pytest.mark.asyncio
+async def test_headline_splitter_missing_property_large_doc():
+    # Case 2: Large document (> min_tokens) with missing headlines
+    # Should fallback to splitting by chunks (legacy behavior)
+    long_content = "word " * 600 # Approx 600 tokens
+    node = Node(
+        type=NodeType.DOCUMENT,
+        properties={
+            "page_content": long_content
+        }
+    )
+    splitter = HeadlineSplitter(min_tokens=500)
+    nodes, relationships = await splitter.split(node)
+    
+    # Should contain at least 1 node (chunked or original if not large enough for max_tokens)
+    assert len(nodes) >= 1
+
+@pytest.mark.asyncio
+async def test_headline_splitter_with_headlines():
+    # Case 3: Document with headlines present
+    content = "Section 1\nContent.\nSection 2\nContent."
+    node = Node(
+        type=NodeType.DOCUMENT,
+        properties={
+            "page_content": content,
+            "headlines": ["Section 1", "Section 2"]
+        }
+    )
+    splitter = HeadlineSplitter(min_tokens=2) # Low threshold to force split
+    nodes, relationships = await splitter.split(node)
+    
+    # Should be split into chunks
+    assert len(nodes) > 1


### PR DESCRIPTION
## Summary

The official [Testset Generation Quickstart](https://docs.ragas.io/en/stable/getstarted/rag_testset_generation/) crashes when run with the provided sample documents.

## Issue Link / Problem Description

**Steps to Reproduce:**

1. Clone the sample dataset:

```bash
git clone https://huggingface.co/datasets/vibrantlabsai/Sample_Docs_Markdown
```

2. Run the quickstart code:

```python
import os
import openai
from langchain_community.document_loaders import DirectoryLoader
from ragas.llms import LangchainLLMWrapper
from langchain_openai import ChatOpenAI
from ragas.embeddings import OpenAIEmbeddings
from ragas.testset import TestsetGenerator

path = "Sample_Docs_Markdown/"
loader = DirectoryLoader(path, glob="**/*.md")
docs = loader.load()

generator_llm = LangchainLLMWrapper(ChatOpenAI(model="gpt-4o"))
generator_embeddings = OpenAIEmbeddings(client=openai.OpenAI())

generator = TestsetGenerator(llm=generator_llm, embedding_model=generator_embeddings)
dataset = generator.generate_with_langchain_docs(docs, testset_size=10)
```

3. Observe the crash:

```
Applying HeadlinesExtractor: 100%|██████████| 5/5
Applying HeadlineSplitter:   0%|          | 0/12
Task failed with ValueError: 'headlines' property not found in this node
...
ValueError: 'headlines' property not found in this node
```

**Root Cause:** The sample dataset contains documents of varying sizes (31 to 2321 words). `HeadlinesExtractor` runs only on documents >500 tokens, but `HeadlineSplitter` runs on all documents. Small documents never receive a `headlines` property.

**Note:** This bug existed previously but was masked by exception suppression. After #2362 (which correctly removed error suppression to "fail fast"), this latent bug became visible.

## Changes Made

- Changed `HeadlineSplitter.split()` to treat missing `headlines` as an empty list instead of raising `ValueError`
- Added unit tests for the three scenarios: small docs, large docs without headlines, docs with headlines

## Testing

### How to Test
- [x] Automated tests added/updated
- [x] Manual testing steps:
  1. Clone sample dataset and run quickstart code above
  2. Verify testset generation completes without crashing
  3. Run `pytest tests/unit/test_headline_splitter.py`

## References

- Related issues: #2362 (removed error suppression, exposing this bug)
- Documentation: [Testset Generation Quickstart](https://docs.ragas.io/en/stable/getstarted/rag_testset_generation/)
