### PR TITLE
fix(cost): support Bedrock token usage metadata

### DIFF
--- a/src/ragas/cost.py
+++ b/src/ragas/cost.py
@@ -116,27 +116,41 @@ def get_token_usage_for_bedrock(
     for gs in llm_result.generations:
         for g in gs:
             if isinstance(g, ChatGeneration):
-                if g.message.response_metadata != {}:
+                message = g.message
+                response_metadata = message.response_metadata
+
+                if response_metadata:
+                    usage_metadata = getattr(message, "usage_metadata", {}) or {}
+
+                    usage = (
+                        usage_metadata
+                        or get_from_dict(message.additional_kwargs, "usage", {})
+                        or get_from_dict(response_metadata, "usage", {})
+                    )
+
                     token_usages.append(
                         TokenUsage(
                             input_tokens=get_from_dict(
-                                g.message.response_metadata,
-                                "usage.prompt_tokens",
-                                0,
+                                usage,
+                                "input_tokens",
+                                get_from_dict(usage, "prompt_tokens", 0),
                             ),
                             output_tokens=get_from_dict(
-                                g.message.response_metadata,
-                                "usage.completion_tokens",
-                                0,
+                                usage,
+                                "output_tokens",
+                                get_from_dict(usage, "completion_tokens", 0),
                             ),
                             model=get_from_dict(
-                                g.message.response_metadata, "model_id", ""
+                                response_metadata,
+                                "model_name",
+                                get_from_dict(response_metadata, "model_id", ""),
                             ),
                         )
                     )
         model = next((usage.model for usage in token_usages if usage.model), "")
         return sum(
-            token_usages, TokenUsage(input_tokens=0, output_tokens=0, model=model)
+            token_usages,
+            TokenUsage(input_tokens=0, output_tokens=0, model=model),
         )
     return TokenUsage(input_tokens=0, output_tokens=0)
 

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -91,14 +91,14 @@ bedrock_llama_result = LLMResult(
                 text="Hello, world!",
                 message=AIMessage(
                     content="Hello, world!",
+                    usage_metadata={
+                        "input_tokens": 10,
+                        "output_tokens": 10,
+                        "total_tokens": 20,
+                    },
                     response_metadata={
-                        "usage": {
-                            "prompt_tokens": 10,
-                            "completion_tokens": 10,
-                            "total_tokens": 20,
-                        },
-                        "stop_reason": "stop",
-                        "model_id": "us.meta.llama3-1-70b-instruct-v1:0",
+                        "model_provider": "bedrock",
+                        "model_name": "us.meta.llama3-1-70b-instruct-v1:0",
                     },
                 ),
             )
@@ -114,16 +114,60 @@ bedrock_claude_result = LLMResult(
                 text="Hello, world!",
                 message=AIMessage(
                     content="Hello, world!",
+                    usage_metadata={
+                        "input_tokens": 10,
+                        "output_tokens": 10,
+                        "total_tokens": 20,
+                    },
                     response_metadata={
-                        "usage": {
-                            "prompt_tokens": 10,
-                            "completion_tokens": 10,
-                            "total_tokens": 20,
-                        },
-                        "stop_reason": "end_turn",
-                        "model_id": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+                        "model_provider": "bedrock",
+                        "model_name": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
                     },
                 ),
+            )
+        ]
+    ],
+    llm_output={},
+)
+
+# Bedrock legacy response format
+bedrock_legacy_result = LLMResult(
+    generations=[
+        [
+            ChatGeneration(
+                message=AIMessage(
+                    content="Hello",
+                    response_metadata={
+                        "usage": {
+                            "prompt_tokens": 12,
+                            "completion_tokens": 9,
+                        },
+                        "model_id": "legacy-bedrock-model",
+                    },
+                )
+            )
+        ]
+    ],
+    llm_output={},
+)
+
+# Bedrock additional_kwargs response format
+bedrock_additional_kwargs_result = LLMResult(
+    generations=[
+        [
+            ChatGeneration(
+                message=AIMessage(
+                    content="Hello, world!",
+                    additional_kwargs={
+                        "usage": {
+                            "prompt_tokens": 15,
+                            "completion_tokens": 7,
+                        }
+                    },
+                    response_metadata={
+                        "model_name": "test-bedrock-model",
+                    },
+                )
             )
         ]
     ],
@@ -172,6 +216,24 @@ def test_parse_llm_results():
     token_usage = get_token_usage_for_azure_ai(azure_ai_result)
     assert token_usage == TokenUsage(
         input_tokens=10, output_tokens=10, model="mistral-small-2503"
+    )
+
+    # Bedrock additional_kwargs usage format
+    token_usage = get_token_usage_for_bedrock(bedrock_additional_kwargs_result)
+
+    assert token_usage == TokenUsage(
+        input_tokens=15,
+        output_tokens=7,
+        model="test-bedrock-model",
+    )
+
+    # Bedrock legacy response format
+    token_usage = get_token_usage_for_bedrock(bedrock_legacy_result)
+
+    assert token_usage == TokenUsage(
+        input_tokens=12,
+        output_tokens=9,
+        model="legacy-bedrock-model",
     )
 
 


### PR DESCRIPTION
## Summary

This PR updates the Bedrock token usage parser to support newer LangChain response formats while maintaining compatibility with existing ones.

### What's changed

* Added support for `message.usage_metadata`
* Added a fallback to `message.additional_kwargs["usage"]`
* Preserved support for legacy `response_metadata["usage"]`
* Added support for both:

  * `input_tokens` / `output_tokens`
  * `prompt_tokens` / `completion_tokens`
* Resolved model names from `model_name` with a fallback to `model_id`

### Tests

Added unit tests covering:

* Bedrock Llama (`usage_metadata`)
* Bedrock Claude (`usage_metadata`)
* Legacy Bedrock response format
* `additional_kwargs["usage"]` fallback
