### PR TITLE
fix(metrics/summarization): return NaN instead of dividing by zero on empty answers

### DIFF
--- a/src/ragas/metrics/_summarization.py
+++ b/src/ragas/metrics/_summarization.py
@@ -5,6 +5,7 @@ import typing as t
 from dataclasses import dataclass, field
 from typing import Dict
 
+import numpy as np
 from pydantic import BaseModel
 
 from ragas.dataset_schema import SingleTurnSample
@@ -193,6 +194,10 @@ class SummarizationScore(MetricWithLLM, SingleTurnMetric):
         )
 
     def _compute_qa_score(self, answers: t.List[str]) -> float:
+        if not answers:
+            # Upstream keyphrase / question generation can return [] when the LLM
+            # fails or the input is empty; signal "no score" instead of raising.
+            return np.nan
         correct = sum([1 for a in answers if a.lower() == "1"])
         return correct / len(answers)
 

--- a/tests/unit/test_summarization_score.py
+++ b/tests/unit/test_summarization_score.py
@@ -1,0 +1,35 @@
+"""Unit tests for ``SummarizationScore``."""
+
+import math
+
+import numpy as np
+
+from ragas.metrics import SummarizationScore
+
+
+def test_compute_qa_score_returns_nan_for_empty_answers():
+    """Regression: empty ``answers`` list must not raise ZeroDivisionError.
+
+    When upstream keyphrase extraction or question generation returns ``[]``
+    (the LLM refused, was rate-limited, or the input had no extractable
+    content), ``_get_answers`` is called with no questions and returns an empty
+    list of answers. ``_compute_qa_score`` must not divide by zero in that case;
+    it should signal "no score" by returning NaN, matching the convention used
+    by other ragas metrics (e.g. context_recall).
+    """
+    metric = SummarizationScore()
+    assert math.isnan(metric._compute_qa_score([]))
+
+
+def test_compute_qa_score_normal_path():
+    metric = SummarizationScore()
+    # 3 of 4 answers correct
+    assert metric._compute_qa_score(["1", "0", "1", "1"]) == 0.75
+
+
+def test_compute_score_propagates_nan_when_qa_fails():
+    """If qa_score is NaN, the overall score should also be NaN."""
+    metric = SummarizationScore()
+    nan_qa = metric._compute_qa_score([])
+    overall = metric._compute_score({"qa_score": nan_qa, "conciseness_score": 1.0})
+    assert np.isnan(overall)


### PR DESCRIPTION
## Summary

`SummarizationScore._compute_qa_score` divides by `len(answers)` without
guarding the empty case (`src/ragas/metrics/_summarization.py:195-197` on `main`).
This is reachable in normal operation:

1. `_extract_keyphrases` returns `[]` (and logs an error) when the LLM refuses,
   is rate-limited, or the input has no extractable keyphrases
   (`_summarization.py:202-212`).
2. With no keyphrases, `_get_questions` is called with `keyphrases=[]` and itself
   returns `[]` on the same kinds of LLM failures (`_summarization.py:214-227`).
3. `_get_answers([])` then yields `answers=[]`.
4. `_compute_qa_score([])` raises `ZeroDivisionError`, which propagates out of
   `_ascore` and crashes the entire metric run instead of letting the evaluator
   record a missing score.

This is the same defensive pattern already used elsewhere in ragas, e.g.
`metrics/collections/context_recall/metric.py:127`:

```python
score = sum(attributions) / len(attributions) if attributions else np.nan
```

## Fix

Return `np.nan` from `_compute_qa_score` when `answers` is empty.
NaN naturally propagates through `_compute_score` so the overall metric
result becomes NaN — signaling \"no score for this row\" — instead of
crashing the whole run.

## Tests

`tests/unit/test_summarization_score.py` (new):

- `test_compute_qa_score_returns_nan_for_empty_answers` — regression for the
  ZeroDivisionError reported above.
- `test_compute_qa_score_normal_path` — sanity check the math still works.
- `test_compute_score_propagates_nan_when_qa_fails` — confirms the NaN bubbles
  out through `_compute_score`.

I verified the function-level logic locally (`make test` requires the full
ragas dev env which I don't have set up) — empty input returns NaN, normal
input still returns the expected ratio, and the previous code path indeed
raises `ZeroDivisionError: division by zero`.