### PR TITLE
Fix missing FaithfulnesswithHHEM export from collections

### DIFF
--- a/src/ragas/metrics/collections/__init__.py
+++ b/src/ragas/metrics/collections/__init__.py
@@ -35,7 +35,7 @@ from ragas.metrics.collections.domain_specific_rubrics import (
     RubricsScoreWithReference,
 )
 from ragas.metrics.collections.factual_correctness import FactualCorrectness
-from ragas.metrics.collections.faithfulness import Faithfulness
+from ragas.metrics.collections.faithfulness import Faithfulness, FaithfulnesswithHHEM
 from ragas.metrics.collections.instance_specific_rubrics import InstanceSpecificRubrics
 from ragas.metrics.collections.multi_modal_faithfulness import MultiModalFaithfulness
 from ragas.metrics.collections.multi_modal_relevance import MultiModalRelevance
@@ -67,6 +67,7 @@ __all__ = [
     "ExactMatch",
     "FactualCorrectness",
     "Faithfulness",
+    "FaithfulnesswithHHEM",
     "MultiModalFaithfulness",
     "MultiModalRelevance",
     "NoiseSensitivity",

--- a/src/ragas/metrics/collections/faithfulness/__init__.py
+++ b/src/ragas/metrics/collections/faithfulness/__init__.py
@@ -1,7 +1,10 @@
 """Faithfulness metrics v2 - Modern implementation."""
 
+from ragas.metrics._faithfulness import FaithfulnesswithHHEM
+
 from .metric import Faithfulness
 
 __all__ = [
     "Faithfulness",
+    "FaithfulnesswithHHEM",
 ]


### PR DESCRIPTION
## Summary

Fixes broken import path for `FaithfulnesswithHHEM`.

After the metrics restructuring into `ragas.metrics.collections`, importing `FaithfulnesswithHHEM` from `ragas.metrics` stopped working because the collections `__init__.py` only re-exported `Faithfulness` but not the HHEM variant.

Adds `FaithfulnesswithHHEM` to the re-exports so existing user code continues to work.