### PR TITLE
Change embedding calls to use async method for semantic similarity

### DIFF
--- a/src/ragas/metrics/collections/_semantic_similarity.py
+++ b/src/ragas/metrics/collections/_semantic_similarity.py
@@ -82,8 +82,8 @@ class SemanticSimilarity(BaseMetric):
         reference = reference or " "
         response = response or " "
 
-        embedding_1 = np.array(self.embeddings.embed_text(reference))
-        embedding_2 = np.array(self.embeddings.embed_text(response))
+        embedding_1 = np.array(await self.embeddings.aembed_text(reference))
+        embedding_2 = np.array(await self.embeddings.aembed_text(response))
 
         norms_1 = np.linalg.norm(embedding_1, keepdims=True)
         norms_2 = np.linalg.norm(embedding_2, keepdims=True)


### PR DESCRIPTION
## Issue Link / Problem Description

* Fixes #[issue_number]
* The async `ascore` method in `semantic_similarity` was calling the synchronous `embed_text` method instead of the asynchronous `aembed_text`. This breaks the expected async behavior and can cause blocking execution when used in async pipelines.

**Replication:**

1. Use the `SemanticSimilarity` metric inside an async evaluation workflow.
2. Call `ascore()` with embeddings that provide both `embed_text` and `aembed_text`.
3. The method executes the synchronous embedding call instead of the async one, potentially blocking the event loop.

## Changes Made

* Replaced synchronous `embed_text` calls with `await aembed_text` inside the `ascore` method.
* Ensured the method properly follows the asynchronous execution pattern.
* Maintained existing logic while aligning embedding calls with the async interface.

## Testing

### How to Test

* [x] Manual testing steps:

  1. Run an async evaluation using the `SemanticSimilarity` metric.
  2. Call `ascore(reference, response)` within an async context.
  3. Verify embeddings are generated via `aembed_text` and no blocking behavior occurs.

## References

* Related issues: #[issue_number]
* Documentation: Ragas metrics async evaluation docs
* External references: Async embedding interfaces in supported embedding providers

## Screenshots/Examples (if applicable)

**Before**

```python
embedding_1 = np.array(self.embeddings.embed_text(reference))
embedding_2 = np.array(self.embeddings.embed_text(response))
```

**After**

```python
embedding_1 = np.array(await self.embeddings.aembed_text(reference))
embedding_2 = np.array(await self.embeddings.aembed_text(response))
```
