### PR TITLE
fix: read Bedrock token usage from usage_metadata and model_name

### DIFF
--- a/src/ragas/cost.py
+++ b/src/ragas/cost.py
@@ -116,20 +116,34 @@ def get_token_usage_for_bedrock(
     for gs in llm_result.generations:
         for g in gs:
             if isinstance(g, ChatGeneration):
-                if g.message.response_metadata != {}:
+                # langchain-aws ChatBedrock / ChatBedrockConverse expose token
+                # counts on the message-level usage_metadata and the model under
+                # response_metadata["model_name"]. Older releases used
+                # response_metadata["usage"] and "model_id"; kept as fallbacks.
+                usage_metadata = getattr(g.message, "usage_metadata", None) or {}
+                if usage_metadata or g.message.response_metadata != {}:
                     token_usages.append(
                         TokenUsage(
-                            input_tokens=get_from_dict(
-                                g.message.response_metadata,
-                                "usage.prompt_tokens",
-                                0,
+                            input_tokens=usage_metadata.get(
+                                "input_tokens",
+                                get_from_dict(
+                                    g.message.response_metadata,
+                                    "usage.prompt_tokens",
+                                    0,
+                                ),
                             ),
-                            output_tokens=get_from_dict(
-                                g.message.response_metadata,
-                                "usage.completion_tokens",
-                                0,
+                            output_tokens=usage_metadata.get(
+                                "output_tokens",
+                                get_from_dict(
+                                    g.message.response_metadata,
+                                    "usage.completion_tokens",
+                                    0,
+                                ),
                             ),
                             model=get_from_dict(
+                                g.message.response_metadata, "model_name", ""
+                            )
+                            or get_from_dict(
                                 g.message.response_metadata, "model_id", ""
                             ),
                         )

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -130,6 +130,32 @@ bedrock_claude_result = LLMResult(
     llm_output={},
 )
 
+# Current langchain-aws ChatBedrock / ChatBedrockConverse shape: token counts on
+# the message-level usage_metadata, model under response_metadata["model_name"].
+bedrock_converse_result = LLMResult(
+    generations=[
+        [
+            ChatGeneration(
+                text="Hello, world!",
+                message=AIMessage(
+                    content="Hello, world!",
+                    usage_metadata={
+                        "input_tokens": 10,
+                        "output_tokens": 10,
+                        "total_tokens": 20,
+                    },
+                    response_metadata={
+                        "model_provider": "bedrock",
+                        "model_name": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+                        "stop_reason": "end_turn",
+                    },
+                ),
+            )
+        ]
+    ],
+    llm_output={},
+)
+
 azure_ai_result = LLMResult(
     generations=[[ChatGeneration(message=AIMessage(content="Hello, world!"))]],
     llm_output={
@@ -162,6 +188,14 @@ def test_parse_llm_results():
 
     # Bedrock Claude
     token_usage = get_token_usage_for_bedrock(bedrock_claude_result)
+    assert token_usage == TokenUsage(
+        input_tokens=10,
+        output_tokens=10,
+        model="us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+    )
+
+    # Bedrock via current langchain-aws (usage_metadata + model_name)
+    token_usage = get_token_usage_for_bedrock(bedrock_converse_result)
     assert token_usage == TokenUsage(
         input_tokens=10,
         output_tokens=10,


### PR DESCRIPTION
## Issue Link / Problem Description
- Fixes #2779 — `get_token_usage_for_bedrock` always returned 0 tokens / empty model, so Bedrock cost was always 0.

## Changes Made
- Prefer the message-level `usage_metadata` (`input_tokens`/`output_tokens`) that langchain-aws `ChatBedrock`/`ChatBedrockConverse` actually populate, keeping the old `response_metadata['usage']` paths as fallbacks for older releases.
- Read the model from `response_metadata['model_name']` with fallback to the legacy `model_id`.
- Added a `bedrock_converse_result` fixture matching the current langchain-aws response shape.

## Testing
### How to Test
- [x] Automated tests added/updated
- Run `pytest tests/unit/test_cost.py` — the new fixture fails on main (returns 0 tokens) and passes with this change; the legacy-shape fixtures still pass.