### PR TITLE
fix: fix the embed_query error during calculating similarity

### DIFF
--- a/src/ragas/metrics/_answer_relevance.py
+++ b/src/ragas/metrics/_answer_relevance.py
@@ -97,9 +97,9 @@ class ResponseRelevancy(MetricWithLLM, MetricWithEmbeddings, SingleTurnMetric):
         assert self.embeddings is not None, (
             f"Error: '{self.name}' requires embeddings to be set."
         )
-        question_vec = np.asarray(self.embeddings.embed_query(question)).reshape(1, -1)  # type: ignore[attr-defined]
+        question_vec = np.asarray(self.embeddings.embed_text(question)).reshape(1, -1)  # type: ignore[attr-defined]
         gen_question_vec = np.asarray(
-            self.embeddings.embed_documents(generated_questions)  # type: ignore[attr-defined]
+            self.embeddings.embed_texts(generated_questions)  # type: ignore[attr-defined]
         ).reshape(len(generated_questions), -1)
         norm = np.linalg.norm(gen_question_vec, axis=1) * np.linalg.norm(
             question_vec, axis=1

--- a/src/ragas/metrics/_answer_relevance.py
+++ b/src/ragas/metrics/_answer_relevance.py
@@ -97,10 +97,17 @@ class ResponseRelevancy(MetricWithLLM, MetricWithEmbeddings, SingleTurnMetric):
         assert self.embeddings is not None, (
             f"Error: '{self.name}' requires embeddings to be set."
         )
-        question_vec = np.asarray(self.embeddings.embed_text(question)).reshape(1, -1)  # type: ignore[attr-defined]
-        gen_question_vec = np.asarray(
-            self.embeddings.embed_texts(generated_questions)  # type: ignore[attr-defined]
-        ).reshape(len(generated_questions), -1)
+        if isinstance(self.embeddings, BaseRagasEmbeddings):
+            question_vec = np.asarray(self.embeddings.embed_query(question)).reshape(1, -1)  # type: ignore[attr-defined]
+            gen_question_vec = np.asarray(
+                self.embeddings.embed_documents(generated_questions)  # type: ignore[attr-defined]
+            ).reshape(len(generated_questions), -1)
+        else:
+            question_vec = np.asarray(self.embeddings.embed_text(question)).reshape(1,
+                                                                                     -1)  # type: ignore[attr-defined]
+            gen_question_vec = np.asarray(
+                self.embeddings.embed_texts(generated_questions)  # type: ignore[attr-defined]
+            ).reshape(len(generated_questions), -1)
         norm = np.linalg.norm(gen_question_vec, axis=1) * np.linalg.norm(
             question_vec, axis=1
         )

--- a/src/ragas/metrics/_answer_relevance.py
+++ b/src/ragas/metrics/_answer_relevance.py
@@ -15,6 +15,7 @@ from ragas.metrics.base import (
     MetricWithLLM,
     SingleTurnMetric,
 )
+from ragas.embeddings.base import BaseRagasEmbeddings
 from ragas.prompt import PydanticPrompt
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Issue Link / Problem Description
The PR fixes the following bugs:
In the calculate_similarity method within ragas/metrics/_answer_relevance.py, the type of self.embeddings could be either BaseRagasEmbeddings or BaseRagasEmbedding. However, since BaseRagasEmbedding does not have an embed_query method, this causes an error.

## Changes Made
Fixing the issue by changing self.embeddings.embed_query to self.embeddings.embed_text, and embed_documents to embed_texts.

## Testing
### How to Test
- [ ] Automated tests added/updated
- [x] Manual testing steps:
  1. using embedding_factory("openai", "xxx", client=client) to init embedding
  2. using any dataset to evaluate answer_relevancy

