### PR TITLE
replaced deprecated LangchainLLMWrapper with llm_factory in quickstart

### DIFF
--- a/docs/getstarted/rag_eval.md
+++ b/docs/getstarted/rag_eval.md
@@ -168,14 +168,20 @@ evaluation_dataset = EvaluationDataset.from_list(dataset)
 We have successfully collected the evaluation data. Now, we can evaluate our RAG system on the collected dataset using a set of commonly used RAG evaluation metrics. You may choose any model as [evaluator LLM](./../howtos/customizations/customize_models.md) for evaluation. 
 
 ```python
+import openai
 from ragas import evaluate
-from ragas.llms import LangchainLLMWrapper
-
-
-evaluator_llm = LangchainLLMWrapper(llm)
+from ragas.llms import llm_factory
 from ragas.metrics import LLMContextRecall, Faithfulness, FactualCorrectness
 
-result = evaluate(dataset=evaluation_dataset,metrics=[LLMContextRecall(), Faithfulness(), FactualCorrectness()],llm=evaluator_llm)
+# llm_factory recommended hai, LangchainLLMWrapper ab deprecated hai
+openai_client = openai.OpenAI()
+evaluator_llm = llm_factory("gpt-4o", client=openai_client)
+
+result = evaluate(
+    dataset=evaluation_dataset,
+    metrics=[LLMContextRecall(), Faithfulness(), FactualCorrectness()],
+    llm=evaluator_llm,
+)
 result
 ```
 

--- a/docs/getstarted/rag_eval.md
+++ b/docs/getstarted/rag_eval.md
@@ -173,7 +173,7 @@ from ragas import evaluate
 from ragas.llms import llm_factory
 from ragas.metrics import LLMContextRecall, Faithfulness, FactualCorrectness
 
-# llm_factory recommended hai, LangchainLLMWrapper ab deprecated hai
+# Use llm_factory to create the evaluator LLM instance
 openai_client = openai.OpenAI()
 evaluator_llm = llm_factory("gpt-4o", client=openai_client)
 


### PR DESCRIPTION
Related to #2584

The RAG eval quickstart guide ([docs/getstarted/rag_eval.md](cci:7://file:///Users/yashnaidu/.gemini/antigravity/scratch/opensource/ragas/docs/getstarted/rag_eval.md:0:0-0:0)) was using 
[LangchainLLMWrapper](cci:2://file:///Users/yashnaidu/.gemini/antigravity/scratch/opensource/ragas/src/ragas/llms/base.py:129:0-348:103), which is now deprecated and raises a `DeprecationWarning`.

Updated the evaluate example to use [llm_factory](cci:1://file:///Users/yashnaidu/.gemini/antigravity/scratch/opensource/ragas/src/ragas/llms/base.py:605:0-747:14) — the current recommended approach.
Also cleaned up the code formatting in that block.
