### PR TITLE
feat: make diskcache an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "pydantic>=2.0.0",
     "nest-asyncio",
     "appdirs",
-    "diskcache>=5.6.3",
     "typer",
     "rich",
     "openai>=1.0.0",
@@ -38,6 +37,7 @@ Issues = "https://github.com/vibrantlabsai/ragas/issues"
 [project.optional-dependencies]
 # Core optional features
 all = [
+    "diskcache>=5.6.3",
     "sentence-transformers",
     "transformers",
     "nltk",
@@ -52,6 +52,7 @@ all = [
 ]
 
 # Specific integrations
+cache = ["diskcache>=5.6.3"]
 git = ["GitPython"]
 tracing = ["langfuse>=3.2.4", "mlflow>=3.1.4"]
 gdrive = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "tiktoken",
     "pydantic>=2.0.0",
     "nest-asyncio",
-    "appdirs",
+    "platformdirs",
     "typer",
     "rich",
     "openai>=1.0.0",

--- a/src/ragas/_analytics.py
+++ b/src/ragas/_analytics.py
@@ -12,7 +12,7 @@ from threading import Lock, Thread
 from typing import List
 
 import requests
-from appdirs import user_data_dir
+from platformdirs import user_data_dir
 from pydantic import BaseModel, Field
 
 from ragas._version import __version__

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -15,6 +15,7 @@ def temp_cache_dir(tmp_path):
 @pytest.fixture(scope="function")
 def cache_backend(temp_cache_dir):
     """Provide a DiskCacheBackend instance with a temporary directory."""
+    pytest.importorskip("diskcache")
     return DiskCacheBackend(cache_dir=temp_cache_dir)
 
 

--- a/tests/unit/test_dspy_optimizer.py
+++ b/tests/unit/test_dspy_optimizer.py
@@ -469,6 +469,7 @@ class TestDSPyOptimizer:
         fake_llm,
     ):
         """Test that cached results are returned on cache hit."""
+        pytest.importorskip("diskcache")
         from ragas.cache import DiskCacheBackend
         from ragas.optimizers.dspy_optimizer import DSPyOptimizer
 
@@ -537,6 +538,7 @@ class TestDSPyOptimizer:
         fake_llm,
     ):
         """Test that optimization runs on cache miss."""
+        pytest.importorskip("diskcache")
         from ragas.cache import DiskCacheBackend
         from ragas.optimizers.dspy_optimizer import DSPyOptimizer
 

--- a/tests/unit/test_embeddings_caching.py
+++ b/tests/unit/test_embeddings_caching.py
@@ -1,8 +1,10 @@
 """Unit tests for embeddings caching functionality."""
 
-from unittest.mock import MagicMock
-
 import pytest
+
+pytest.importorskip("diskcache")
+
+from unittest.mock import MagicMock
 
 from ragas.cache import DiskCacheBackend
 from ragas.embeddings import embedding_factory


### PR DESCRIPTION
## Issue Link / Problem Description
- Fixes #2622
- Also supersedes #2659 (appdirs → platformdirs, consolidated here)

## Changes Made
- Move `diskcache` from core deps to `cache` optional extra, add to `all`
- Add `pytest.importorskip("diskcache")` in cache-related tests
- Replace unmaintained `appdirs` with `platformdirs` (its maintained successor, compatible API)
- Same approach as #2453 (GitPython)

After this: `pip install ragas` won't pull diskcache or appdirs. `pip install ragas[cache]` or `ragas[all]` will include diskcache.