### PR TITLE
fix(prompt): top_k=0 returns no examples in InMemoryExampleStore

### DIFF
--- a/src/ragas/prompt/few_shot_pydantic_prompt.py
+++ b/src/ragas/prompt/few_shot_pydantic_prompt.py
@@ -68,6 +68,10 @@ class InMemoryExampleStore(ExampleStore):
         top_k: int = 3,
         threshold: float = 0.7,
     ) -> t.List[int]:
+        # top_k=0 must select nothing; guard against numpy's -0 slice returning all
+        if top_k <= 0:
+            return []
+
         # Convert to numpy arrays for efficient computation
         query = np.array(query_embedding)
         embed_matrix = np.array(embeddings)

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -267,3 +267,20 @@ def test_in_memory_example_store():
     assert store.get_examples(FakeInputModel(text="hello", embedding=[1, 2, 3])) == [
         FakeOutputModel(text="hello")
     ]
+
+
+def test_get_nearest_examples_respects_top_k():
+    from ragas.prompt import InMemoryExampleStore
+
+    query = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.9, 0.1], [0.8, 0.2]]
+
+    top_2 = InMemoryExampleStore.get_nearest_examples(
+        query, embeddings, top_k=2, threshold=0.0
+    )
+    assert len(top_2) == 2
+
+    top_0 = InMemoryExampleStore.get_nearest_examples(
+        query, embeddings, top_k=0, threshold=0.0
+    )
+    assert top_0 == []


### PR DESCRIPTION
Closes #2877.

`get_nearest_examples` selects the top matches with `np.argsort(...)[-top_k:]`. When `top_k=0` that slice is `[-0:]`, which numpy treats as `[0:]`, so it returns every example above the threshold instead of none.

Same root cause as the `SimpleInMemoryExampleStore` fix in #2872, but that one doesn't reach this store.

## Summary
- Guard `top_k <= 0` in `InMemoryExampleStore.get_nearest_examples` and return an empty list
- Add a regression test covering `top_k=2` and `top_k=0`

## Test plan
- [x] `uv run pytest tests/unit/test_prompt.py -k top_k`
- [x] Confirm the new test fails on `main` and passes with this change
