### PR TITLE
Fix VertexAI imports with newer LangChain

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -9,8 +9,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
 import instructor
-from langchain_community.chat_models.vertexai import ChatVertexAI
-from langchain_community.llms import VertexAI
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.outputs import ChatGeneration, Generation, LLMResult
 from langchain_openai.chat_models import AzureChatOpenAI, ChatOpenAI
@@ -22,6 +20,22 @@ from ragas._analytics import LLMUsageEvent, track
 from ragas.cache import CacheInterface, cacher
 from ragas.exceptions import LLMDidNotFinishException
 from ragas.run_config import RunConfig, add_async_retry
+
+try:
+    from langchain_google_vertexai import ChatVertexAI
+except ImportError:
+    try:
+        from langchain_community.chat_models.vertexai import ChatVertexAI
+    except ImportError:
+        ChatVertexAI = None  # type: ignore[assignment]
+
+try:
+    from langchain_google_vertexai import VertexAI
+except ImportError:
+    try:
+        from langchain_community.llms import VertexAI
+    except ImportError:
+        VertexAI = None  # type: ignore[assignment]
 
 if t.TYPE_CHECKING:
     from langchain_core.callbacks import Callbacks
@@ -40,9 +54,13 @@ MULTIPLE_COMPLETION_SUPPORTED = [
     ChatOpenAI,
     AzureOpenAI,
     AzureChatOpenAI,
-    ChatVertexAI,
-    VertexAI,
 ]
+
+if ChatVertexAI is not None:
+    MULTIPLE_COMPLETION_SUPPORTED.append(ChatVertexAI)
+
+if VertexAI is not None:
+    MULTIPLE_COMPLETION_SUPPORTED.append(VertexAI)
 
 
 def is_multiple_completion_supported(llm: BaseLanguageModel) -> bool:

--- a/tests/unit/test_llms_base_imports.py
+++ b/tests/unit/test_llms_base_imports.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_llms_base_imports_without_vertexai_provider():
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{repo_root / 'src'}{os.pathsep}{env.get('PYTHONPATH', '')}"
+
+    code = textwrap.dedent(
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name.startswith("langchain_google_vertexai"):
+                raise ImportError(name)
+            if name == "langchain_community.chat_models.vertexai":
+                raise ImportError(name)
+            return real_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = fake_import
+
+        import ragas.llms.base  # noqa: F401
+        """
+    )
+
+    subprocess.run([sys.executable, "-c", code], env=env, check=True)

--- a/tests/unit/test_llms_base_imports.py
+++ b/tests/unit/test_llms_base_imports.py
@@ -21,11 +21,17 @@ def test_llms_base_imports_without_vertexai_provider():
                 raise ImportError(name)
             if name == "langchain_community.chat_models.vertexai":
                 raise ImportError(name)
+            if name == "langchain_community.llms" and "VertexAI" in fromlist:
+                raise ImportError(name)
             return real_import(name, globals, locals, fromlist, level)
 
         builtins.__import__ = fake_import
 
-        import ragas.llms.base  # noqa: F401
+        import ragas.llms.base as base
+
+        assert base.ChatVertexAI is None
+        assert base.VertexAI is None
+        assert None not in base.MULTIPLE_COMPLETION_SUPPORTED
         """
     )
 


### PR DESCRIPTION
## Summary

- prefer `langchain_google_vertexai` for VertexAI model classes when installed
- fall back to legacy `langchain_community` VertexAI imports for older environments
- avoid failing `import ragas` when neither optional VertexAI provider path is available
- only register provider classes that were actually imported
- test both missing ChatVertexAI and VertexAI paths and the completion-support registry

Fixes #2745.
Fixes #2753.

## Validation

Validated on current upstream `main` with Python 3.12 and `langchain-community==0.4.2`:

- a real editable install successfully executed `import ragas`
- `pytest tests/unit/test_llms_base_imports.py -q`: 1 passed
- Ruff lint passed
- Ruff format check passed
- Python compilation passed

Directly importing `langchain_community.chat_models.vertexai` in the same environment raises `ModuleNotFoundError`, reproducing the compatibility break. Fault-injecting the old unconditional imports made test collection fail with that same error; restoring this fix returned the test to green.

The subprocess regression test now blocks both modern provider imports and both legacy provider types, then verifies both optional classes are `None` and `MULTIPLE_COMPLETION_SUPPORTED` contains no `None` entry.

## AI assistance

AI assistance was used to reproduce the issue against current LangChain, strengthen missing-provider coverage, run fault-injection validation, and refine this PR description. The resulting changes and validation evidence were reviewed before submission.
