### PR TITLE
support DO_NOT_TRACK and DISABLE_TELEMETRY env vars

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,7 +130,7 @@ jobs:
           fi
         env:
           __RAGAS_DEBUG_TRACKING: true
-          RAGAS_DO_NOT_TRACK: true
+          DO_NOT_TRACK: true
 
   code_quality_check:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ run-ci: ## Run complete CI pipeline (mirrors GitHub CI exactly)
 	@echo "Type check..."
 	$(Q)$(MAKE) type
 	@echo "Unit tests..."
-	$(Q)__RAGAS_DEBUG_TRACKING=true RAGAS_DO_NOT_TRACK=true uv run --active pytest --nbmake tests/unit --dist loadfile -n auto
+	$(Q)__RAGAS_DEBUG_TRACKING=true DO_NOT_TRACK=true uv run --active pytest --nbmake tests/unit --dist loadfile -n auto
 	@echo "All CI checks passed!"
 
 run-ci-format-check: ## Run format check in dry-run mode (like GitHub CI)
@@ -113,7 +113,7 @@ run-ci-type: ## Run type checking (matches GitHub CI)
 
 run-ci-tests: ## Run all tests with CI options
 	@echo "Running all tests with CI options..."
-	$(Q)__RAGAS_DEBUG_TRACKING=true RAGAS_DO_NOT_TRACK=true pytest --nbmake tests/unit --dist loadfile -n auto
+	$(Q)__RAGAS_DEBUG_TRACKING=true DO_NOT_TRACK=true pytest --nbmake tests/unit --dist loadfile -n auto
 
 run-ci-fast: ## Fast CI check for quick local validation (2-3 minutes)
 	@echo "Running fast CI check for quick feedback..."

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ At Ragas, we believe in transparency. We collect minimal, anonymized usage data 
 
 ✅ Publicly available aggregated [data](https://github.com/vibrantlabsai/ragas/issues/49)
 
-To opt-out, set the `RAGAS_DO_NOT_TRACK` environment variable to `true`.
+To opt-out, set the `RAGAS_DO_NOT_TRACK`, `DO_NOT_TRACK`, or `DISABLE_TELEMETRY` environment variable to `true` or `1`.
 
 ### Cite Us
 

--- a/src/ragas/_analytics.py
+++ b/src/ragas/_analytics.py
@@ -38,14 +38,12 @@ USAGE_TRACKING_URL = "https://t.explodinggradients.com"
 USAGE_REQUESTS_TIMEOUT_SEC = 1
 USER_DATA_DIR_NAME = "ragas"
 # Any chance you chance this also change the variable in our ci.yaml file
-# all standard opt-out vars, any one set will disable tracking
 _DO_NOT_TRACK_VARS = ("RAGAS_DO_NOT_TRACK", "DO_NOT_TRACK", "DISABLE_TELEMETRY")
 RAGAS_DEBUG_TRACKING = "__RAGAS_DEBUG_TRACKING"
 
 
 @lru_cache(maxsize=1)
 def do_not_track() -> bool:  # pragma: no cover
-    # cached for performance, checked only once per process
     return any(
         os.environ.get(var, "").strip().lower() in ("1", "true")
         for var in _DO_NOT_TRACK_VARS

--- a/src/ragas/_analytics.py
+++ b/src/ragas/_analytics.py
@@ -38,14 +38,14 @@ USAGE_TRACKING_URL = "https://t.explodinggradients.com"
 USAGE_REQUESTS_TIMEOUT_SEC = 1
 USER_DATA_DIR_NAME = "ragas"
 # Any chance you chance this also change the variable in our ci.yaml file
-# all standard opt-out vars, ek bhi set ho toh bas
+# all standard opt-out vars, any one set will disable tracking
 _DO_NOT_TRACK_VARS = ("RAGAS_DO_NOT_TRACK", "DO_NOT_TRACK", "DISABLE_TELEMETRY")
 RAGAS_DEBUG_TRACKING = "__RAGAS_DEBUG_TRACKING"
 
 
 @lru_cache(maxsize=1)
 def do_not_track() -> bool:  # pragma: no cover
-    # cached for performance, check karo ek baar hi
+    # cached for performance, checked only once per process
     return any(
         os.environ.get(var, "").strip().lower() in ("1", "true")
         for var in _DO_NOT_TRACK_VARS

--- a/src/ragas/_analytics.py
+++ b/src/ragas/_analytics.py
@@ -38,15 +38,18 @@ USAGE_TRACKING_URL = "https://t.explodinggradients.com"
 USAGE_REQUESTS_TIMEOUT_SEC = 1
 USER_DATA_DIR_NAME = "ragas"
 # Any chance you chance this also change the variable in our ci.yaml file
-RAGAS_DO_NOT_TRACK = "RAGAS_DO_NOT_TRACK"
+# all standard opt-out vars, ek bhi set ho toh bas
+_DO_NOT_TRACK_VARS = ("RAGAS_DO_NOT_TRACK", "DO_NOT_TRACK", "DISABLE_TELEMETRY")
 RAGAS_DEBUG_TRACKING = "__RAGAS_DEBUG_TRACKING"
 
 
 @lru_cache(maxsize=1)
 def do_not_track() -> bool:  # pragma: no cover
-    # Returns True if and only if the environment variable is defined and has value True
-    # The function is cached for better performance.
-    return os.environ.get(RAGAS_DO_NOT_TRACK, str(False)).lower() == "true"
+    # cached for performance, check karo ek baar hi
+    return any(
+        os.environ.get(var, "").strip().lower() in ("1", "true")
+        for var in _DO_NOT_TRACK_VARS
+    )
 
 
 @lru_cache(maxsize=1)
@@ -269,7 +272,7 @@ def track_was_completed(
     func: t.Callable[P, T],
 ) -> t.Callable[P, T]:  # pragma: no cover
     """
-    Track if the function was completed. This helps us understand failure cases and improve the user experience. Disable tracking by setting the environment variable RAGAS_DO_NOT_TRACK to True as usual.
+    Track if the function was completed. Disable tracking via RAGAS_DO_NOT_TRACK, DO_NOT_TRACK, or DISABLE_TELEMETRY env vars.
     """
 
     @wraps(func)


### PR DESCRIPTION
Fixes #2603

Currently ragas only respects `RAGAS_DO_NOT_TRACK=true` to opt out of telemetry. 
The community is standardising on `DO_NOT_TRACK=1` and `DISABLE_TELEMETRY=1` 
(used by HuggingFace, consoledonottrack.com, etc.).

This PR updates [do_not_track()](cci:1://file:///Users/yashnaidu/.gemini/antigravity/scratch/opensource/ragas/src/ragas/_analytics.py:44:0-48:75) in [_analytics.py](cci:7://file:///Users/yashnaidu/.gemini/antigravity/scratch/opensource/ragas/src/ragas/_analytics.py:0:0-0:0) to check all three vars:
- `RAGAS_DO_NOT_TRACK` (existing, unchanged)
- `DO_NOT_TRACK`
- `DISABLE_TELEMETRY`

No breaking changes. Existing users are unaffected.
