### PR TITLE
Harden multimodal image URL validation

### DIFF
--- a/src/ragas/metrics/collections/multi_modal_faithfulness/util.py
+++ b/src/ragas/metrics/collections/multi_modal_faithfulness/util.py
@@ -2,9 +2,11 @@
 
 import base64
 import binascii
+import ipaddress
 import logging
 import os
 import re
+import socket
 import typing as t
 from io import BytesIO
 from urllib.parse import urlparse
@@ -23,6 +25,7 @@ DATA_URI_REGEX = re.compile(
     r"^data:(image\/(?:png|jpeg|gif|webp));base64,([a-zA-Z0-9+/=]+)$"
 )
 COMMON_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
+DISALLOWED_IP_CHECKS = {"is_loopback", "is_private", "is_link_local", "is_reserved"}
 
 
 class MultiModalFaithfulnessInput(BaseModel):
@@ -63,13 +66,15 @@ def is_image_path_or_url(item: str) -> bool:
     # Check for URL
     try:
         parsed = urlparse(item)
-        if parsed.scheme in ALLOWED_URL_SCHEMES:
+        if _is_allowed_image_url(item):
             path_part = parsed.path
             _, ext = os.path.splitext(path_part)
             if ext.lower() in COMMON_IMAGE_EXTENSIONS:
                 return True
             # Could be an image URL without extension
-            return True if parsed.scheme in ALLOWED_URL_SCHEMES else False
+            return True
+        if parsed.scheme:
+            return False
     except ValueError:
         pass
 
@@ -124,7 +129,10 @@ def _try_process_url(item: str) -> t.Optional[t.Dict[str, str]]:
     """Download and process image from URL."""
     try:
         parsed_url = urlparse(item)
-        if parsed_url.scheme not in ALLOWED_URL_SCHEMES:
+        if not _is_allowed_image_url(item) or not parsed_url.hostname:
+            return None
+
+        if not _is_safe_url_target(parsed_url.hostname):
             return None
 
         response = requests.get(
@@ -173,6 +181,60 @@ def _try_process_url(item: str) -> t.Optional[t.Dict[str, str]]:
         return None
     except Exception:
         return None
+
+
+def _is_allowed_image_url(url: str) -> bool:
+    """Validate URL syntax before DNS and request-level SSRF checks."""
+    try:
+        parsed_url = urlparse(url)
+        _ = parsed_url.port
+    except ValueError:
+        return False
+
+    if parsed_url.scheme not in ALLOWED_URL_SCHEMES or not parsed_url.hostname:
+        return False
+
+    if "\\" in parsed_url.netloc or parsed_url.username or parsed_url.password:
+        logger.error(f"Rejecting ambiguous image URL '{url}'")
+        return False
+
+    return True
+
+
+def _is_safe_url_target(url_hostname: str) -> bool:
+    """Return False when a URL hostname resolves to an internal address."""
+    try:
+        addrinfo_results = socket.getaddrinfo(
+            url_hostname, None, family=socket.AF_UNSPEC
+        )
+    except socket.gaierror as dns_err:
+        logger.error(
+            f"SSRF check: DNS resolution error for hostname '{url_hostname}': {dns_err}"
+        )
+        return False
+
+    if not addrinfo_results:
+        return False
+
+    for _family, _type, _proto, _canonname, sockaddr in addrinfo_results:
+        try:
+            ip = ipaddress.ip_address(sockaddr[0])
+        except ValueError as ip_err:
+            logger.error(
+                f"SSRF check: Error parsing resolved IP address '{sockaddr[0]}' "
+                f"for hostname '{url_hostname}': {ip_err}"
+            )
+            return False
+
+        for check_name in DISALLOWED_IP_CHECKS:
+            if getattr(ip, check_name, False):
+                logger.error(
+                    f"SSRF check: Hostname '{url_hostname}' resolved to disallowed "
+                    f"IP '{sockaddr[0]}' ({check_name}=True). Blocking request."
+                )
+                return False
+
+    return True
 
 
 def _try_process_local_file(item: str) -> t.Optional[t.Dict[str, str]]:

--- a/src/ragas/prompt/multi_modal_prompt.py
+++ b/src/ragas/prompt/multi_modal_prompt.py
@@ -353,15 +353,26 @@ class ImageTextPromptValue(PromptValue):
         If so, attempts to download, validate, and encode the image.
         Returns dict with 'mime_type' and 'encoded_data' or None.
         """
-        try:
-            parsed_url = urlparse(item)
-            if parsed_url.scheme in ALLOWED_URL_SCHEMES:
-                # URL seems plausible, attempt download and validation
-                return self._download_validate_and_encode(item)
-        except ValueError:
-            # Invalid URL format
-            pass
+        if self._is_allowed_image_url(item):
+            return self._download_validate_and_encode(item)
         return None
+
+    def _is_allowed_image_url(self, url: str) -> bool:
+        """Validate URL syntax before DNS and request-level SSRF checks."""
+        try:
+            parsed_url = urlparse(url)
+            _ = parsed_url.port
+        except ValueError:
+            return False
+
+        if parsed_url.scheme not in ALLOWED_URL_SCHEMES or not parsed_url.hostname:
+            return False
+
+        if "\\" in parsed_url.netloc or parsed_url.username or parsed_url.password:
+            logger.error(f"Rejecting ambiguous image URL '{url}'")
+            return False
+
+        return True
 
     def _download_validate_and_encode(self, url: str) -> t.Optional[dict]:
         """
@@ -371,6 +382,9 @@ class ImageTextPromptValue(PromptValue):
         try:
             # <<< SSRF CHECK START >>>
             parsed_url = urlparse(url)
+            if not self._is_allowed_image_url(url):
+                return None
+
             if not parsed_url.hostname:
                 logger.error(
                     f"Could not extract hostname from URL '{url}' for SSRF check."

--- a/tests/unit/prompt/test_multi_modal_prompt_security.py
+++ b/tests/unit/prompt/test_multi_modal_prompt_security.py
@@ -1,0 +1,62 @@
+from unittest.mock import patch
+
+from ragas.metrics.collections.multi_modal_faithfulness.util import (
+    is_image_path_or_url,
+    process_image_to_base64,
+)
+from ragas.prompt.multi_modal_prompt import ImageTextPromptValue
+
+
+def test_image_url_rejects_backslash_userinfo_ssrf_bypass():
+    prompt_value = ImageTextPromptValue(items=[])
+    bypass_url = "http://127.0.0.1:6666\\@1.1.1.1/image.png"
+
+    with patch("ragas.prompt.multi_modal_prompt.requests.get") as mock_get:
+        assert prompt_value._download_validate_and_encode(bypass_url) is None
+
+    mock_get.assert_not_called()
+
+
+def test_image_url_rejects_userinfo_before_request():
+    prompt_value = ImageTextPromptValue(items=[])
+
+    with patch("ragas.prompt.multi_modal_prompt.requests.get") as mock_get:
+        assert (
+            prompt_value._try_process_allowed_url("https://user@example.com/a.png")
+            is None
+        )
+
+    mock_get.assert_not_called()
+
+
+def test_image_url_accepts_plain_http_url_shape():
+    prompt_value = ImageTextPromptValue(items=[])
+
+    assert prompt_value._is_allowed_image_url("https://example.com/a.png") is True
+
+
+def test_collections_image_url_rejects_backslash_userinfo_ssrf_bypass():
+    bypass_url = "http://127.0.0.1:6666\\@1.1.1.1/image.png"
+
+    assert is_image_path_or_url(bypass_url) is False
+    with patch(
+        "ragas.metrics.collections.multi_modal_faithfulness.util.requests.get"
+    ) as mock_get:
+        assert process_image_to_base64(bypass_url) is None
+
+    mock_get.assert_not_called()
+
+
+def test_collections_image_url_blocks_internal_resolved_target():
+    with (
+        patch(
+            "ragas.metrics.collections.multi_modal_faithfulness.util.socket.getaddrinfo",
+            return_value=[(None, None, None, None, ("127.0.0.1", 0))],
+        ),
+        patch(
+            "ragas.metrics.collections.multi_modal_faithfulness.util.requests.get"
+        ) as mock_get,
+    ):
+        assert process_image_to_base64("https://example.com/a.png") is None
+
+    mock_get.assert_not_called()


### PR DESCRIPTION
## What

Harden multimodal image URL handling against ambiguous URL parsing before any outbound image fetch. This rejects URLs with userinfo or backslashes in the authority, including the `urlparse`/`requests` mismatch shape reported in #2754, and repeats the syntactic check inside the direct download helper.

The collections multimodal faithfulness image path now also performs the same syntactic guard and blocks hostnames that resolve to internal IP ranges before calling `requests.get`.

Fixes #2754.

## Tests

- `PYTHONPYCACHEPREFIX=/private/tmp/ragas-pycache /usr/bin/python3 -m py_compile src/ragas/prompt/multi_modal_prompt.py src/ragas/metrics/collections/multi_modal_faithfulness/util.py tests/unit/prompt/test_multi_modal_prompt_security.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-ragas UV_TOOL_DIR=/private/tmp/uv-tools-ragas uvx ruff check src/ragas/prompt/multi_modal_prompt.py src/ragas/metrics/collections/multi_modal_faithfulness/util.py tests/unit/prompt/test_multi_modal_prompt_security.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-ragas UV_TOOL_DIR=/private/tmp/uv-tools-ragas uvx ruff format --check src/ragas/prompt/multi_modal_prompt.py src/ragas/metrics/collections/multi_modal_faithfulness/util.py tests/unit/prompt/test_multi_modal_prompt_security.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-ragas UV_PROJECT_ENVIRONMENT=/private/tmp/ragas-uv-env PYTHONPATH=/private/tmp/ragas-site:src uv run --group dev pytest -q tests/unit/prompt/test_multi_modal_prompt_security.py`

Note: the pytest run used a temporary `/private/tmp/ragas-site/sitecustomize.py` shim for the existing main-branch `langchain_community.chat_models.vertexai` import break with current langchain-community. The shim only affects the local test process and is not part of this PR.