### PR TITLE
Make diskcache an optional cache extra

### DIFF
--- a/docs/howtos/customizations/caching.ipynb
+++ b/docs/howtos/customizations/caching.ipynb
@@ -10,6 +10,8 @@
     "\n",
     "You can use the [DiskCacheBackend][ragas.cache.DiskCacheBackend] which uses a local disk cache to store the cached responses. You can also implement your own custom cacher by implementing the [CacheInterface][ragas.cache.CacheInterface].\n",
     "\n",
+    "If you installed Ragas without extras, install the disk cache dependencies with `pip install 'ragas[cache]'` before using [DiskCacheBackend][ragas.cache.DiskCacheBackend].\n",
+    "\n",
     "\n",
     "## Using DefaultCacher\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "pydantic>=2.0.0",
     "nest-asyncio",
     "appdirs",
-    "diskcache>=5.6.3",
     "typer",
     "rich",
     "openai>=1.0.0",
@@ -48,10 +47,12 @@ all = [
     "sacrebleu",
     "llama_index",
     "r2r",
-    "GitPython"
+    "GitPython",
+    "diskcache>=5.6.3",
 ]
 
 # Specific integrations
+cache = ["diskcache>=5.6.3"]
 git = ["GitPython"]
 tracing = ["langfuse>=3.2.4", "mlflow>=3.1.4"]
 gdrive = [

--- a/src/ragas/cache.py
+++ b/src/ragas/cache.py
@@ -82,7 +82,8 @@ class DiskCacheBackend(CacheInterface):
             from diskcache import Cache
         except ImportError:
             raise ImportError(
-                "For using the diskcache backend, please install it with `pip install diskcache`."
+                "For using the diskcache backend, please install it with "
+                "`pip install 'ragas[cache]'`."
             )
 
         self.cache = Cache(cache_dir)

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,4 +1,5 @@
 import asyncio
+import builtins
 
 import pytest
 
@@ -58,6 +59,21 @@ def test_generate_cache_key_bound_method():
     assert key1 == key2, (
         "Cache keys should match even if the originating objects the methods are bound to are not the same, as long as the arguments match"
     )
+
+
+def test_disk_cache_backend_missing_dependency_message(monkeypatch):
+    """Disk cache should point users at the optional cache extra."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "diskcache":
+            raise ImportError("No module named 'diskcache'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError, match=r"pip install 'ragas\[cache\]'"):
+        DiskCacheBackend()
 
 
 def test_no_cache_backend():


### PR DESCRIPTION
## Summary

- move `diskcache` out of the core install requirements into a new `cache` extra
- keep `diskcache` included in the existing `all` extra
- update the missing-dependency guidance for `DiskCacheBackend` to point users at `pip install 'ragas[cache]'`
- document the new extra in the caching how-to
- add regression coverage for the missing optional dependency path

Fixes #2622.

## Validation

- `make check`
  - Ruff formatting and lint checks passed without changing files
  - full-project Pyright reached 12 existing errors outside this PR's four files (CLI, embeddings, Haystack, Langfuse, and NumPy typing)
- focused cache suite: 8 passed
- built `ragas-0.4.4.dev9+g2a518f851-py3-none-any.whl`
- verified wheel metadata has no unconditional `diskcache` requirement and includes:
  - `Requires-Dist: diskcache>=5.6.3; extra == "cache"`
  - `Requires-Dist: diskcache>=5.6.3; extra == "all"`
- installed the wheel into two fresh Python 3.12 environments:
  - core install: 88 packages, `diskcache` absent
  - `[cache]` install: 89 packages, `diskcache==5.6.3` present

Focused test command:

```bash
uv pip install 'langchain-community==0.3.31'
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --active --no-sync pytest \
  -p pytest_asyncio.plugin -p xdist.plugin tests/unit/test_cache.py -q
```

The compatibility pin avoids the current unrelated removal of `langchain_community.chat_models.vertexai`; disabling automatic plugin loading avoids a broken Phoenix pytest plugin in the full development environment.

## AI assistance

AI assistance was used to revalidate the dependency boundary, exercise fresh wheel installations, inspect the existing implementation and tests, and refine this PR description. The resulting changes and validation evidence were reviewed before submission.
