### PR TITLE
Fix InstructorLLM reasoning model parameter mapping

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import re
 import threading
 import typing as t
 from abc import ABC, abstractmethod
@@ -859,8 +860,8 @@ class InstructorLLM(InstructorBaseRagasLLM):
         - If structured output is truncated, increase max_tokens further
 
         Pattern-based matching for future-proof coverage:
-        - O-series: o1, o2, o3, o4, o5, ... (all reasoning versions)
-        - GPT-5 series: gpt-5, gpt-5-*, gpt-6, gpt-7, ... (all GPT-5+ models)
+        - O-series: o1, o2, o3, o10, ... (all reasoning versions)
+        - GPT-5 series: gpt-5, gpt-5.1, gpt-5-*, gpt-6, ... (all GPT-5+ models)
         - Other: codex-mini
         """
         mapped_args = self.model_args.copy()
@@ -871,31 +872,16 @@ class InstructorLLM(InstructorBaseRagasLLM):
         # Uses prefix matching to cover current and future model variants
         def is_reasoning_model(model_str: str) -> bool:
             """Check if model is a reasoning model requiring max_completion_tokens."""
-            # O-series reasoning models (o1, o1-mini, o1-2024-12-17, o2, o3, o4, o5, o6, o7, o8, o9)
-            # Pattern: "o" followed by single digit 1-9, then optional "-" or end of string
-            # TODO: Update to support o10+ when OpenAI releases models beyond o9
-            if (
-                len(model_str) >= 2
-                and model_str[0] == "o"
-                and model_str[1] in "123456789"
-            ):
-                # Allow single digit o-series: o1, o2, ..., o9
-                if len(model_str) == 2 or model_str[2] in ("-", "_"):
-                    return True
+            # O-series reasoning models (o1, o1-mini, o10, o10-mini).
+            if re.match(r"^o[1-9]\d*(?:[-_].*)?$", model_str):
+                return True
 
-            # GPT-5 and newer generation models (gpt-5, gpt-5-*, gpt-6, gpt-7, ..., gpt-19)
-            # Pattern: "gpt-" followed by single or double digit >= 5, max 19
-            # TODO: Update to support gpt-20+ when OpenAI releases models beyond gpt-19
+            # GPT-5 and newer generation models, including dotted versions such as
+            # gpt-5.1 and suffixed variants such as gpt-5.1-mini.
             if model_str.startswith("gpt-"):
-                version_str = (
-                    model_str[4:].split("-")[0].split("_")[0]
-                )  # Get version number
-                try:
-                    version = int(version_str)
-                    if 5 <= version <= 19:
-                        return True
-                except ValueError:
-                    pass
+                match = re.match(r"^gpt-(\d+)(?:\.\d+)?(?:[-_].*)?$", model_str)
+                if match and int(match.group(1)) >= 5:
+                    return True
 
             # Other specific reasoning models
             if model_str == "codex-mini":

--- a/tests/unit/llms/test_instructor_factory.py
+++ b/tests/unit/llms/test_instructor_factory.py
@@ -221,6 +221,73 @@ def test_llm_model_args_storage(mock_sync_client, monkeypatch):
     assert llm.model_args == model_args  # type: ignore
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "o1",
+        "o3-mini",
+        "o10",
+        "o10-mini",
+        "gpt-5",
+        "gpt-5-mini",
+        "gpt-5.1",
+        "gpt-5.1-mini",
+        "gpt-20",
+    ],
+)
+def test_openai_reasoning_models_use_max_completion_tokens(
+    model, mock_sync_client, monkeypatch
+):
+    """Reasoning models require max_completion_tokens instead of max_tokens."""
+
+    def mock_from_openai(client, mode=None):
+        return MockInstructor(client)
+
+    monkeypatch.setattr("instructor.from_openai", mock_from_openai)
+
+    llm = llm_factory(
+        model,
+        provider="openai",
+        client=mock_sync_client,
+        temperature=0.7,
+        max_tokens=1000,
+        top_p=0.9,
+    )
+
+    mapped_args = llm._map_provider_params()  # type: ignore[attr-defined]
+
+    assert mapped_args["max_completion_tokens"] == 1000
+    assert "max_tokens" not in mapped_args
+    assert mapped_args["temperature"] == 1.0
+    assert "top_p" not in mapped_args
+
+
+@pytest.mark.parametrize("model", ["gpt-4", "gpt-4o", "gpt-4.1", "gpt-4.1-mini"])
+def test_legacy_openai_models_keep_max_tokens(model, mock_sync_client, monkeypatch):
+    """Legacy OpenAI models keep their existing parameter names."""
+
+    def mock_from_openai(client, mode=None):
+        return MockInstructor(client)
+
+    monkeypatch.setattr("instructor.from_openai", mock_from_openai)
+
+    llm = llm_factory(
+        model,
+        provider="openai",
+        client=mock_sync_client,
+        temperature=0.7,
+        max_tokens=1000,
+        top_p=0.9,
+    )
+
+    mapped_args = llm._map_provider_params()  # type: ignore[attr-defined]
+
+    assert mapped_args["max_tokens"] == 1000
+    assert "max_completion_tokens" not in mapped_args
+    assert mapped_args["temperature"] == 0.7
+    assert mapped_args["top_p"] == 0.9
+
+
 def test_llm_factory_missing_client():
     """Test that missing client raises ValueError."""
     with pytest.raises(ValueError, match="requires a client instance"):


### PR DESCRIPTION
## Summary

Fix `InstructorLLM._map_openai_params()` reasoning-model detection so OpenAI/Azure reasoning model names with dotted versions or multi-digit o-series versions remap `max_tokens` to `max_completion_tokens`.

This covers model names such as:

- `gpt-5.1`
- `gpt-5.1-mini`
- `o10`
- `o10-mini`

while keeping legacy model names such as `gpt-4o` and `gpt-4.1` on the existing `max_tokens` path.

Fixes #2708.

## Root cause

The previous detection parsed only integer GPT versions and only single-digit o-series names. Dotted GPT versions like `gpt-5.1` raised `ValueError` during integer parsing and skipped the reasoning-model parameter mapping entirely.

## Tests

- `UV_CACHE_DIR=/Users/yinxiaogou/Documents/resume/.tmp-uv-cache uv run ruff check src/ragas/llms/base.py tests/unit/llms/test_instructor_factory.py`
- `UV_CACHE_DIR=/Users/yinxiaogou/Documents/resume/.tmp-uv-cache uv run ruff format --check src/ragas/llms/base.py tests/unit/llms/test_instructor_factory.py`
- `UV_CACHE_DIR=/Users/yinxiaogou/Documents/resume/.tmp-uv-cache PYTHONPATH=src uv run --with 'langchain-community==0.3.27' --with 'langchain-core==0.3.75' --with 'langchain-openai==0.3.29' pytest tests/unit/llms/test_instructor_factory.py`

The temporary LangChain pins are only for local test execution. The default local dependency resolution currently hits the existing VertexAI/LangChain import incompatibility tracked separately in #2753.
