### PR TITLE
Guard LangChain embedding telemetry model names

### DIFF
--- a/src/ragas/embeddings/base.py
+++ b/src/ragas/embeddings/base.py
@@ -257,6 +257,15 @@ class BaseRagasEmbeddings(Embeddings, ABC):
         )
 
 
+def _safe_langchain_embedding_model_name(embeddings: Embeddings) -> str | None:
+    """Return a telemetry-safe model name for LangChain embeddings."""
+    for attr in ("model", "model_name"):
+        value = getattr(embeddings, attr, None)
+        if isinstance(value, str):
+            return value
+    return None
+
+
 class LangchainEmbeddingsWrapper(BaseRagasEmbeddings):
     """
     Wrapper for any embeddings from langchain.
@@ -305,7 +314,7 @@ class LangchainEmbeddingsWrapper(BaseRagasEmbeddings):
         track(
             EmbeddingUsageEvent(
                 provider="langchain",
-                model=getattr(self.embeddings, "model", None),
+                model=_safe_langchain_embedding_model_name(self.embeddings),
                 embedding_type="legacy",
                 num_requests=1,
                 is_async=False,
@@ -323,7 +332,7 @@ class LangchainEmbeddingsWrapper(BaseRagasEmbeddings):
         track(
             EmbeddingUsageEvent(
                 provider="langchain",
-                model=getattr(self.embeddings, "model", None),
+                model=_safe_langchain_embedding_model_name(self.embeddings),
                 embedding_type="legacy",
                 num_requests=len(texts),
                 is_async=False,
@@ -341,7 +350,7 @@ class LangchainEmbeddingsWrapper(BaseRagasEmbeddings):
         track(
             EmbeddingUsageEvent(
                 provider="langchain",
-                model=getattr(self.embeddings, "model", None),
+                model=_safe_langchain_embedding_model_name(self.embeddings),
                 embedding_type="legacy",
                 num_requests=1,
                 is_async=True,
@@ -359,7 +368,7 @@ class LangchainEmbeddingsWrapper(BaseRagasEmbeddings):
         track(
             EmbeddingUsageEvent(
                 provider="langchain",
-                model=getattr(self.embeddings, "model", None),
+                model=_safe_langchain_embedding_model_name(self.embeddings),
                 embedding_type="legacy",
                 num_requests=len(texts),
                 is_async=True,

--- a/tests/unit/test_embeddings.py
+++ b/tests/unit/test_embeddings.py
@@ -1,5 +1,18 @@
 from __future__ import annotations
 
+import pytest
+
+
+class _ObjectModelEmbeddings:
+    model = object()
+    model_name = "fastembed-compatible-model"
+
+    def embed_query(self, text: str):
+        return [1.0]
+
+    def embed_documents(self, texts: list[str]):
+        return [[1.0] for _ in texts]
+
 
 def test_basic_legacy_imports():
     """Test that basic legacy imports work."""
@@ -76,3 +89,23 @@ def test_backward_compatibility_alias():
     # They should be the same class
     assert RagasBaseEmbedding is BaseRagasEmbedding
     print("Backward compatibility confirmed: RagasBaseEmbedding is BaseRagasEmbedding")
+
+
+def test_langchain_embedding_usage_event_accepts_non_string_model(monkeypatch):
+    """Telemetry should not fail when a LangChain embedding exposes a model object."""
+    import ragas.embeddings.base as base_module
+    from ragas.embeddings.base import LangchainEmbeddingsWrapper
+
+    events = []
+    monkeypatch.setattr(base_module, "track", events.append)
+
+    with pytest.warns(DeprecationWarning):
+        wrapper = LangchainEmbeddingsWrapper(_ObjectModelEmbeddings())
+
+    assert wrapper.embed_query("hello") == [1.0]
+    assert wrapper.embed_documents(["hello", "world"]) == [[1.0], [1.0]]
+
+    assert [event.model for event in events] == [
+        "fastembed-compatible-model",
+        "fastembed-compatible-model",
+    ]


### PR DESCRIPTION
## Summary

Fixes #2783 by normalizing the model name used for legacy LangChain embedding telemetry before constructing `EmbeddingUsageEvent`.

Some LangChain embeddings expose a loaded model object on `.model` instead of a string model name. Since `EmbeddingUsageEvent.model` is typed as `str | None`, constructing the telemetry event could raise before `track()` had a chance to silence telemetry errors. The wrapper now uses a telemetry-safe helper that accepts string `.model`, falls back to string `.model_name`, and otherwise records `None`.

## Tests

- `git diff --check`
- `PYTHONPYCACHEPREFIX=/private/tmp/ragas-pycache PYTHONPATH=src /usr/bin/python3 -m py_compile src/ragas/embeddings/base.py tests/unit/test_embeddings.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-ragas uv run ruff check src/ragas/embeddings/base.py tests/unit/test_embeddings.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-ragas uv run ruff format --check src/ragas/embeddings/base.py tests/unit/test_embeddings.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-ragas PYTHONPATH=/private/tmp/ragas-stubs:src uv run --extra test pytest -q tests/unit/test_embeddings.py`

Note: the pytest command uses a temporary local stub for `langchain_community.chat_models.vertexai` because the current test environment hits the existing import issue tracked separately in #2753 before this test module runs. The stub is not part of this PR.
