### PR TITLE
Fix non-LLM context recall threshold boundary

### DIFF
--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -216,7 +216,7 @@ class NonLLMContextRecall(SingleTurnMetric):
         return await self._single_turn_ascore(SingleTurnSample(**row), callbacks)
 
     def _compute_score(self, verdict_list: t.List[float]) -> float:
-        response = [1 if score > self.threshold else 0 for score in verdict_list]
+        response = [1 if score >= self.threshold else 0 for score in verdict_list]
         denom = len(response)
         numerator = sum(response)
         score = numerator / denom if denom > 0 else np.nan

--- a/tests/unit/test_non_llm_context_metrics.py
+++ b/tests/unit/test_non_llm_context_metrics.py
@@ -1,0 +1,12 @@
+import pytest
+
+from ragas.metrics._context_precision import NonLLMContextPrecisionWithReference
+from ragas.metrics._context_recall import NonLLMContextRecall
+
+
+def test_non_llm_context_metrics_include_scores_at_threshold():
+    recall = NonLLMContextRecall(threshold=0.5)
+    precision = NonLLMContextPrecisionWithReference(threshold=0.5)
+
+    assert recall._compute_score([0.5]) == 1.0
+    assert precision._calculate_average_precision([1]) == pytest.approx(1.0)


### PR DESCRIPTION
## What

Align `NonLLMContextRecall` with `NonLLMContextPrecisionWithReference` at the similarity threshold boundary. Recall now treats a score exactly equal to `threshold` as relevant (`>=`), matching precision and the threshold convention used elsewhere in the codebase.

Fixes #2777.

## Why

The sibling non-LLM context metrics both expose the same `threshold` and use the same string-similarity style relevance decision, but recall previously used strict `>` while precision used `>=`. This made an exactly-on-threshold context relevant for precision but irrelevant for recall.

## Tests

- `git diff --check`
- `PYTHONPYCACHEPREFIX=/private/tmp/ragas-pycache PYTHONPATH=src /usr/bin/python3 -m py_compile src/ragas/metrics/_context_recall.py tests/unit/test_non_llm_context_metrics.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-ragas uv run ruff check src/ragas/metrics/_context_recall.py tests/unit/test_non_llm_context_metrics.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-ragas uv run ruff format --check src/ragas/metrics/_context_recall.py tests/unit/test_non_llm_context_metrics.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-ragas PYTHONPATH=/private/tmp/ragas-stubs:src uv run --extra test pytest -q tests/unit/test_non_llm_context_metrics.py`

Note: the pytest run used a temporary local stub for `langchain_community.chat_models.vertexai.ChatVertexAI` because current dependency resolution hits the existing import break tracked separately in #2753/#2745 before tests are collected. The stub was not committed; it only lets this focused metric test run locally.
