### PR TITLE
fix: use >= threshold in NonLLMContextRecall for consistency

### DIFF
--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -216,7 +216,9 @@ class NonLLMContextRecall(SingleTurnMetric):
         return await self._single_turn_ascore(SingleTurnSample(**row), callbacks)
 
     def _compute_score(self, verdict_list: t.List[float]) -> float:
-        response = [1 if score > self.threshold else 0 for score in verdict_list]
+        # >= so a score exactly at the threshold counts as relevant, consistent
+        # with NonLLMContextPrecisionWithReference.
+        response = [1 if score >= self.threshold else 0 for score in verdict_list]
         denom = len(response)
         numerator = sum(response)
         score = numerator / denom if denom > 0 else np.nan

--- a/tests/unit/test_context_threshold_boundary.py
+++ b/tests/unit/test_context_threshold_boundary.py
@@ -1,0 +1,17 @@
+"""Threshold boundary behavior for the non-LLM context metrics (#2777)."""
+
+from ragas.metrics import NonLLMContextRecall
+
+
+def test_non_llm_context_recall_score_at_threshold_counts_as_relevant():
+    """A similarity score exactly equal to the threshold is relevant, consistent
+    with NonLLMContextPrecisionWithReference's `>=` comparison."""
+    metric = NonLLMContextRecall()
+    assert metric.threshold == 0.5
+    assert metric._compute_score([0.5]) == 1.0
+
+
+def test_non_llm_context_recall_scores_below_threshold_not_relevant():
+    metric = NonLLMContextRecall()
+    assert metric._compute_score([0.49, 0.51]) == 0.5
+    assert metric._compute_score([0.1, 0.2]) == 0.0


### PR DESCRIPTION
## Issue Link / Problem Description
- Fixes #2777 — `NonLLMContextRecall` uses strict `>` on the shared `threshold` while `NonLLMContextPrecisionWithReference` uses `>=`, so a similarity score of exactly 0.5 (the shared default) is relevant for precision but not recall.

## Changes Made
- Align `NonLLMContextRecall._compute_score` on `>=`, matching precision's boundary semantics.

## Testing
### How to Test
- [x] Automated tests added/updated
- Run `pytest tests/unit/test_context_threshold_boundary.py` — the at-threshold case fails on main and passes with this change.