### PR TITLE
Fix: Use float to parse GPT model versions for max_completion_tokens

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -891,7 +891,7 @@ class InstructorLLM(InstructorBaseRagasLLM):
                     model_str[4:].split("-")[0].split("_")[0]
                 )  # Get version number
                 try:
-                    version = int(version_str)
+                    version = float(version_str)
                     if 5 <= version <= 19:
                         return True
                 except ValueError:


### PR DESCRIPTION
Fixes #2573

The `is_reasoning_model` check in `base.py` fails for decimal model versions (like `gpt-5.2`) because `int("5.2")` raises a `ValueError`. Consequently, it falls back to parsing the model as a legacy model rather than a reasoning model, incorrectly maintaining `max_tokens` instead of rewriting it to `max_completion_tokens`.

This PR changes the `int(version_str)` to `float(version_str)` so that `5.2 <= 19` successfully returns True for reasoning models, allowing `gpt-5.2` to utilize `max_completion_tokens`.