### PR TITLE
feat(metrics): add SQLSchemaHallucination metric

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ all = [
     "rapidfuzz",
     "pandas",
     "datacompy",
+    "sqlparse",
     "sacrebleu",
     "llama_index",
     "r2r",

--- a/src/ragas/metrics/collections/__init__.py
+++ b/src/ragas/metrics/collections/__init__.py
@@ -42,6 +42,7 @@ from ragas.metrics.collections.multi_modal_relevance import MultiModalRelevance
 from ragas.metrics.collections.noise_sensitivity import NoiseSensitivity
 from ragas.metrics.collections.quoted_spans import QuotedSpansAlignment
 from ragas.metrics.collections.response_groundedness import ResponseGroundedness
+from ragas.metrics.collections.sql_schema_hallucination import SQLSchemaHallucination
 from ragas.metrics.collections.sql_semantic_equivalence import SQLSemanticEquivalence
 from ragas.metrics.collections.summary_score import SummaryScore
 from ragas.metrics.collections.tool_call_accuracy import ToolCallAccuracy
@@ -91,5 +92,6 @@ __all__ = [
     "RubricsScoreWithReference",
     # SQL & Data metrics
     "DataCompyScore",
+    "SQLSchemaHallucination",
     "SQLSemanticEquivalence",
 ]

--- a/src/ragas/metrics/collections/sql_schema_hallucination/__init__.py
+++ b/src/ragas/metrics/collections/sql_schema_hallucination/__init__.py
@@ -1,0 +1,7 @@
+"""SQLSchemaHallucination metric - Modern collections implementation."""
+
+from ragas.metrics.collections.sql_schema_hallucination.metric import (
+    SQLSchemaHallucination,
+)
+
+__all__ = ["SQLSchemaHallucination"]

--- a/src/ragas/metrics/collections/sql_schema_hallucination/metric.py
+++ b/src/ragas/metrics/collections/sql_schema_hallucination/metric.py
@@ -1,0 +1,95 @@
+"""SQLSchemaHallucination metric - Modern collections implementation."""
+
+import typing as t
+
+from ragas.metrics.collections.base import BaseMetric
+from ragas.metrics.result import MetricResult
+
+from .util import Schema, extract_references, score_references
+
+
+class SQLSchemaHallucination(BaseMetric):
+    """
+    Measure how much a generated SQL query references a schema that exists.
+
+    Text-to-SQL models often invent plausible but non-existent tables and
+    columns, especially over wide schemas. This non-LLM metric parses the query,
+    collects the tables and columns it references, and checks them against a
+    provided schema. The score is the fraction of references that are valid, so
+    1.0 means no hallucinated references and lower values mean the query names
+    tables or columns the schema does not contain.
+
+    ``SELECT *`` and function calls claim no specific column and are ignored.
+    In-query aliases and CTE names are resolved and never counted as
+    hallucinations. A query that references nothing (e.g. ``SELECT *``) scores
+    1.0.
+
+    Usage:
+        >>> from ragas.metrics.collections import SQLSchemaHallucination
+        >>>
+        >>> metric = SQLSchemaHallucination()
+        >>>
+        >>> result = await metric.ascore(
+        ...     response="SELECT emial FROM users",
+        ...     schema={"users": ["id", "name", "email"]},
+        ... )
+        >>> print(result.value)  # 0.5 - 'emial' is hallucinated
+        >>> print(result.reason)
+
+    Attributes:
+        name: The metric name (default: "sql_schema_hallucination")
+        allowed_values: Score range (0.0 to 1.0)
+    """
+
+    def __init__(
+        self,
+        name: str = "sql_schema_hallucination",
+        **base_kwargs,
+    ):
+        super().__init__(name=name, **base_kwargs)
+
+        try:
+            import sqlparse  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                f"{e.name} is required for SQLSchemaHallucination. "
+                f"Please install it using `pip install {e.name}`"
+            )
+
+    async def ascore(
+        self,
+        response: str,
+        schema: Schema,
+    ) -> MetricResult:
+        """
+        Calculate the schema hallucination score for a generated SQL query.
+
+        Args:
+            response: The generated SQL query to evaluate.
+            schema: Mapping of table name to its column names, e.g.
+                ``{"users": ["id", "name"], "orders": ["id", "user_id"]}``.
+
+        Returns:
+            MetricResult with the fraction of valid references (0.0-1.0). The
+            reason lists any hallucinated references.
+        """
+        if not isinstance(response, str) or not response.strip():
+            raise ValueError("response must be a non-empty SQL query string")
+        if not isinstance(schema, t.Mapping) or not schema:
+            raise ValueError("schema must be a non-empty mapping of table to columns")
+
+        references = extract_references(response)
+        valid, total, hallucinated = score_references(references, schema)
+
+        if total == 0:
+            return MetricResult(
+                value=1.0,
+                reason="No table or column references to validate",
+            )
+
+        score = valid / total
+        reason = f"Valid references {valid}/{total}"
+        if hallucinated:
+            reason += f"; hallucinated: {', '.join(sorted(hallucinated))}"
+
+        return MetricResult(value=float(score), reason=reason)

--- a/src/ragas/metrics/collections/sql_schema_hallucination/util.py
+++ b/src/ragas/metrics/collections/sql_schema_hallucination/util.py
@@ -52,12 +52,30 @@ class _Scope:
     never affect validation in the enclosing query.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, parent: t.Optional["_Scope"] = None) -> None:
+        self.parent = parent
         self.tables: t.Set[str] = set()
         self.alias_to_table: t.Dict[str, str] = {}
         self.virtual: t.Set[str] = set()  # CTE and derived-table names
         self.raw_columns: t.Set[t.Tuple[t.Optional[str], str]] = set()
         self.aliases: t.Set[str] = set()  # column aliases to ignore
+
+    def lookup_alias(self, name: str) -> t.Optional[str]:
+        """Resolve a table alias, walking outer scopes for correlated queries."""
+        scope: t.Optional["_Scope"] = self
+        while scope is not None:
+            if name in scope.alias_to_table:
+                return scope.alias_to_table[name]
+            scope = scope.parent
+        return None
+
+    def is_virtual(self, name: str) -> bool:
+        scope: t.Optional["_Scope"] = self
+        while scope is not None:
+            if name in scope.virtual:
+                return True
+            scope = scope.parent
+        return False
 
 
 def _clean(name: t.Optional[str]) -> t.Optional[str]:
@@ -138,7 +156,7 @@ def _descend_parenthesis(
 ) -> None:
     """A subquery gets its own scope; any other parenthesis stays in-scope."""
     if _has_select(paren):
-        child = _Scope()
+        child = _Scope(parent=scope)
         scopes.append(child)
         _walk(paren, "COLUMN", child, scopes)
     else:
@@ -210,10 +228,10 @@ def _resolve(
         if qualifier is None:
             unqualified.add((scope_tables, name))
             continue
-        if qualifier in scope.virtual:
+        if scope.is_virtual(qualifier):
             continue
-        resolved = scope.alias_to_table.get(qualifier, qualifier)
-        if resolved in scope.virtual:
+        resolved = scope.lookup_alias(qualifier) or qualifier
+        if scope.is_virtual(resolved):
             continue
         qualified.add((resolved, name))
 

--- a/src/ragas/metrics/collections/sql_schema_hallucination/util.py
+++ b/src/ragas/metrics/collections/sql_schema_hallucination/util.py
@@ -28,14 +28,28 @@ _COLUMN_CONTEXT = {"SELECT", "WHERE", "ON", "GROUP BY", "ORDER BY", "HAVING", "S
 
 class SQLReferences(t.NamedTuple):
     tables: t.Set[str]
-    columns: t.Set[t.Tuple[t.Optional[str], str]]
+    # Columns qualified by a table name, as (table, column).
+    qualified: t.Set[t.Tuple[str, str]]
+    # Unqualified columns paired with the tables visible in their query scope,
+    # so they are validated only against those tables and never leak across
+    # subquery / CTE boundaries.
+    unqualified: t.Set[t.Tuple[t.FrozenSet[str], str]]
+
+    @property
+    def columns(self) -> t.Set[t.Tuple[t.Optional[str], str]]:
+        """Flat view of all column references for introspection and tests."""
+        flat: t.Set[t.Tuple[t.Optional[str], str]] = {
+            (table, col) for table, col in self.qualified
+        }
+        flat |= {(None, col) for _, col in self.unqualified}
+        return flat
 
 
 class _Scope:
-    """Table/column references collected within a single query scope.
+    """References collected within one query scope (a SELECT or DML statement).
 
-    A scope is one ``SELECT`` (or DML statement). Subqueries and CTEs form their
-    own nested scopes so their aliases never leak out as schema references.
+    Subqueries and CTE bodies get their own scope so their tables and aliases
+    never affect validation in the enclosing query.
     """
 
     def __init__(self) -> None:
@@ -81,8 +95,8 @@ def _collect_ctes(statement: TokenList) -> t.Set[str]:
     return ctes
 
 
-def _walk(statement: TokenList, context: str, scope: _Scope) -> None:
-    for token in statement.tokens:
+def _walk(node: TokenList, context: str, scope: _Scope, scopes: t.List[_Scope]) -> None:
+    for token in node.tokens:
         if token.is_whitespace:
             continue
 
@@ -98,28 +112,42 @@ def _walk(statement: TokenList, context: str, scope: _Scope) -> None:
             continue
 
         if isinstance(token, Where):
-            _walk(token, "COLUMN", scope)
+            _walk(token, "COLUMN", scope, scopes)
             continue
         if isinstance(token, Parenthesis):
-            _walk(token, "COLUMN", scope)
+            _descend_parenthesis(token, context, scope, scopes)
             continue
 
         if isinstance(token, (Identifier, IdentifierList)):
             for child in _tokens(token):
-                _handle(child, context, scope)
+                _handle(child, context, scope, scopes)
             continue
 
         if isinstance(token, Function):
-            _handle(token, context, scope)
+            _handle(token, context, scope, scopes)
             continue
 
         # Recurse into grouped tokens like Comparison or Operation so nested
         # identifiers (e.g. a WHERE predicate) are still classified.
         if isinstance(token, TokenList):
-            _walk(token, context, scope)
+            _walk(token, context, scope, scopes)
 
 
-def _handle(identifier: t.Any, context: str, scope: _Scope) -> None:
+def _descend_parenthesis(
+    paren: Parenthesis, context: str, scope: _Scope, scopes: t.List[_Scope]
+) -> None:
+    """A subquery gets its own scope; any other parenthesis stays in-scope."""
+    if _has_select(paren):
+        child = _Scope()
+        scopes.append(child)
+        _walk(paren, "COLUMN", child, scopes)
+    else:
+        _walk(paren, context, scope, scopes)
+
+
+def _handle(
+    identifier: t.Any, context: str, scope: _Scope, scopes: t.List[_Scope]
+) -> None:
     # A function call: its name is not a column, but its arguments may be. In a
     # table context ``table (col, col)`` also parses as a function (e.g. the
     # target of INSERT INTO), so the name is the table there.
@@ -131,7 +159,7 @@ def _handle(identifier: t.Any, context: str, scope: _Scope) -> None:
             (tok for tok in identifier.tokens if isinstance(tok, Parenthesis)), None
         )
         if paren is not None:
-            _walk(paren, "COLUMN", scope)
+            _descend_parenthesis(paren, "COLUMN", scope, scopes)
         return
     if not isinstance(identifier, Identifier):
         return
@@ -139,21 +167,14 @@ def _handle(identifier: t.Any, context: str, scope: _Scope) -> None:
     paren = next(
         (tok for tok in identifier.tokens if isinstance(tok, Parenthesis)), None
     )
-    if paren is not None:
+    if paren is not None and _has_select(paren):
+        # Derived table: (SELECT ...) alias. The alias is virtual in this scope
+        # and the subquery is walked as its own scope.
         alias = _clean(identifier.get_alias())
-        if _has_select(paren):
-            # Derived table: (SELECT ...) alias. The alias is virtual and its
-            # inner scope is walked so real tables inside are still checked.
-            if alias:
-                scope.virtual.add(alias)
-                scope.aliases.add(alias)
-            _walk(paren, "COLUMN", scope)
-            return
-        # INSERT-style ``table (col, col)``: the name is a table, parens columns.
-        name = _clean(identifier.get_real_name())
-        if name and context == "TABLE":
-            scope.tables.add(name)
-        _walk(paren, "COLUMN", scope)
+        if alias:
+            scope.virtual.add(alias)
+            scope.aliases.add(alias)
+        _descend_parenthesis(paren, "COLUMN", scope, scopes)
         return
 
     alias = _clean(identifier.get_alias())
@@ -173,32 +194,40 @@ def _handle(identifier: t.Any, context: str, scope: _Scope) -> None:
         scope.raw_columns.add((qualifier, real))
 
 
-def _resolve(scope: _Scope) -> SQLReferences:
+def _resolve(
+    scope: _Scope,
+) -> t.Tuple[
+    t.Set[str], t.Set[t.Tuple[str, str]], t.Set[t.Tuple[t.FrozenSet[str], str]]
+]:
     tables = scope.tables - scope.virtual
+    scope_tables = frozenset(tables)
 
-    columns: t.Set[t.Tuple[t.Optional[str], str]] = set()
+    qualified: t.Set[t.Tuple[str, str]] = set()
+    unqualified: t.Set[t.Tuple[t.FrozenSet[str], str]] = set()
     for qualifier, name in scope.raw_columns:
         if name in scope.aliases:
             continue
         if qualifier is None:
-            columns.add((None, name))
+            unqualified.add((scope_tables, name))
             continue
         if qualifier in scope.virtual:
             continue
         resolved = scope.alias_to_table.get(qualifier, qualifier)
         if resolved in scope.virtual:
             continue
-        columns.add((resolved, name))
+        qualified.add((resolved, name))
 
-    return SQLReferences(tables=tables, columns=columns)
+    return tables, qualified, unqualified
 
 
 def extract_references(sql: str) -> SQLReferences:
     """Extract table and column references from a SQL query.
 
     Handles multiple statements, joins, functions, subqueries, CTEs and simple
-    DML. In-query aliases and CTE / derived-table names are resolved and never
-    counted as references. ``*`` wildcards and function names are ignored.
+    DML. Subqueries and CTE bodies form their own scope, so an unqualified
+    column is validated only against the tables of its own query. In-query
+    aliases and CTE / derived-table names are resolved and never counted as
+    references. ``*`` wildcards and function names are ignored.
 
     Note: schema-qualified names deeper than ``table.column`` (e.g.
     ``db.schema.table``) are not resolved, matching the flat ``{table: columns}``
@@ -207,16 +236,20 @@ def extract_references(sql: str) -> SQLReferences:
     assert sqlparse is not None, "sqlparse is required for SQLSchemaHallucination"
 
     tables: t.Set[str] = set()
-    columns: t.Set[t.Tuple[t.Optional[str], str]] = set()
+    qualified: t.Set[t.Tuple[str, str]] = set()
+    unqualified: t.Set[t.Tuple[t.FrozenSet[str], str]] = set()
     for statement in sqlparse.parse(sql):
-        scope = _Scope()
-        scope.virtual |= _collect_ctes(statement)
-        _walk(statement, "COLUMN", scope)
-        refs = _resolve(scope)
-        tables |= refs.tables
-        columns |= refs.columns
+        root = _Scope()
+        root.virtual |= _collect_ctes(statement)
+        scopes: t.List[_Scope] = [root]
+        _walk(statement, "COLUMN", root, scopes)
+        for scope in scopes:
+            scope_tables, scope_qualified, scope_unqualified = _resolve(scope)
+            tables |= scope_tables
+            qualified |= scope_qualified
+            unqualified |= scope_unqualified
 
-    return SQLReferences(tables=tables, columns=columns)
+    return SQLReferences(tables=tables, qualified=qualified, unqualified=unqualified)
 
 
 def _normalize_schema(schema: Schema) -> t.Dict[str, t.Set[str]]:
@@ -231,19 +264,13 @@ def score_references(
 ) -> t.Tuple[int, int, t.List[str]]:
     """Count references that exist in the schema.
 
-    Unqualified columns are validated against the columns of the tables the
-    query actually references, not the whole schema, so a column that exists in
-    some unrelated table is still flagged. Returns (valid, total, hallucinated).
+    Unqualified columns are validated against the columns of the tables their
+    own query scope references, so a column that only exists in an unrelated
+    table (or in a subquery) is still flagged. Returns (valid, total,
+    hallucinated).
     """
     normalized = _normalize_schema(schema)
-
-    referenced_columns: t.Set[str] = set()
-    for table in references.tables:
-        referenced_columns |= normalized.get(table.lower(), set())
-    if not referenced_columns:
-        # No referenced table is in the schema; fall back to the whole schema so
-        # a bad table name does not also flag every column as hallucinated.
-        referenced_columns = {col for cols in normalized.values() for col in cols}
+    all_columns = {col for cols in normalized.values() for col in cols}
 
     valid = 0
     total = 0
@@ -256,16 +283,23 @@ def score_references(
         else:
             hallucinated.append(table)
 
-    for qualifier, column in references.columns:
+    for table, column in references.qualified:
         total += 1
-        col = column.lower()
-        if qualifier is not None:
-            table = qualifier.lower()
-            if table in normalized and col in normalized[table]:
-                valid += 1
-            else:
-                hallucinated.append(f"{qualifier}.{column}")
-        elif col in referenced_columns:
+        if table.lower() in normalized and column.lower() in normalized[table.lower()]:
+            valid += 1
+        else:
+            hallucinated.append(f"{table}.{column}")
+
+    for scope_tables, column in references.unqualified:
+        total += 1
+        referenced = set()
+        for table in scope_tables:
+            referenced |= normalized.get(table.lower(), set())
+        # No referenced table is in the schema; fall back to the whole schema so
+        # a bad table name does not also flag every column as hallucinated.
+        if not referenced:
+            referenced = all_columns
+        if column.lower() in referenced:
             valid += 1
         else:
             hallucinated.append(column)

--- a/src/ragas/metrics/collections/sql_schema_hallucination/util.py
+++ b/src/ragas/metrics/collections/sql_schema_hallucination/util.py
@@ -1,0 +1,219 @@
+"""SQL schema hallucination utility functions."""
+
+from __future__ import annotations
+
+import typing as t
+
+try:
+    import sqlparse
+    from sqlparse.sql import (
+        Function,
+        Identifier,
+        IdentifierList,
+        Parenthesis,
+        TokenList,
+        Where,
+    )
+    from sqlparse.tokens import DML, Keyword
+except ImportError:  # pragma: no cover - surfaced at metric init with guidance
+    sqlparse = None  # type: ignore[assignment]
+
+Schema = t.Mapping[str, t.Sequence[str]]
+
+# Keywords whose following identifiers name tables rather than columns.
+_TABLE_CONTEXT = {"FROM", "JOIN", "INTO", "UPDATE"}
+# Keywords that return us to a column context.
+_COLUMN_CONTEXT = {"SELECT", "WHERE", "ON", "GROUP BY", "ORDER BY", "HAVING", "SET"}
+
+
+class SQLReferences(t.NamedTuple):
+    tables: t.Set[str]
+    columns: t.Set[t.Tuple[t.Optional[str], str]]
+
+
+def _clean(name: t.Optional[str]) -> t.Optional[str]:
+    return name.strip('"`[]') if name else None
+
+
+def _children(token: TokenList) -> t.Iterator[Identifier]:
+    """Yield Identifier children, flattening an IdentifierList."""
+    if isinstance(token, IdentifierList):
+        source: t.Iterable[t.Any] = token.get_identifiers()  # type: ignore[attr-defined]
+    else:
+        source = [token]
+    for child in source:
+        if isinstance(child, Identifier):
+            yield child
+
+
+def _collect_ctes(statement: TokenList) -> t.Set[str]:
+    ctes: t.Set[str] = set()
+    after_with = False
+    for token in statement.tokens:
+        if token.is_whitespace:
+            continue
+        if token.normalized == "WITH":
+            after_with = True
+            continue
+        if after_with:
+            if isinstance(token, (Identifier, IdentifierList)):
+                for identifier in _children(token):
+                    name = _clean(identifier.get_real_name())
+                    if name:
+                        ctes.add(name)
+            after_with = False
+    return ctes
+
+
+def _walk(
+    statement: TokenList,
+    context: str,
+    tables: t.Set[str],
+    alias_to_table: t.Dict[str, str],
+    columns: t.Set[t.Tuple[t.Optional[str], str]],
+    aliases: t.Set[str],
+) -> None:
+    for token in statement.tokens:
+        if token.is_whitespace:
+            continue
+
+        if token.ttype is DML and token.normalized == "SELECT":
+            context = "COLUMN"
+            continue
+        if token.ttype is Keyword:
+            upper = token.normalized.upper()
+            if upper in _TABLE_CONTEXT or upper.endswith("JOIN"):
+                context = "TABLE"
+            elif upper in _COLUMN_CONTEXT:
+                context = "COLUMN"
+            continue
+
+        if isinstance(token, Where):
+            _walk(token, "COLUMN", tables, alias_to_table, columns, aliases)
+            continue
+        if isinstance(token, Parenthesis):
+            _walk(token, "COLUMN", tables, alias_to_table, columns, aliases)
+            continue
+
+        if isinstance(token, (Identifier, IdentifierList)):
+            for identifier in _children(token):
+                _handle_identifier(
+                    identifier, context, tables, alias_to_table, columns, aliases
+                )
+            continue
+
+        # Recurse into grouped tokens like Comparison or Operation (e.g. a WHERE
+        # predicate) so identifiers nested inside them are still classified.
+        if isinstance(token, TokenList) and not isinstance(token, Function):
+            _walk(token, context, tables, alias_to_table, columns, aliases)
+
+
+def _handle_identifier(
+    identifier: Identifier,
+    context: str,
+    tables: t.Set[str],
+    alias_to_table: t.Dict[str, str],
+    columns: t.Set[t.Tuple[t.Optional[str], str]],
+    aliases: t.Set[str],
+) -> None:
+    if isinstance(identifier, Function):
+        return
+
+    # A subquery aliased as a derived table: recurse, don't treat as a reference.
+    if any(isinstance(tok, Parenthesis) for tok in identifier.tokens):
+        _walk(identifier, "COLUMN", tables, alias_to_table, columns, aliases)
+        return
+
+    alias = _clean(identifier.get_alias())
+    if alias:
+        aliases.add(alias)
+
+    real = _clean(identifier.get_real_name())
+    if not real:
+        return
+
+    if context == "TABLE":
+        tables.add(real)
+        if alias:
+            alias_to_table[alias] = real
+    else:
+        qualifier = _clean(identifier.get_parent_name())
+        columns.add((qualifier, real))
+
+
+def extract_references(sql: str) -> SQLReferences:
+    """Extract table and column references from a SQL query.
+
+    In-query aliases and CTE names are excluded, as are ``*`` wildcards and
+    function calls. Qualifiers on columns are resolved through table aliases so
+    ``u.email`` on ``FROM users u`` validates against ``users``.
+    """
+    assert sqlparse is not None, "sqlparse is required for SQLSchemaHallucination"
+    parsed = sqlparse.parse(sql)
+    if not parsed:
+        return SQLReferences(tables=set(), columns=set())
+    statement = parsed[0]
+    ctes = _collect_ctes(statement)
+
+    tables: t.Set[str] = set()
+    alias_to_table: t.Dict[str, str] = {}
+    raw_columns: t.Set[t.Tuple[t.Optional[str], str]] = set()
+    aliases: t.Set[str] = set()
+    _walk(statement, "COLUMN", tables, alias_to_table, raw_columns, aliases)
+
+    tables -= ctes
+
+    columns: t.Set[t.Tuple[t.Optional[str], str]] = set()
+    for qualifier, name in raw_columns:
+        if name in aliases:
+            continue
+        resolved = alias_to_table.get(qualifier, qualifier) if qualifier else None
+        columns.add((resolved, name))
+
+    return SQLReferences(tables=tables, columns=columns)
+
+
+def _normalize_schema(schema: Schema) -> t.Dict[str, t.Set[str]]:
+    return {
+        table.lower(): {col.lower() for col in cols} for table, cols in schema.items()
+    }
+
+
+def score_references(
+    references: SQLReferences,
+    schema: Schema,
+) -> t.Tuple[int, int, t.List[str]]:
+    """Count references that exist in the schema.
+
+    Returns (valid_count, total_count, hallucinated) where ``hallucinated`` lists
+    the offending references for diagnostics.
+    """
+    normalized = _normalize_schema(schema)
+    all_columns = {col for cols in normalized.values() for col in cols}
+
+    valid = 0
+    total = 0
+    hallucinated: t.List[str] = []
+
+    for table in references.tables:
+        total += 1
+        if table.lower() in normalized:
+            valid += 1
+        else:
+            hallucinated.append(table)
+
+    for qualifier, column in references.columns:
+        total += 1
+        col = column.lower()
+        if qualifier is not None:
+            table = qualifier.lower()
+            if table in normalized and col in normalized[table]:
+                valid += 1
+            else:
+                hallucinated.append(f"{qualifier}.{column}")
+        elif col in all_columns:
+            valid += 1
+        else:
+            hallucinated.append(column)
+
+    return valid, total, hallucinated

--- a/src/ragas/metrics/collections/sql_schema_hallucination/util.py
+++ b/src/ragas/metrics/collections/sql_schema_hallucination/util.py
@@ -21,7 +21,7 @@ except ImportError:  # pragma: no cover - surfaced at metric init with guidance
 Schema = t.Mapping[str, t.Sequence[str]]
 
 # Keywords whose following identifiers name tables rather than columns.
-_TABLE_CONTEXT = {"FROM", "JOIN", "INTO", "UPDATE"}
+_TABLE_CONTEXT = {"FROM", "INTO", "UPDATE"}
 # Keywords that return us to a column context.
 _COLUMN_CONTEXT = {"SELECT", "WHERE", "ON", "GROUP BY", "ORDER BY", "HAVING", "SET"}
 
@@ -31,19 +31,35 @@ class SQLReferences(t.NamedTuple):
     columns: t.Set[t.Tuple[t.Optional[str], str]]
 
 
+class _Scope:
+    """Table/column references collected within a single query scope.
+
+    A scope is one ``SELECT`` (or DML statement). Subqueries and CTEs form their
+    own nested scopes so their aliases never leak out as schema references.
+    """
+
+    def __init__(self) -> None:
+        self.tables: t.Set[str] = set()
+        self.alias_to_table: t.Dict[str, str] = {}
+        self.virtual: t.Set[str] = set()  # CTE and derived-table names
+        self.raw_columns: t.Set[t.Tuple[t.Optional[str], str]] = set()
+        self.aliases: t.Set[str] = set()  # column aliases to ignore
+
+
 def _clean(name: t.Optional[str]) -> t.Optional[str]:
     return name.strip('"`[]') if name else None
 
 
-def _children(token: TokenList) -> t.Iterator[Identifier]:
-    """Yield Identifier children, flattening an IdentifierList."""
+def _tokens(token: TokenList) -> t.Iterator[t.Any]:
+    """Yield the meaningful children of a token, flattening an IdentifierList."""
     if isinstance(token, IdentifierList):
-        source: t.Iterable[t.Any] = token.get_identifiers()  # type: ignore[attr-defined]
+        yield from token.get_identifiers()  # type: ignore[attr-defined]
     else:
-        source = [token]
-    for child in source:
-        if isinstance(child, Identifier):
-            yield child
+        yield token
+
+
+def _has_select(token: TokenList) -> bool:
+    return any(getattr(tok, "ttype", None) is DML for tok in token.flatten())
 
 
 def _collect_ctes(statement: TokenList) -> t.Set[str]:
@@ -57,28 +73,21 @@ def _collect_ctes(statement: TokenList) -> t.Set[str]:
             continue
         if after_with:
             if isinstance(token, (Identifier, IdentifierList)):
-                for identifier in _children(token):
-                    name = _clean(identifier.get_real_name())
+                for child in _tokens(token):
+                    name = _clean(child.get_real_name())
                     if name:
                         ctes.add(name)
             after_with = False
     return ctes
 
 
-def _walk(
-    statement: TokenList,
-    context: str,
-    tables: t.Set[str],
-    alias_to_table: t.Dict[str, str],
-    columns: t.Set[t.Tuple[t.Optional[str], str]],
-    aliases: t.Set[str],
-) -> None:
+def _walk(statement: TokenList, context: str, scope: _Scope) -> None:
     for token in statement.tokens:
         if token.is_whitespace:
             continue
 
-        if token.ttype is DML and token.normalized == "SELECT":
-            context = "COLUMN"
+        if token.ttype is DML:
+            context = "TABLE" if token.normalized.upper() == "UPDATE" else "COLUMN"
             continue
         if token.ttype is Keyword:
             upper = token.normalized.upper()
@@ -89,86 +98,123 @@ def _walk(
             continue
 
         if isinstance(token, Where):
-            _walk(token, "COLUMN", tables, alias_to_table, columns, aliases)
+            _walk(token, "COLUMN", scope)
             continue
         if isinstance(token, Parenthesis):
-            _walk(token, "COLUMN", tables, alias_to_table, columns, aliases)
+            _walk(token, "COLUMN", scope)
             continue
 
         if isinstance(token, (Identifier, IdentifierList)):
-            for identifier in _children(token):
-                _handle_identifier(
-                    identifier, context, tables, alias_to_table, columns, aliases
-                )
+            for child in _tokens(token):
+                _handle(child, context, scope)
             continue
 
-        # Recurse into grouped tokens like Comparison or Operation (e.g. a WHERE
-        # predicate) so identifiers nested inside them are still classified.
-        if isinstance(token, TokenList) and not isinstance(token, Function):
-            _walk(token, context, tables, alias_to_table, columns, aliases)
+        if isinstance(token, Function):
+            _handle(token, context, scope)
+            continue
+
+        # Recurse into grouped tokens like Comparison or Operation so nested
+        # identifiers (e.g. a WHERE predicate) are still classified.
+        if isinstance(token, TokenList):
+            _walk(token, context, scope)
 
 
-def _handle_identifier(
-    identifier: Identifier,
-    context: str,
-    tables: t.Set[str],
-    alias_to_table: t.Dict[str, str],
-    columns: t.Set[t.Tuple[t.Optional[str], str]],
-    aliases: t.Set[str],
-) -> None:
+def _handle(identifier: t.Any, context: str, scope: _Scope) -> None:
+    # A function call: its name is not a column, but its arguments may be. In a
+    # table context ``table (col, col)`` also parses as a function (e.g. the
+    # target of INSERT INTO), so the name is the table there.
     if isinstance(identifier, Function):
+        name = _clean(identifier.get_real_name())
+        if context == "TABLE" and name:
+            scope.tables.add(name)
+        paren = next(
+            (tok for tok in identifier.tokens if isinstance(tok, Parenthesis)), None
+        )
+        if paren is not None:
+            _walk(paren, "COLUMN", scope)
+        return
+    if not isinstance(identifier, Identifier):
         return
 
-    # A subquery aliased as a derived table: recurse, don't treat as a reference.
-    if any(isinstance(tok, Parenthesis) for tok in identifier.tokens):
-        _walk(identifier, "COLUMN", tables, alias_to_table, columns, aliases)
+    paren = next(
+        (tok for tok in identifier.tokens if isinstance(tok, Parenthesis)), None
+    )
+    if paren is not None:
+        alias = _clean(identifier.get_alias())
+        if _has_select(paren):
+            # Derived table: (SELECT ...) alias. The alias is virtual and its
+            # inner scope is walked so real tables inside are still checked.
+            if alias:
+                scope.virtual.add(alias)
+                scope.aliases.add(alias)
+            _walk(paren, "COLUMN", scope)
+            return
+        # INSERT-style ``table (col, col)``: the name is a table, parens columns.
+        name = _clean(identifier.get_real_name())
+        if name and context == "TABLE":
+            scope.tables.add(name)
+        _walk(paren, "COLUMN", scope)
         return
 
     alias = _clean(identifier.get_alias())
     if alias:
-        aliases.add(alias)
+        scope.aliases.add(alias)
 
     real = _clean(identifier.get_real_name())
     if not real:
         return
 
     if context == "TABLE":
-        tables.add(real)
+        scope.tables.add(real)
         if alias:
-            alias_to_table[alias] = real
+            scope.alias_to_table[alias] = real
     else:
         qualifier = _clean(identifier.get_parent_name())
-        columns.add((qualifier, real))
+        scope.raw_columns.add((qualifier, real))
+
+
+def _resolve(scope: _Scope) -> SQLReferences:
+    tables = scope.tables - scope.virtual
+
+    columns: t.Set[t.Tuple[t.Optional[str], str]] = set()
+    for qualifier, name in scope.raw_columns:
+        if name in scope.aliases:
+            continue
+        if qualifier is None:
+            columns.add((None, name))
+            continue
+        if qualifier in scope.virtual:
+            continue
+        resolved = scope.alias_to_table.get(qualifier, qualifier)
+        if resolved in scope.virtual:
+            continue
+        columns.add((resolved, name))
+
+    return SQLReferences(tables=tables, columns=columns)
 
 
 def extract_references(sql: str) -> SQLReferences:
     """Extract table and column references from a SQL query.
 
-    In-query aliases and CTE names are excluded, as are ``*`` wildcards and
-    function calls. Qualifiers on columns are resolved through table aliases so
-    ``u.email`` on ``FROM users u`` validates against ``users``.
+    Handles multiple statements, joins, functions, subqueries, CTEs and simple
+    DML. In-query aliases and CTE / derived-table names are resolved and never
+    counted as references. ``*`` wildcards and function names are ignored.
+
+    Note: schema-qualified names deeper than ``table.column`` (e.g.
+    ``db.schema.table``) are not resolved, matching the flat ``{table: columns}``
+    schema contract.
     """
     assert sqlparse is not None, "sqlparse is required for SQLSchemaHallucination"
-    parsed = sqlparse.parse(sql)
-    if not parsed:
-        return SQLReferences(tables=set(), columns=set())
-    statement = parsed[0]
-    ctes = _collect_ctes(statement)
 
     tables: t.Set[str] = set()
-    alias_to_table: t.Dict[str, str] = {}
-    raw_columns: t.Set[t.Tuple[t.Optional[str], str]] = set()
-    aliases: t.Set[str] = set()
-    _walk(statement, "COLUMN", tables, alias_to_table, raw_columns, aliases)
-
-    tables -= ctes
-
     columns: t.Set[t.Tuple[t.Optional[str], str]] = set()
-    for qualifier, name in raw_columns:
-        if name in aliases:
-            continue
-        resolved = alias_to_table.get(qualifier, qualifier) if qualifier else None
-        columns.add((resolved, name))
+    for statement in sqlparse.parse(sql):
+        scope = _Scope()
+        scope.virtual |= _collect_ctes(statement)
+        _walk(statement, "COLUMN", scope)
+        refs = _resolve(scope)
+        tables |= refs.tables
+        columns |= refs.columns
 
     return SQLReferences(tables=tables, columns=columns)
 
@@ -185,11 +231,19 @@ def score_references(
 ) -> t.Tuple[int, int, t.List[str]]:
     """Count references that exist in the schema.
 
-    Returns (valid_count, total_count, hallucinated) where ``hallucinated`` lists
-    the offending references for diagnostics.
+    Unqualified columns are validated against the columns of the tables the
+    query actually references, not the whole schema, so a column that exists in
+    some unrelated table is still flagged. Returns (valid, total, hallucinated).
     """
     normalized = _normalize_schema(schema)
-    all_columns = {col for cols in normalized.values() for col in cols}
+
+    referenced_columns: t.Set[str] = set()
+    for table in references.tables:
+        referenced_columns |= normalized.get(table.lower(), set())
+    if not referenced_columns:
+        # No referenced table is in the schema; fall back to the whole schema so
+        # a bad table name does not also flag every column as hallucinated.
+        referenced_columns = {col for cols in normalized.values() for col in cols}
 
     valid = 0
     total = 0
@@ -211,7 +265,7 @@ def score_references(
                 valid += 1
             else:
                 hallucinated.append(f"{qualifier}.{column}")
-        elif col in all_columns:
+        elif col in referenced_columns:
             valid += 1
         else:
             hallucinated.append(column)

--- a/tests/unit/test_sql_schema_hallucination_collections.py
+++ b/tests/unit/test_sql_schema_hallucination_collections.py
@@ -1,0 +1,144 @@
+"""Tests for SQLSchemaHallucination metric (collections implementation)."""
+
+import pytest
+
+from ragas.metrics.collections import SQLSchemaHallucination
+from ragas.metrics.collections.sql_schema_hallucination.util import (
+    extract_references,
+    score_references,
+)
+
+SCHEMA = {
+    "users": ["id", "name", "email"],
+    "orders": ["id", "user_id", "total"],
+}
+
+
+class TestSQLReferenceExtraction:
+    """Test cases for the SQL parsing utilities."""
+
+    def test_extracts_table_and_columns(self):
+        refs = extract_references("SELECT id, name FROM users")
+        assert refs.tables == {"users"}
+        assert refs.columns == {(None, "id"), (None, "name")}
+
+    def test_wildcard_is_ignored(self):
+        refs = extract_references("SELECT * FROM users")
+        assert refs.columns == set()
+        assert refs.tables == {"users"}
+
+    def test_function_name_is_not_a_column(self):
+        refs = extract_references("SELECT COUNT(*) FROM users")
+        assert refs.columns == set()
+
+    def test_column_alias_is_excluded(self):
+        refs = extract_references("SELECT id AS user_id FROM users")
+        assert refs.columns == {(None, "id")}
+
+    def test_table_alias_resolves_qualified_column(self):
+        refs = extract_references("SELECT u.email FROM users u")
+        assert refs.columns == {("users", "email")}
+
+    def test_cte_name_is_not_a_table(self):
+        refs = extract_references("WITH t AS (SELECT id FROM users) SELECT id FROM t")
+        assert "t" not in refs.tables
+        assert "users" in refs.tables
+
+    def test_where_clause_columns_are_extracted(self):
+        refs = extract_references("SELECT name FROM users WHERE emial = 'x'")
+        assert (None, "emial") in refs.columns
+
+    def test_empty_query_yields_no_references(self):
+        refs = extract_references("")
+        assert refs.tables == set()
+        assert refs.columns == set()
+
+    def test_score_counts_valid_and_hallucinated(self):
+        refs = extract_references("SELECT emial FROM users")
+        valid, total, hallucinated = score_references(refs, SCHEMA)
+        assert (valid, total) == (1, 2)
+        assert hallucinated == ["emial"]
+
+
+class TestSQLSchemaHallucination:
+    """Test cases for the SQLSchemaHallucination metric."""
+
+    def test_init_default_name(self):
+        metric = SQLSchemaHallucination()
+        assert metric.name == "sql_schema_hallucination"
+
+    def test_init_custom_name(self):
+        metric = SQLSchemaHallucination(name="custom")
+        assert metric.name == "custom"
+
+    @pytest.mark.asyncio
+    async def test_all_references_valid(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(
+            response="SELECT id, name FROM users", schema=SCHEMA
+        )
+        assert result.value == 1.0
+
+    @pytest.mark.asyncio
+    async def test_hallucinated_column(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(response="SELECT emial FROM users", schema=SCHEMA)
+        assert result.value == 0.5
+        assert "emial" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_hallucinated_table(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(response="SELECT id FROM userz", schema=SCHEMA)
+        assert result.value == 0.5
+        assert "userz" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_qualified_column_via_alias(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(
+            response="SELECT o.total FROM orders o JOIN users u ON o.user_id = u.id",
+            schema=SCHEMA,
+        )
+        assert result.value == 1.0
+
+    @pytest.mark.asyncio
+    async def test_select_star_scores_one(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(response="SELECT * FROM users", schema=SCHEMA)
+        assert result.value == 1.0
+        assert result.reason == "Valid references 1/1"
+
+    @pytest.mark.asyncio
+    async def test_cte_name_not_flagged(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(
+            response="WITH recent AS (SELECT id FROM users) SELECT id FROM recent",
+            schema=SCHEMA,
+        )
+        assert result.value == 1.0
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_matching(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(
+            response="SELECT ID, NAME FROM USERS", schema=SCHEMA
+        )
+        assert result.value == 1.0
+
+    @pytest.mark.asyncio
+    async def test_empty_response_raises(self):
+        metric = SQLSchemaHallucination()
+        with pytest.raises(ValueError, match="non-empty SQL query"):
+            await metric.ascore(response="  ", schema=SCHEMA)
+
+    @pytest.mark.asyncio
+    async def test_empty_schema_raises(self):
+        metric = SQLSchemaHallucination()
+        with pytest.raises(ValueError, match="non-empty mapping"):
+            await metric.ascore(response="SELECT id FROM users", schema={})
+
+    def test_sync_score_method(self):
+        metric = SQLSchemaHallucination()
+        result = metric.score(response="SELECT emial FROM users", schema=SCHEMA)
+        assert result.value == 0.5

--- a/tests/unit/test_sql_schema_hallucination_collections.py
+++ b/tests/unit/test_sql_schema_hallucination_collections.py
@@ -59,6 +59,30 @@ class TestSQLReferenceExtraction:
         assert (valid, total) == (1, 2)
         assert hallucinated == ["emial"]
 
+    def test_column_inside_function_is_extracted(self):
+        refs = extract_references("SELECT LOWER(emial) FROM users")
+        assert (None, "emial") in refs.columns
+
+    def test_derived_table_alias_is_not_scored(self):
+        refs = extract_references("SELECT x.id FROM (SELECT id FROM users) x")
+        assert refs.tables == {"users"}
+        assert ("x", "id") not in refs.columns
+
+    def test_cte_qualified_column_is_not_scored(self):
+        refs = extract_references(
+            "WITH recent AS (SELECT id FROM users) SELECT recent.id FROM recent"
+        )
+        assert ("recent", "id") not in refs.columns
+
+    def test_multiple_statements_are_all_extracted(self):
+        refs = extract_references("SELECT id FROM users; SELECT emial FROM users")
+        assert (None, "emial") in refs.columns
+
+    def test_update_target_is_a_table(self):
+        refs = extract_references("UPDATE users SET email = 'x' WHERE id = 1")
+        assert refs.tables == {"users"}
+        assert (None, "users") not in refs.columns
+
 
 class TestSQLSchemaHallucination:
     """Test cases for the SQLSchemaHallucination metric."""
@@ -137,6 +161,40 @@ class TestSQLSchemaHallucination:
         metric = SQLSchemaHallucination()
         with pytest.raises(ValueError, match="non-empty mapping"):
             await metric.ascore(response="SELECT id FROM users", schema={})
+
+    @pytest.mark.asyncio
+    async def test_hallucinated_column_inside_function(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(
+            response="SELECT LOWER(emial) FROM users", schema=SCHEMA
+        )
+        assert result.value == 0.5
+        assert "emial" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_derived_table_not_flagged(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(
+            response="SELECT x.id FROM (SELECT id FROM users) x", schema=SCHEMA
+        )
+        assert result.value == 1.0
+
+    @pytest.mark.asyncio
+    async def test_unqualified_column_scoped_to_referenced_tables(self):
+        metric = SQLSchemaHallucination()
+        # 'total' exists in 'orders' but the query only references 'users'.
+        result = await metric.ascore(response="SELECT total FROM users", schema=SCHEMA)
+        assert result.value == 0.5
+        assert "total" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_second_statement_is_scored(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(
+            response="SELECT id FROM users; SELECT emial FROM users", schema=SCHEMA
+        )
+        assert result.value < 1.0
+        assert "emial" in result.reason
 
     def test_sync_score_method(self):
         metric = SQLSchemaHallucination()

--- a/tests/unit/test_sql_schema_hallucination_collections.py
+++ b/tests/unit/test_sql_schema_hallucination_collections.py
@@ -188,6 +188,26 @@ class TestSQLSchemaHallucination:
         assert "total" in result.reason
 
     @pytest.mark.asyncio
+    async def test_subquery_tables_do_not_validate_outer_columns(self):
+        metric = SQLSchemaHallucination()
+        # 'total' is in 'orders' (used only in the subquery), not in 'users'.
+        result = await metric.ascore(
+            response="SELECT total FROM users WHERE id IN (SELECT user_id FROM orders)",
+            schema=SCHEMA,
+        )
+        assert result.value < 1.0
+        assert "total" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_valid_subquery_does_not_false_flag(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(
+            response="SELECT name FROM users WHERE id IN (SELECT user_id FROM orders)",
+            schema=SCHEMA,
+        )
+        assert result.value == 1.0
+
+    @pytest.mark.asyncio
     async def test_second_statement_is_scored(self):
         metric = SQLSchemaHallucination()
         result = await metric.ascore(

--- a/tests/unit/test_sql_schema_hallucination_collections.py
+++ b/tests/unit/test_sql_schema_hallucination_collections.py
@@ -199,6 +199,18 @@ class TestSQLSchemaHallucination:
         assert "total" in result.reason
 
     @pytest.mark.asyncio
+    async def test_correlated_subquery_resolves_outer_alias(self):
+        metric = SQLSchemaHallucination()
+        result = await metric.ascore(
+            response=(
+                "SELECT id FROM orders o "
+                "WHERE EXISTS (SELECT 1 FROM users u WHERE u.id = o.user_id)"
+            ),
+            schema=SCHEMA,
+        )
+        assert result.value == 1.0
+
+    @pytest.mark.asyncio
     async def test_valid_subquery_does_not_false_flag(self):
         metric = SQLSchemaHallucination()
         result = await metric.ascore(


### PR DESCRIPTION
Closes #2644.

Text-to-SQL models often reference tables and columns that aren't in the schema, and it gets worse as schemas grow wide. Existing SQL metrics (`SQLSemanticEquivalence`, `DataCompyScore`) check output correctness but never catch a query that selects a column which doesn't exist.

This adds `SQLSchemaHallucination`, a non-LLM collections metric. It parses the generated query with sqlparse, collects the tables and columns it references, and scores the fraction that actually exist in a schema you pass in. 1.0 means nothing was hallucinated; lower means the query names things the schema doesn't have.

```python
from ragas.metrics.collections import SQLSchemaHallucination

metric = SQLSchemaHallucination()
result = await metric.ascore(
    response="SELECT emial FROM users",
    schema={"users": ["id", "name", "email"]},
)
# result.value == 0.5, reason flags 'emial'
```

## Summary
- Add `SQLSchemaHallucination` under `metrics/collections/sql_schema_hallucination/` (metric + parsing util), registered in `collections/__init__.py`
- Resolve table aliases and CTE names so they're never counted as hallucinations; ignore `SELECT *` and function calls
- Add `sqlparse` to the `all` optional extra, imported lazily with a friendly error, same as `DataCompyScore`
- Add unit tests covering extraction and scoring

## Design notes
- Schema is a structured `{table: [columns]}` dict on purpose. A deterministic metric shouldn't depend on fuzzy-parsing free-text schema descriptions.
- Used sqlparse rather than adding sqlglot, since sqlparse is already in the dependency tree. All parsing lives in `util.py` behind small functions, so the backend can be swapped later without touching the metric.

## Test plan
- [x] `uv run pytest tests/unit/test_sql_schema_hallucination_collections.py`
- [x] Verify `from ragas.metrics.collections import SQLSchemaHallucination` works and the symbol is in `__all__`
