### PR TITLE
fix: replace unmaintained appdirs with platformdirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "tiktoken",
     "pydantic>=2.0.0",
     "nest-asyncio",
-    "appdirs",
+    "platformdirs",
     "diskcache>=5.6.3",
     "typer",
     "rich",

--- a/src/ragas/_analytics.py
+++ b/src/ragas/_analytics.py
@@ -12,7 +12,7 @@ from threading import Lock, Thread
 from typing import List
 
 import requests
-from appdirs import user_data_dir
+from platformdirs import user_data_dir
 from pydantic import BaseModel, Field
 
 from ragas._version import __version__


### PR DESCRIPTION
## Issue Link / Problem Description
`appdirs` hasn't been updated since 2020. `platformdirs` is its actively maintained successor with a compatible API.

## Changes Made
- `pyproject.toml`: `appdirs` → `platformdirs`
- `src/ragas/_analytics.py`: `from appdirs import user_data_dir` → `from platformdirs import user_data_dir`

Drop-in replacement, no behavior change.